### PR TITLE
KTime: Sync with realtime clock

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -24,6 +24,7 @@ const (
 	defaultArgSamplesPerSecond    = 20
 	defaultArgReporterInterval    = 5.0 * time.Second
 	defaultArgMonitorInterval     = 5.0 * time.Second
+	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
 	defaultProbabilisticInterval  = 1 * time.Minute
 	defaultArgSendErrorFrames     = false
@@ -61,11 +62,14 @@ var (
 		tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1)
 	probabilisticIntervalHelp = "Time interval for which probabilistic profiling will be " +
 		"enabled or disabled."
-	pprofHelp            = "Listening address (e.g. localhost:6060) to serve pprof information."
-	samplesPerSecondHelp = "Set the frequency (in Hz) of stack trace sampling."
-	reporterIntervalHelp = "Set the reporter's interval in seconds."
-	monitorIntervalHelp  = "Set the monitor interval in seconds."
-	sendErrorFramesHelp  = "Send error frames (devfiler only, breaks Kibana)"
+	pprofHelp             = "Listening address (e.g. localhost:6060) to serve pprof information."
+	samplesPerSecondHelp  = "Set the frequency (in Hz) of stack trace sampling."
+	reporterIntervalHelp  = "Set the reporter's interval in seconds."
+	monitorIntervalHelp   = "Set the monitor interval in seconds."
+	clockSyncIntervalHelp = "Set the sync interval with the realtime clock. " +
+		"If zero, monotonic-realtime clock sync will be performed once, " +
+		"on agent startup, but not periodically."
+	sendErrorFramesHelp = "Send error frames (devfiler only, breaks Kibana)"
 )
 
 type arguments struct {
@@ -76,6 +80,7 @@ type arguments struct {
 	disableTLS             bool
 	mapScaleFactor         uint
 	monitorInterval        time.Duration
+	clockSyncInterval      time.Duration
 	noKernelVersionCheck   bool
 	pprofAddr              string
 	probabilisticInterval  time.Duration
@@ -114,6 +119,9 @@ func parseArgs() (*arguments, error) {
 
 	fs.DurationVar(&args.monitorInterval, "monitor-interval", defaultArgMonitorInterval,
 		monitorIntervalHelp)
+
+	fs.DurationVar(&args.clockSyncInterval, "clock-sync-interval", defaultClockSyncInterval,
+		clockSyncIntervalHelp)
 
 	fs.BoolVar(&args.noKernelVersionCheck, "no-kernel-version-check", false,
 		noKernelVersionCheckHelp)

--- a/host/host.go
+++ b/host/host.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
@@ -53,7 +54,7 @@ type Trace struct {
 	Comm             string
 	Frames           []Frame
 	Hash             TraceHash
-	KTime            util.KTime
+	KTime            times.KTime
 	PID              util.PID
 	TID              util.PID
 	APMTraceID       libpf.APMTraceID

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func mainWithExitCode() exitCode {
 		args.reporterInterval, args.probabilisticInterval)
 
 	// Start periodic synchronization with the realtime clock
-	times.StartRealtimeSync(mainCtx)
+	times.StartRealtimeSync(mainCtx, args.clockSyncInterval)
 
 	log.Debugf("Determining tracers to include")
 	includeTracers, err := tracertypes.Parse(args.tracers)

--- a/main.go
+++ b/main.go
@@ -144,8 +144,11 @@ func mainWithExitCode() exitCode {
 	traceHandlerCacheSize :=
 		traceCacheSize(args.monitorInterval, args.samplesPerSecond, uint16(presentCores))
 
-	intervals := times.New(mainCtx,
-		args.monitorInterval, args.reporterInterval, args.probabilisticInterval)
+	intervals := times.New(args.monitorInterval,
+		args.reporterInterval, args.probabilisticInterval)
+
+	// Start periodic synchronization with the realtime clock
+	times.StartRealtimeSync(mainCtx)
 
 	log.Debugf("Determining tracers to include")
 	includeTracers, err := tracertypes.Parse(args.tracers)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -29,6 +29,7 @@ import (
 	pmebpf "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/ebpf"
 	eim "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/execinfomanager"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/traceutil"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
@@ -95,7 +96,7 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		interpreterTracerEnabled: em.NumInterpreterLoaders() > 0,
 		eim:                      em,
 		interpreters:             interpreters,
-		exitEvents:               make(map[util.PID]util.KTime),
+		exitEvents:               make(map[util.PID]times.KTime),
 		pidToProcessInfo:         make(map[util.PID]*processInfo),
 		ebpf:                     ebpf,
 		FileIDMapper:             fileIDMapper,
@@ -343,11 +344,11 @@ func (pm *ProcessManager) MaybeNotifyAPMAgent(
 	return serviceName
 }
 
-func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime util.KTime) {
+func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime times.KTime) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	nowKTime := util.GetKTime()
+	nowKTime := times.GetKTime()
 
 	for pid, pidExitKTime := range pm.exitEvents {
 		if pidExitKTime > traceCaptureKTime {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -33,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/proc"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	eim "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/execinfomanager"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tpbase"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
@@ -500,7 +501,7 @@ func (pm *ProcessManager) ProcessPIDExit(pid util.PID) bool {
 	defer pm.mu.Unlock()
 
 	symbolize := false
-	exitKTime := util.GetKTime()
+	exitKTime := times.GetKTime()
 	if pm.interpreterTracerEnabled {
 		if len(pm.interpreters[pid]) > 0 {
 			pm.exitEvents[pid] = exitKTime

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -20,6 +20,7 @@ import (
 	pmebpf "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/ebpf"
 	eim "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/execinfomanager"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tpbase"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
@@ -56,7 +57,7 @@ type ProcessManager struct {
 	pidToProcessInfo map[util.PID]*processInfo
 
 	// exitEvents records the pid exit time and is a list of pending exit events to be handled.
-	exitEvents map[util.PID]util.KTime
+	exitEvents map[util.PID]times.KTime
 
 	// ebpf contains the interface to manipulate ebpf maps
 	ebpf pmebpf.EbpfHandler

--- a/times/ktime.go
+++ b/times/ktime.go
@@ -4,7 +4,7 @@
  * See the file "LICENSE" for details.
  */
 
-package util
+package times
 
 import (
 	_ "unsafe" // required to use //go:linkname for runtime.nanotime

--- a/times/ktime.go
+++ b/times/ktime.go
@@ -7,6 +7,7 @@
 package times
 
 import (
+	"time"
 	_ "unsafe" // required to use //go:linkname for runtime.nanotime
 )
 
@@ -21,3 +22,13 @@ type KTime int64
 //go:noescape
 //go:linkname GetKTime runtime.nanotime
 func GetKTime() KTime
+
+// Time converts the kernel timestamp into a Go time object.
+func (t KTime) Time() time.Time {
+	return time.Unix(0, t.UnixNano())
+}
+
+// UnixNano converts the kernel timestamp to nanoseconds since the epoch.
+func (t KTime) UnixNano() int64 {
+	return int64(t) + bootTimeUnixNano.Load()
+}

--- a/times/times.go
+++ b/times/times.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/periodiccaller"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 const (
@@ -98,7 +97,7 @@ type IntervalsAndTimers interface {
 	// be enabled or disabled.
 	ProbabilisticInterval() time.Duration
 	// BootTimeUnixNano defines the system boot time in nanoseconds since the epoch. This value
-	// can be used to convert monotonic time (e.g. util.GetKTime) to Unix time, by adding it
+	// can be used to convert monotonic time (e.g. GetKTime) to Unix time, by adding it
 	// as a delta.
 	BootTimeUnixNano() int64
 }
@@ -182,7 +181,7 @@ func getDelta(compensationValue int64) int64 {
 	var ts unix.Timespec
 
 	// Does not include suspend time
-	kt := int64(util.GetKTime())
+	kt := int64(GetKTime())
 	// Does include suspend time
 	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
 		// This should never happen in our target environments.
@@ -210,7 +209,7 @@ func getBootTimeUnixNano() int64 {
 		// To avoid noise from scheduling / other delays, we perform a
 		// series of measurements and pick the one with the lowest delta.
 		samples[i].t1 = time.Now()
-		samples[i].ktime = int64(util.GetKTime())
+		samples[i].ktime = int64(GetKTime())
 		samples[i].t2 = time.Now()
 	}
 

--- a/tools/coredump/ebpfhelpers.go
+++ b/tools/coredump/ebpfhelpers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -55,7 +55,7 @@ func __push_frame(id, file, line C.u64, frameType, returnAddress C.uchar) C.int 
 
 //export bpf_ktime_get_ns
 func bpf_ktime_get_ns() C.ulonglong {
-	return C.ulonglong(util.GetKTime())
+	return C.ulonglong(times.GetKTime())
 }
 
 //export bpf_get_current_comm

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -54,7 +54,7 @@ type TraceProcessor interface {
 	// It gets the timestamp of when the Traces (if any) were captured. The timestamp
 	// is in essence an indicator that all Traces until that time have been now processed,
 	// and any events up to this time can be processed.
-	SymbolizationComplete(traceCaptureKTime util.KTime)
+	SymbolizationComplete(traceCaptureKTime times.KTime)
 }
 
 // traceHandler provides functions for handling new traces and trace count updates

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -33,7 +33,6 @@ var _ Times = (*times.Times)(nil)
 // Times is a subset of config.IntervalsAndTimers.
 type Times interface {
 	MonitorInterval() time.Duration
-	BootTimeUnixNano() int64
 }
 
 // TraceProcessor is an interface used by traceHandler to convert traces
@@ -122,7 +121,7 @@ func newTraceHandler(rep reporter.TraceReporter, traceProcessor TraceProcessor,
 
 func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	defer m.traceProcessor.SymbolizationComplete(bpfTrace.KTime)
-	timestamp := libpf.UnixTime64(m.times.BootTimeUnixNano() + int64(bpfTrace.KTime))
+	timestamp := libpf.UnixTime64(bpfTrace.KTime.UnixNano())
 
 	meta := &reporter.TraceEventMeta{
 		Timestamp:      timestamp,

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -30,7 +30,6 @@ func defaultTimes() *fakeTimes {
 }
 
 func (ft *fakeTimes) MonitorInterval() time.Duration { return ft.monitorInterval }
-func (ft *fakeTimes) BootTimeUnixNano() int64        { return 0 }
 
 // fakeTraceProcessor implements a fake TraceProcessor used only within the test scope.
 type fakeTraceProcessor struct{}

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
 )
 

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 type fakeTimes struct {
@@ -44,7 +44,7 @@ func (f *fakeTraceProcessor) ConvertTrace(trace *host.Trace) *libpf.Trace {
 	return &newTrace
 }
 
-func (f *fakeTraceProcessor) SymbolizationComplete(util.KTime) {}
+func (f *fakeTraceProcessor) SymbolizationComplete(times.KTime) {}
 
 func (f *fakeTraceProcessor) MaybeNotifyAPMAgent(*host.Trace, libpf.TraceHash, uint16) string {
 	return ""

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -900,7 +900,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) *host.Trace {
 		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.apm_transaction_id)),
 		PID:              util.PID(ptr.pid),
 		TID:              util.PID(ptr.tid),
-		KTime:            util.KTime(ptr.ktime),
+		KTime:            times.KTime(ptr.ktime),
 	}
 
 	// Trace fields included in the hash:


### PR DESCRIPTION
### Summary

- Moved `KTime` / `GetKTime` from `util` to `times` package
- Periodic sync with realtime clock (instead of boottime monotonic)
- Added realtime clock sync interval configuration option

