### PR TITLE
Fix duplicate entries in Profile.AttributeTable

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -744,8 +744,8 @@ func createFunctionEntry(funcMap map[funcInfo]uint64,
 
 // getSampleAttributes builds a sample-specific list of attributes.
 func getSampleAttributes(profile *profiles.Profile,
-	k traceAndMetaKey, attributeMap map[string]uint64) []uint64 {
-	indices := make([]uint64, 0, 4)
+	traceKey traceAndMetaKey, attributeMap map[string]uint64) []uint64 {
+	indices := make([]uint64, 0, 3)
 
 	addAttr := func(k attribute.Key, v string) {
 		if v == "" {
@@ -765,9 +765,9 @@ func getSampleAttributes(profile *profiles.Profile,
 		attributeMap[attributeCompositeKey] = newIndex
 	}
 
-	addAttr(semconv.ContainerIDKey, k.containerID)
-	addAttr(semconv.ThreadNameKey, k.comm)
-	addAttr(semconv.ServiceNameKey, k.apmServiceName)
+	addAttr(semconv.ContainerIDKey, traceKey.containerID)
+	addAttr(semconv.ThreadNameKey, traceKey.comm)
+	addAttr(semconv.ServiceNameKey, traceKey.apmServiceName)
 
 	return indices
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -673,7 +673,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 			profile.Location = append(profile.Location, loc)
 		}
 
-		sample.Attributes = getSampleAttributes(profile, traceKey, &attributeMap)
+		sample.Attributes = getSampleAttributes(profile, traceKey, attributeMap)
 		sample.LocationsLength = uint64(len(traceInfo.frameTypes))
 		locationIndex += sample.LocationsLength
 
@@ -743,7 +743,8 @@ func createFunctionEntry(funcMap map[funcInfo]uint64,
 }
 
 // getSampleAttributes builds a sample-specific list of attributes.
-func getSampleAttributes(profile *profiles.Profile, k traceAndMetaKey, attributeMap *map[string]uint64) []uint64 {
+func getSampleAttributes(profile *profiles.Profile,
+	k traceAndMetaKey, attributeMap map[string]uint64) []uint64 {
 	indices := make([]uint64, 0, 4)
 
 	addAttr := func(k attribute.Key, v string) {
@@ -751,7 +752,7 @@ func getSampleAttributes(profile *profiles.Profile, k traceAndMetaKey, attribute
 			return
 		}
 		attributeCompositeKey := string(k) + "_" + v
-		if attributeIndex, exists := (*attributeMap)[attributeCompositeKey]; exists {
+		if attributeIndex, exists := attributeMap[attributeCompositeKey]; exists {
 			indices = append(indices, attributeIndex)
 			return
 		}
@@ -761,7 +762,7 @@ func getSampleAttributes(profile *profiles.Profile, k traceAndMetaKey, attribute
 			Key:   string(k),
 			Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: v}},
 		})
-		(*attributeMap)[attributeCompositeKey] = newIndex
+		attributeMap[attributeCompositeKey] = newIndex
 	}
 
 	addAttr(semconv.ContainerIDKey, k.containerID)

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -503,6 +503,11 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 	funcMap := make(map[funcInfo]uint64)
 	funcMap[funcInfo{name: "", fileName: ""}] = 0
 
+	// attributeMap is a temporary helper that maps attribute values to
+	// their respective indices.
+	// This is to ensure that AttributeTable does not contain duplicates.
+	attributeMap := make(map[string]uint64)
+
 	numSamples := len(samples)
 	profile = &profiles.Profile{
 		// SampleType - Next step: Figure out the correct SampleType.
@@ -668,7 +673,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 			profile.Location = append(profile.Location, loc)
 		}
 
-		sample.Attributes = getSampleAttributes(profile, traceKey)
+		sample.Attributes = getSampleAttributes(profile, traceKey, &attributeMap)
 		sample.LocationsLength = uint64(len(traceInfo.frameTypes))
 		locationIndex += sample.LocationsLength
 
@@ -738,19 +743,25 @@ func createFunctionEntry(funcMap map[funcInfo]uint64,
 }
 
 // getSampleAttributes builds a sample-specific list of attributes.
-func getSampleAttributes(profile *profiles.Profile, k traceAndMetaKey) []uint64 {
+func getSampleAttributes(profile *profiles.Profile, k traceAndMetaKey, attributeMap *map[string]uint64) []uint64 {
 	indices := make([]uint64, 0, 4)
 
 	addAttr := func(k attribute.Key, v string) {
 		if v == "" {
 			return
 		}
-
-		indices = append(indices, uint64(len(profile.AttributeTable)))
+		attributeCompositeKey := string(k) + "_" + v
+		if attributeIndex, exists := (*attributeMap)[attributeCompositeKey]; exists {
+			indices = append(indices, attributeIndex)
+			return
+		}
+		newIndex := uint64(len(profile.AttributeTable))
+		indices = append(indices, newIndex)
 		profile.AttributeTable = append(profile.AttributeTable, &common.KeyValue{
 			Key:   string(k),
 			Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: v}},
 		})
+		(*attributeMap)[attributeCompositeKey] = newIndex
 	}
 
 	addAttr(semconv.ContainerIDKey, k.containerID)

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -3,7 +3,7 @@ package reporter
 import (
 	"testing"
 
-	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/stretchr/testify/require"
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	profiles "go.opentelemetry.io/proto/otlp/profiles/v1experimental"

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -1,24 +1,24 @@
 package reporter
 
 import (
+	"testing"
+
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/stretchr/testify/require"
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	profiles "go.opentelemetry.io/proto/otlp/profiles/v1experimental"
-	"testing"
 )
 
 func TestGetSampleAttributes(t *testing.T) {
-
 	tests := map[string]struct {
-		profile                profiles.Profile
+		profile                *profiles.Profile
 		k                      []traceAndMetaKey
 		attributeMap           map[string]uint64
 		expectedIndices        [][]uint64
 		expectedAttributeTable []*common.KeyValue
 	}{
 		"empty": {
-			profile: profiles.Profile{},
+			profile: &profiles.Profile{},
 			k: []traceAndMetaKey{
 				{
 					hash:           libpf.TraceHash{},
@@ -32,7 +32,7 @@ func TestGetSampleAttributes(t *testing.T) {
 			expectedAttributeTable: nil,
 		},
 		"duplicate": {
-			profile: profiles.Profile{},
+			profile: &profiles.Profile{},
 			k: []traceAndMetaKey{
 				{
 					hash:           libpf.TraceHash{},
@@ -51,21 +51,27 @@ func TestGetSampleAttributes(t *testing.T) {
 			expectedIndices: [][]uint64{{0, 1, 2}, {0, 1, 2}},
 			expectedAttributeTable: []*common.KeyValue{
 				{
-					Key:   "container.id",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID1"}},
+					Key: "container.id",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "containerID1"},
+					},
 				},
 				{
-					Key:   "thread.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm1"}},
+					Key: "thread.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "comm1"},
+					},
 				},
 				{
-					Key:   "service.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"}},
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"},
+					},
 				},
 			},
 		},
 		"different": {
-			profile: profiles.Profile{},
+			profile: &profiles.Profile{},
 			k: []traceAndMetaKey{
 				{
 					hash:           libpf.TraceHash{},
@@ -84,28 +90,40 @@ func TestGetSampleAttributes(t *testing.T) {
 			expectedIndices: [][]uint64{{0, 1, 2}, {3, 4, 5}},
 			expectedAttributeTable: []*common.KeyValue{
 				{
-					Key:   "container.id",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID1"}},
+					Key: "container.id",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "containerID1"},
+					},
 				},
 				{
-					Key:   "thread.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm1"}},
+					Key: "thread.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "comm1"},
+					},
 				},
 				{
-					Key:   "service.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"}},
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"},
+					},
 				},
 				{
-					Key:   "container.id",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID2"}},
+					Key: "container.id",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "containerID2"},
+					},
 				},
 				{
-					Key:   "thread.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm2"}},
+					Key: "thread.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "comm2"},
+					},
 				},
 				{
-					Key:   "service.name",
-					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName2"}},
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName2"},
+					},
 				},
 			},
 		},
@@ -117,7 +135,7 @@ func TestGetSampleAttributes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			indices := make([][]uint64, 0)
 			for _, k := range tc.k {
-				indices = append(indices, getSampleAttributes(&tc.profile, k, &tc.attributeMap))
+				indices = append(indices, getSampleAttributes(tc.profile, k, tc.attributeMap))
 			}
 			require.Equal(t, tc.expectedIndices, indices)
 			require.Equal(t, tc.expectedAttributeTable, tc.profile.AttributeTable)

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -1,0 +1,126 @@
+package reporter
+
+import (
+	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/stretchr/testify/require"
+	common "go.opentelemetry.io/proto/otlp/common/v1"
+	profiles "go.opentelemetry.io/proto/otlp/profiles/v1experimental"
+	"testing"
+)
+
+func TestGetSampleAttributes(t *testing.T) {
+
+	tests := map[string]struct {
+		profile                profiles.Profile
+		k                      []traceAndMetaKey
+		attributeMap           map[string]uint64
+		expectedIndices        [][]uint64
+		expectedAttributeTable []*common.KeyValue
+	}{
+		"empty": {
+			profile: profiles.Profile{},
+			k: []traceAndMetaKey{
+				{
+					hash:           libpf.TraceHash{},
+					comm:           "",
+					apmServiceName: "",
+					containerID:    "",
+				},
+			},
+			attributeMap:           make(map[string]uint64),
+			expectedIndices:        [][]uint64{make([]uint64, 0, 4)},
+			expectedAttributeTable: nil,
+		},
+		"duplicate": {
+			profile: profiles.Profile{},
+			k: []traceAndMetaKey{
+				{
+					hash:           libpf.TraceHash{},
+					comm:           "comm1",
+					apmServiceName: "apmServiceName1",
+					containerID:    "containerID1",
+				},
+				{
+					hash:           libpf.TraceHash{},
+					comm:           "comm1",
+					apmServiceName: "apmServiceName1",
+					containerID:    "containerID1",
+				},
+			},
+			attributeMap:    make(map[string]uint64),
+			expectedIndices: [][]uint64{{0, 1, 2}, {0, 1, 2}},
+			expectedAttributeTable: []*common.KeyValue{
+				{
+					Key:   "container.id",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID1"}},
+				},
+				{
+					Key:   "thread.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm1"}},
+				},
+				{
+					Key:   "service.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"}},
+				},
+			},
+		},
+		"different": {
+			profile: profiles.Profile{},
+			k: []traceAndMetaKey{
+				{
+					hash:           libpf.TraceHash{},
+					comm:           "comm1",
+					apmServiceName: "apmServiceName1",
+					containerID:    "containerID1",
+				},
+				{
+					hash:           libpf.TraceHash{},
+					comm:           "comm2",
+					apmServiceName: "apmServiceName2",
+					containerID:    "containerID2",
+				},
+			},
+			attributeMap:    make(map[string]uint64),
+			expectedIndices: [][]uint64{{0, 1, 2}, {3, 4, 5}},
+			expectedAttributeTable: []*common.KeyValue{
+				{
+					Key:   "container.id",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID1"}},
+				},
+				{
+					Key:   "thread.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm1"}},
+				},
+				{
+					Key:   "service.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"}},
+				},
+				{
+					Key:   "container.id",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "containerID2"}},
+				},
+				{
+					Key:   "thread.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "comm2"}},
+				},
+				{
+					Key:   "service.name",
+					Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "apmServiceName2"}},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			indices := make([][]uint64, 0)
+			for _, k := range tc.k {
+				indices = append(indices, getSampleAttributes(&tc.profile, k, &tc.attributeMap))
+			}
+			require.Equal(t, tc.expectedIndices, indices)
+			require.Equal(t, tc.expectedAttributeTable, tc.profile.AttributeTable)
+		})
+	}
+}


### PR DESCRIPTION
* Adds a helper map to track attributes that were already inserted into `Profile.attributeTable` and avoid duplication.

- closes https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/99