### PR TITLE
Initial CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+#####################################################
+#
+# List of approvers for this repository
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+* @open-telemetry/ebpf-profiler-maintainers @open-telemetry/ebpf-profiler-approvers
+
+CODEOWNERS @open-telemetry/ebpf-profiler-maintainers


### PR DESCRIPTION
The GH approvers and maintainers groups are referenced to avoid duplication.