### PR TITLE
Handle zero-length FDEs and CIEs

### DIFF
--- a/nativeunwind/elfunwindinfo/elfehframe.go
+++ b/nativeunwind/elfunwindinfo/elfehframe.go
@@ -35,6 +35,9 @@ const (
 // errUnexpectedType is used internally to detect inconsistent FDE/CIE types
 var errUnexpectedType = errors.New("unexpected FDE/CIE type")
 
+// errEmptyEntry is used internally to report FDEs/CIEs of length 0.
+var errEmptyEntry = errors.New("FDE/CIE empty")
+
 // ehframeHooks interface provides hooks for filtering and debugging eh_frame parsing
 type ehframeHooks interface {
 	// fdeHook is called for each FDE. Returns false if the FDE should be filtered out.
@@ -725,6 +728,9 @@ func (r *reader) parseHDR(expectCIE bool) (hlen, ciePos uint64, err error) {
 	var idPos, cieMarker uint64
 	pos := r.pos
 	hlen = uint64(r.u32())
+	if hlen == 0 {
+		return 4, 0, errEmptyEntry
+	}
 	if hlen < 0xfffffff0 {
 		// Normal 32-bit dwarf
 		hlen += 4
@@ -1197,7 +1203,7 @@ func (ee *elfExtractor) walkBinSearchTable(parsedFile *pfelf.File, ehFrameHdrSec
 
 		fr := ehFrameSec.reader(fdeAddr-ehFrameSec.vaddr, false)
 		_, err = ee.parseFDE(&fr, parsedFile, ipStart, cieCache, true)
-		if err != nil {
+		if err != nil && !errors.Is(err, errEmptyEntry) {
 			return fmt.Errorf("failed to parse FDE: %v", err)
 		}
 	}
@@ -1219,7 +1225,7 @@ func (ee *elfExtractor) walkFDEs(ef *pfelf.File, ehFrameSec *elfRegion, debugFra
 	for f := uintptr(0); f < uintptr(len(ehFrameSec.data)); f += entryLen {
 		fr := ehFrameSec.reader(f, debugFrame)
 		entryLen, err = ee.parseFDE(&fr, ef, 0, cieCache, false)
-		if err != nil && !errors.Is(err, errUnexpectedType) {
+		if err != nil && !errors.Is(err, errUnexpectedType) && !errors.Is(err, errEmptyEntry) {
 			return fmt.Errorf("failed to parse FDE %#x: %v", f, err)
 		}
 		if entryLen == 0 {


### PR DESCRIPTION
These aren't mentioned by the DWARF standard,
but they appear occasionally. `objdump` just skips them; this PR has us do the same.