### PR TITLE
process: fix mapping last modified timestamp

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -206,7 +206,7 @@ func (sp *systemProcess) GetMappingFileLastModified(m *Mapping) int64 {
 	filename := sp.getMappingFile(m)
 	if filename != "" {
 		var st unix.Stat_t
-		if err := unix.Stat(filename, &st); err != nil {
+		if err := unix.Stat(filename, &st); err == nil {
 			return st.Mtim.Nano()
 		}
 	}


### PR DESCRIPTION
Currently, the function incorrectly always returns `0` as the modified timestamp.

The consequence is that if a new mapping has the same device ID and inode ID as a previous mapping, the [elfInfoCache](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/d7d24bc1c5eaec44f00c064dc7dc655084754156/processmanager/types.go#L87) will wrongly return the old mapping's file ID even though modified timestamps are different on those mappings ([here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/processmanager/processinfo.go#L250-L255)).

We encountered this on short-lived Java workloads using JNI and sharing the same local disk (same device ID), where two different librairies had the same inode ID in consecutive runs.