### PR TITLE
reporter: bundle trace meta args in a struct

### DIFF
--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -28,6 +28,13 @@ type Reporter interface {
 	GetMetrics() Metrics
 }
 
+type TraceEventMeta struct {
+	Timestamp      libpf.UnixTime64
+	Comm           string
+	APMServiceName string
+	PID, TID       util.PID
+}
+
 type TraceReporter interface {
 	// ReportFramesForTrace accepts a trace with the corresponding frames
 	// and caches this information before a periodic reporting to the backend.
@@ -35,14 +42,12 @@ type TraceReporter interface {
 
 	// ReportCountForTrace accepts a hash of a trace with a corresponding count and
 	// caches this information before a periodic reporting to the backend.
-	ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime64,
-		count uint16, comm, apmServiceName string, pid, tid util.PID)
+	ReportCountForTrace(traceHash libpf.TraceHash, count uint16, meta *TraceEventMeta)
 
 	// ReportTraceEvent accepts a trace event (trace metadata with frames and counts)
 	// and caches it for reporting to the backend. It returns true if the event was
 	// enqueued for reporting, and false if the event was ignored.
-	ReportTraceEvent(trace *libpf.Trace, timestamp libpf.UnixTime64,
-		comm, apmServiceName string, pid, tid util.PID)
+	ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta)
 
 	// SupportsReportTraceEvent returns true if the reporter supports reporting trace events
 	// via ReportTraceEvent().

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
@@ -78,7 +79,7 @@ func (m *mockReporter) ReportFramesForTrace(trace *libpf.Trace) {
 }
 
 func (m *mockReporter) ReportCountForTrace(traceHash libpf.TraceHash,
-	_ libpf.UnixTime64, count uint16, _, _ string, _, _ util.PID) {
+	count uint16, _ *reporter.TraceEventMeta) {
 	m.reportedCounts = append(m.reportedCounts, reportedCount{
 		traceHash: traceHash,
 		count:     count,
@@ -88,8 +89,7 @@ func (m *mockReporter) ReportCountForTrace(traceHash libpf.TraceHash,
 
 func (m *mockReporter) SupportsReportTraceEvent() bool { return false }
 
-func (m *mockReporter) ReportTraceEvent(_ *libpf.Trace,
-	_ libpf.UnixTime64, _, _ string, _, _ util.PID) {
+func (m *mockReporter) ReportTraceEvent(_ *libpf.Trace, _ *reporter.TraceEventMeta) {
 }
 
 func TestTraceHandler(t *testing.T) {


### PR DESCRIPTION
As previously announced [here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/115#pullrequestreview-2237893710), this bundles all the trace meta fields in a struct instead of passing them individually. This approach ensures that we aren't breaking the reporter interface every time we add new meta data.

CC @umanwizard