### PR TITLE
Fix failing tests with Go 1.23.0

### DIFF
--- a/periodiccaller/periodiccaller_test.go
+++ b/periodiccaller/periodiccaller_test.go
@@ -59,6 +59,7 @@ func isSelfOrRuntime(t *testing.T, stack *[32]uintptr, self string) bool {
 			if !strings.HasPrefix(funcName, "runtime.") &&
 				!strings.HasPrefix(funcName, "runtime/") &&
 				!strings.HasPrefix(funcName, "testing.") &&
+				!strings.HasPrefix(funcName, "internal/runtime") &&
 				funcName != "main.main" {
 				isRuntimeOnly = false
 			}


### PR DESCRIPTION
See [here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/10403644107/job/28810534977?pr=96).

We should rework the periodiccaller tests to not make assumptions about Go internals as this is likely to break again in the future.