### PR TITLE
Update Go + linter and fix various linter warnings

### DIFF
--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -23,16 +23,16 @@ runs:
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
         EOF
-        
+
         sudo dpkg --add-architecture arm64
         sudo apt-get update -y
-        
+
         sudo apt-get install -y llvm clang dwz curl unzip gcc-aarch64-linux-gnu \
           libc6-arm64-cross qemu-user-binfmt libc6:arm64
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        go-version: "1.23"
         check-latest: true
         cache-dependency-path: go.sum
       id: go

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Linter
         run: |
           go version
-          make lint
+          make lint TARGET_ARCH=${{ matrix.target_arch }}
 
   test:
     name: Test (${{ matrix.target_arch }})

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.59.x
+  golangci-lint-version: 1.60.x
 
 issues:
   exclude-dirs:
@@ -31,7 +31,7 @@ linters:
     #   - too many non-sensical warnings
     #   - not relevant for us
     #   - false positives
-    # 
+    #
     # "might be worth fixing" means we should investigate/fix in the mid term
     - containedctx # might be worth fixing
     - contextcheck # might be worth fixing

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ binary:
 ebpf:
 	$(MAKE) -j$(shell nproc) -C support/ebpf
 
-GOLANGCI_LINT_VERSION = "v1.59.1"
+GOLANGCI_LINT_VERSION = "v1.60.1"
 lint: generate
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --build-tags integration,linux --timeout 10m

--- a/interpreter/php/decode_arm64.go
+++ b/interpreter/php/decode_arm64.go
@@ -9,6 +9,7 @@
 package php
 
 import (
+	"errors"
 	"fmt"
 
 	ah "github.com/open-telemetry/opentelemetry-ebpf-profiler/armhelpers"
@@ -53,7 +54,7 @@ func retrieveZendVMKindWrapper(code []byte) (uint, error) {
 	}
 
 	// If we haven't already returned then clearly we're in an error state.
-	return 0, fmt.Errorf("did not find a mov into w0 in the given code blob")
+	return 0, errors.New("did not find a mov into w0 in the given code blob")
 }
 
 // retrieveExecuteExJumpLabelAddressWrapper. This function reads the code blob and returns
@@ -95,7 +96,7 @@ func retrieveExecuteExJumpLabelAddressWrapper(
 			return libpf.SymbolValue(offs+4) + addrBase, nil
 		}
 	}
-	return libpf.SymbolValueInvalid, fmt.Errorf("did not find a BR in the given code blob")
+	return libpf.SymbolValueInvalid, errors.New("did not find a BR in the given code blob")
 }
 
 // retrieveJITBufferPtrWrapper reads the code blob and returns a pointer to the JIT buffer used by
@@ -197,6 +198,5 @@ func retrieveJITBufferPtrWrapper(code []byte, addrBase libpf.SymbolValue) (
 	}
 
 	return libpf.SymbolValueInvalid, libpf.SymbolValueInvalid,
-		fmt.Errorf("did not find a BL instruction in" +
-			"the given code blob")
+		errors.New("did not find a BL instruction in the given code blob")
 }

--- a/maccess/maccess_arm64.go
+++ b/maccess/maccess_arm64.go
@@ -9,7 +9,7 @@
 package maccess
 
 import (
-	"fmt"
+	"errors"
 
 	ah "github.com/open-telemetry/opentelemetry-ebpf-profiler/armhelpers"
 	aa "golang.org/x/arch/arm64/arm64asm"
@@ -29,12 +29,13 @@ const (
 // for x86 and returns always TRUE [1] on other architectures like arm64. So the compiler
 // optimizes this function as the result of the function is known at compile time.
 //
-//nolint:lll
 // [0] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d319f344561de23e810515d109c7278919bff7b0
 // [1] https://github.com/torvalds/linux/blob/8bc9e6515183935fa0cccaf67455c439afe4982b/include/asm-generic/tlb.h#L26
-func CopyFromUserNoFaultIsPatched(codeblob []byte, _ uint64, _ uint64) (bool, error) {
+//
+//nolint:lll
+func CopyFromUserNoFaultIsPatched(codeblob []byte, _, _ uint64) (bool, error) {
 	if len(codeblob) == 0 {
-		return false, fmt.Errorf("empty code blob")
+		return false, errors.New("empty code blob")
 	}
 
 	// With the patch [0] of copy_from_user_nofault, access_ok() got replaced with __access_ok() [1].
@@ -45,7 +46,6 @@ func CopyFromUserNoFaultIsPatched(codeblob []byte, _ uint64, _ uint64) (bool, er
 	// B HI, .+0x14
 	// SUB X2, X2, X19
 	//
-	//nolint:lll
 	// [0] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d319f344561de23e810515d109c7278919bff7b0
 	// [1] https://github.com/torvalds/linux/blob/1c41041124bd14dd6610da256a3da4e5b74ce6b1/include/asm-generic/access_ok.h#L20-L41
 	// [2] https://github.com/torvalds/linux/blob/1c41041124bd14dd6610da256a3da4e5b74ce6b1/include/asm-generic/access_ok.h#L40

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func mainWithExitCode() exitCode {
 		vc.Version(), vc.Revision(), vc.BuildTimestamp())
 
 	if err = tracer.ProbeBPFSyscall(); err != nil {
-		return failure(fmt.Sprintf("Failed to probe eBPF syscall: %v", err))
+		return failure("Failed to probe eBPF syscall: %v", err)
 	}
 
 	if err = tracer.ProbeTracepoint(); err != nil {

--- a/pacmask/pacmask_arm64.go
+++ b/pacmask/pacmask_arm64.go
@@ -57,8 +57,8 @@ func GetPACMask() uint64 {
 		// The stack pointer on aarch64 needs to be aligned to 8 bytes at all
 		// times. The `<< 3` ensures that this is always the case for our fake
 		// pointers that will temporarily be placed as a fake stack pointer.
-		probe := uint64(rand.Uint32() << 3)
-		modifier := rand.Uint64()
+		probe := uint64(rand.Uint32() << 3) //nolint:gosec
+		modifier := rand.Uint64()           //nolint:gosec
 		probeWithPAC := PACIA(probe, modifier)
 		mask |= probeWithPAC & ^uint64(0xFFFF_FFFF)
 	}

--- a/periodiccaller/periodiccaller_test.go
+++ b/periodiccaller/periodiccaller_test.go
@@ -59,6 +59,7 @@ func isSelfOrRuntime(t *testing.T, stack *[32]uintptr, self string) bool {
 			if !strings.HasPrefix(funcName, "runtime.") &&
 				!strings.HasPrefix(funcName, "runtime/") &&
 				!strings.HasPrefix(funcName, "testing.") &&
+				!strings.HasPrefix(funcName, "internal/runtime") &&
 				funcName != "main.main" {
 				isRuntimeOnly = false
 			}


### PR DESCRIPTION
- We previously forgot to actually pass `TARGET_ARCH=xxx` to `make lint` in CI, so the ARM64 lint target didn't work as intended. 
  - This PR fixes this and also addresses various lints that have previously slipped due to that misconfiguration.
- Update and pin Go version used in CI to v1.23 
- Update `golanglint-ci` to v1.60.1 (previous version is broken with new Go)
- Cherry-picked commit from https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/118 to fix periodiccaller's goroutine leak check