### PR TITLE
reporter: drop project ID

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -46,7 +46,6 @@ var (
 		"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
 		"Default is %d corresponding to 4GB of executable address space, max is %d.",
 		defaultArgMapScaleFactor, maxArgMapScaleFactor)
-	secretTokenHelp         = "The secret token associated with the project id."
 	disableTLSHelp          = "Disable encryption for data in transit."
 	bpfVerifierLogLevelHelp = "Log level of the eBPF verifier output (0,1,2). Default is 0."
 	bpfVerifierLogSizeHelp  = "Size in bytes that will be allocated for the eBPF " +
@@ -82,7 +81,6 @@ type arguments struct {
 	probabilisticThreshold uint
 	reporterInterval       time.Duration
 	samplesPerSecond       int
-	secretToken            string
 	sendErrorFrames        bool
 	tracers                string
 	verboseMode            bool
@@ -130,9 +128,6 @@ func parseArgs() (*arguments, error) {
 
 	fs.IntVar(&args.samplesPerSecond, "samples-per-second", defaultArgSamplesPerSecond,
 		samplesPerSecondHelp)
-
-	// Using a default value here to simplify OTEL review process.
-	fs.StringVar(&args.secretToken, "secret-token", "abc123", secretTokenHelp)
 
 	fs.BoolVar(&args.sendErrorFrames, "send-error-frames", defaultArgSendErrorFrames,
 		sendErrorFramesHelp)

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -131,9 +131,6 @@ type OTLPReporter struct {
 	// samplesPerSecond is the number of samples per second.
 	samplesPerSecond int
 
-	// projectID is the project ID set by the user.
-	projectID string
-
 	// hostID is the unique identifier of the host.
 	hostID string
 
@@ -469,8 +466,6 @@ func (r *OTLPReporter) getResource() *resource.Resource {
 	// Add event specific attributes.
 	// These attributes are also included in the host metadata, but with different names/keys.
 	// That makes our hostmetadata attributes incompatible with OTEL collectors.
-	// TODO: Make a final decision about project id.
-	addAttr("profiling.project.id", r.projectID)
 	addAttr(semconv.HostIDKey, r.hostID)
 	addAttr(semconv.HostIPKey, r.ipAddress)
 	addAttr(semconv.HostNameKey, r.hostName)


### PR DESCRIPTION
Reporting a project ID originates from a SaaS setup. Currently neither users of the agent nor users of the reporter package can set the project ID and so a default value is sent every time.

In the OTel environment some element in OTel ResourceProfile should be preferred to set such a value.