### PR TITLE
Use `golangci-lint-action` in CI

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/workflows/env
-      - name: Getting linter version
+      - name: Get linter version
         id: linter-version
         run: (echo -n "version="; make linter-version) >> "$GITHUB_OUTPUT"
       - name: golangci-lint

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -18,13 +18,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/workflows/env
+      - name: Getting linter version
+        id: linter-version
+        run: (echo -n "version="; make linter-version) >> "$GITHUB_OUTPUT"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         env:
           GOARCH: ${{ matrix.target-arch }}
           CGO_ENABLED: 1
         with:
-          version: v1.60.1
+          version: ${{ steps.linter-version.outputs.version }}
 
   test:
     name: Test (${{ matrix.target_arch }})

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -18,10 +18,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/workflows/env
-      - name: Linter
-        run: |
-          go version
-          make lint TARGET_ARCH=${{ matrix.target_arch }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        env:
+          GOARCH: ${{ matrix.target-arch }}
+          CGO_ENABLED: 1
+        with:
+          version: v1.60.1
 
   test:
     name: Test (${{ matrix.target_arch }})

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-service:
-  golangci-lint-version: 1.60.x
-
 run:
   timeout: 10m
   build-tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,12 @@
 service:
   golangci-lint-version: 1.60.x
 
+run:
+  timeout: 10m
+  build-tags:
+    - integration
+    - linux
+
 issues:
   exclude-dirs:
     - artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all all-common binary clean ebpf generate test test-deps protobuf docker-image agent legal \
-	integration-test-binaries linter-version
+	integration-test-binaries lint linter-version
 
 SHELL := /usr/bin/env bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all all-common binary clean ebpf generate test test-deps protobuf docker-image agent legal \
-	integration-test-binaries
+	integration-test-binaries linter-version
 
 SHELL := /usr/bin/env bash
 
@@ -69,6 +69,9 @@ GOLANGCI_LINT_VERSION = "v1.60.1"
 lint: generate
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+
+linter-version:
+	@echo $(GOLANGCI_LINT_VERSION)
 
 test: generate ebpf test-deps
 	go test $(GO_FLAGS) ./...

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ebpf:
 GOLANGCI_LINT_VERSION = "v1.60.1"
 lint: generate
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --build-tags integration,linux --timeout 10m
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 
 test: generate ebpf test-deps
 	go test $(GO_FLAGS) ./...


### PR DESCRIPTION
Use the official [`golangci-lint-action`](https://github.com/golangci/golangci-lint-action) action for linting. This comes with two major benefits:

- It creates nice inline annotations on your diff if problems are found
- It takes care of caching the right paths automatically

Resolves https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/124