### PR TITLE
Remove context from reporter.ExecutableMetadata

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -7,7 +7,6 @@
 package dotnet
 
 import (
-	"context"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -19,6 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/elastic/go-freelru"
+
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/interpreter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
@@ -634,7 +634,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			open := func() (process.ReadAtCloser, error) {
 				return os.Open(m.Path)
 			}
-			symbolReporter.ExecutableMetadata(context.TODO(), info.fileID, path.Base(m.Path),
+			symbolReporter.ExecutableMetadata(info.fileID, path.Base(m.Path),
 				info.guid, libpf.Dotnet, open)
 			info.reported = true
 		}

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -254,7 +254,7 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
-func (s *symbolReporterMockup) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string,
+func (s *symbolReporterMockup) ExecutableMetadata(_ libpf.FileID, _, _ string,
 	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 }
 

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -15,7 +15,6 @@ package processmanager
 // HA/tracer and utils/coredump modules only.
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -306,7 +305,7 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	open := func() (process.ReadAtCloser, error) {
 		return pr.OpenMappingFile(&mapping2)
 	}
-	pm.reporter.ExecutableMetadata(context.TODO(), fileID, baseName, buildID, libpf.Native, open)
+	pm.reporter.ExecutableMetadata(fileID, baseName, buildID, libpf.Native, open)
 
 	return info
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -67,7 +67,7 @@ type SymbolReporter interface {
 	// that don't support this may pass a `nil` function pointer. Implementations that
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
-	ExecutableMetadata(ctx context.Context, fileID libpf.FileID, fileName, buildID string,
+	ExecutableMetadata(fileID libpf.FileID, fileName, buildID string,
 		interp libpf.InterpreterType, open ExecutableOpener)
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -20,9 +20,6 @@ import (
 	"time"
 
 	lru "github.com/elastic/go-freelru"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/xsync"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/zeebo/xxh3"
 	"go.opentelemetry.io/otel/attribute"
@@ -34,6 +31,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/xsync"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 var (
@@ -205,7 +206,7 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
-func (r *OTLPReporter) ExecutableMetadata(_ context.Context, fileID libpf.FileID, fileName,
+func (r *OTLPReporter) ExecutableMetadata(fileID libpf.FileID, fileName,
 	buildID string, _ libpf.InterpreterType, _ ExecutableOpener) {
 	r.executables.Add(fileID, execInfo{
 		fileName: fileName,

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -17,15 +17,15 @@ import (
 	"unsafe"
 
 	cebpf "github.com/cilium/ebpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
-	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/xsync"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/nativeunwind/elfunwindinfo"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	pm "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
+	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
@@ -65,7 +65,7 @@ func newSymbolizationCache() *symbolizationCache {
 	}
 }
 
-func (c *symbolizationCache) ExecutableMetadata(_ context.Context, fileID libpf.FileID,
+func (c *symbolizationCache) ExecutableMetadata(fileID libpf.FileID,
 	fileName, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 	c.files[fileID] = fileName
 }

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -17,17 +17,16 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/rlimit"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
+	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // forceContextSwitch makes sure two Go threads are running concurrently
@@ -96,7 +95,7 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string,
+func (f mockReporter) ExecutableMetadata(_ libpf.FileID, _, _ string,
 	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 }
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -25,8 +25,6 @@ import (
 	"github.com/cilium/ebpf/link"
 	lru "github.com/elastic/go-freelru"
 	"github.com/elastic/go-perf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/zeebo/xxh3"
 
@@ -43,7 +41,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/rlimit"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
@@ -170,8 +170,7 @@ type hookPoint struct {
 
 // processKernelModulesMetadata computes the FileID of kernel files and reports executable metadata
 // for all kernel modules and the vmlinux image.
-func processKernelModulesMetadata(ctx context.Context,
-	rep reporter.SymbolReporter, kernelModules *libpf.SymbolMap,
+func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *libpf.SymbolMap,
 	kernelSymbols *libpf.SymbolMap) (map[string]libpf.FileID, error) {
 	result := make(map[string]libpf.FileID, kernelModules.Len())
 	kernelModules.VisitAll(func(moduleSym libpf.Symbol) {
@@ -203,7 +202,7 @@ func processKernelModulesMetadata(ctx context.Context,
 		}
 
 		result[nameStr] = fileID
-		rep.ExecutableMetadata(ctx, fileID, nameStr, buildID, libpf.Kernel, nil)
+		rep.ExecutableMetadata(fileID, nameStr, buildID, libpf.Kernel, nil)
 	})
 
 	return result, nil
@@ -304,8 +303,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("unable to instantiate transmitted fallback symbols cache: %v", err)
 	}
 
-	moduleFileIDs, err := processKernelModulesMetadata(ctx,
-		cfg.Reporter, kernelModules, kernelSymbols)
+	moduleFileIDs, err := processKernelModulesMetadata(cfg.Reporter, kernelModules, kernelSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract kernel modules metadata: %v", err)
 	}


### PR DESCRIPTION
It looks like that the context parameter of `reporter.ExecutableMetadata()` is a historical remnant.