### PR TITLE
Add CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to opentelemetry-ebpf-profiler
+
+The Go special interest group (SIG) meets regularly. See the
+OpenTelemetry
+[community](https://github.com/open-telemetry/community)
+repo for information on this and other SIGs.
+
+See the [public meeting
+notes](https://docs.google.com/document/d/19UqPPPlGE83N37MhS93uRlxsP1_wGxQ33Qv6CDHaEp0/edit#heading=h.4rdgawyis2hd)
+for a summary description of past meetings.
+
+## Development
+
+You can view and edit the source code by cloning this repository:
+
+```sh
+git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler.git
+```
+
+Run `make test` to run the tests instead of `go test`.
+
+Additionally, there is a `codespell` target that checks for common
+typos in the code. It is not run by default, but you can run it
+manually with `make codespell`.
+
+## Pull Requests
+
+### How to Send Pull Requests
+
+Everyone is welcome to contribute code to `opentelemetry-ebpf-profiler` via
+GitHub pull requests (PRs).
+
+To create a new PR, fork the project in GitHub and clone the upstream
+repo:
+
+```sh
+git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
+```
+
+This would put the project in the `opentelemetry-go` directory in
+current working directory.
+
+Enter the newly created directory and add your fork as a new remote:
+
+```sh
+git remote add <YOUR_FORK> git@github.com:<YOUR_GITHUB_USERNAME>/opentelemetry-ebpf-profiler
+```
+
+Check out a new branch, make modifications, run linters and tests, and push the
+branch to your fork:
+
+```sh
+git checkout -b <YOUR_BRANCH_NAME>
+# edit files
+# update changelog
+git add -p
+git commit
+git push <YOUR_FORK> <YOUR_BRANCH_NAME>
+```
+
+Open a pull request against the main `opentelemetry-ebpf-profiler` repo.
+
+Avoid rebasing and force-pushing to your branch to facilitate reviewing the
+pull request.
+Rewriting Git history makes it difficult to keep track of iterations during
+code review.
+All pull requests are squashed to a single commit upon merge to `main`.
+
+### How to Receive Comments
+
+* If the PR is not ready for review, please put `[WIP]` in the title,
+	tag it as `work-in-progress`, or mark it as
+	[`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+* Make sure CLA is signed and CI is clear.
+
+### How to Get PRs Merged
+
+A PR is considered **ready to merge** when:
+
+* It has received two qualified approvals[^1].
+
+	This is not enforced through automation, but needs to be validated by the
+	maintainer merging.
+	* PRs introducing changes that have already been discussed and consensus
+		reached only need one qualified approval. The discussion and resolution
+		needs to be linked to the PR.
+	* Trivial changes[^2] only need one qualified approval.
+
+* All feedback has been addressed.
+	* All PR comments and suggestions are resolved.
+	* All GitHub Pull Request reviews with a status of "Request changes" have
+		been addressed. Another review by the objecting reviewer with a different
+		status can be submitted to clear the original review, or the review can be
+		dismissed by a [Maintainer] when the issues from the original review have
+		been addressed.
+	* Any comments or reviews that cannot be resolved between the PR author and
+		reviewers can be submitted to the community [Approver]s and [Maintainer]s
+		during the weekly SIG meeting. If consensus is reached among the
+		[Approver]s and [Maintainer]s during the SIG meeting the objections to the
+		PR may be dismissed or resolved or the PR closed by a [Maintainer].
+	* Any substantive changes to the PR require existing Approval reviews be
+		cleared unless the approver explicitly states that their approval persists
+		across changes. This includes changes resulting from other feedback.
+		[Approver]s and [Maintainer]s can help in clearing reviews and they should
+		be consulted if there are any questions.
+
+* The PR branch is up to date with the base branch it is merging into.
+	* To ensure this does not block the PR, it should be configured to allow
+		maintainers to update it.
+
+* It has been open for review for at least one working day. This gives people
+	reasonable time to review.
+	* Trivial changes[^2] do not have to wait for one day and may be merged with
+		a single [Maintainer]'s approval.
+
+* All required GitHub workflows have succeeded.
+* Urgent fix can take exception as long as it has been actively communicated
+	among [Maintainer]s.
+
+Any [Maintainer] can merge the PR once the above criteria have been met.
+
+[^1]: A qualified approval is a GitHub Pull Request review with "Approve"
+	status from an OpenTelemetry Profiler [Approver] or [Maintainer].
+[^2]: Trivial changes include: typo corrections, cosmetic non-substantive
+	changes, documentation corrections or updates, dependency updates, etc.
+
+## Approvers and Maintainers
+
+### Approvers
+
+- [Christos Kalkanis](https://github.com/christos68k), Elastic
+- [Florian Lehner](https://github.com/florianl), Elastic
+- [Tim Rühsen](https://github.com/rockdaboot), Elastic
+
+### Maintainers
+
+- [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana-
+- [Felix Geisendörfer](https://github.com/felixge), Datadog
+- [Joel Höner ](https://github.com/athre0z), Elastic
+- [Timo Teräs](https://github.com/fabled)
+
+### Become an Approver or a Maintainer
+
+See the [community membership document in OpenTelemetry community
+repo](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md).
+
+[Approver]: #approvers
+[Maintainer]: #maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 - [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana
 - [Felix Geisendörfer](https://github.com/felixge), Datadog
-- [Joel Höner ](https://github.com/athre0z), Elastic
+- [Joel Höner](https://github.com/athre0z), Elastic
 - [Timo Teräs](https://github.com/fabled)
 
 ### Become an Approver or a Maintainer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ for a summary description of past meetings.
 You can view and edit the source code by cloning this repository:
 
 ```sh
-git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler.git
+git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
 ```
 
 Run `make test` to run the tests instead of `go test`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to opentelemetry-ebpf-profiler
 
-The Go special interest group (SIG) meets regularly. See the
+The Profiling special interest group (SIG) meets regularly. See the
 OpenTelemetry
 [community](https://github.com/open-telemetry/community)
 repo for information on this and other SIGs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 ### Maintainers
 
-- [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana-
+- [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana
 - [Felix Geisendörfer](https://github.com/felixge), Datadog
 - [Joel Höner ](https://github.com/athre0z), Elastic
 - [Timo Teräs](https://github.com/fabled)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ OpenTelemetry
 [community](https://github.com/open-telemetry/community)
 repo for information on this and other SIGs.
 
+## Community
+
 See the [public meeting
 notes](https://docs.google.com/document/d/19UqPPPlGE83N37MhS93uRlxsP1_wGxQ33Qv6CDHaEp0/edit#heading=h.4rdgawyis2hd)
 for a summary description of past meetings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,6 @@ git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
 
 Run `make test` to run the tests instead of `go test`.
 
-Additionally, there is a `codespell` target that checks for common
-typos in the code. It is not run by default, but you can run it
-manually with `make codespell`.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ See the [public meeting
 notes](https://docs.google.com/document/d/19UqPPPlGE83N37MhS93uRlxsP1_wGxQ33Qv6CDHaEp0/edit#heading=h.4rdgawyis2hd)
 for a summary description of past meetings.
 
+See the [calendar
+group](https://groups.google.com/a/opentelemetry.io/g/calendar-profiling) to
+get invited to meetings.
+
+See the [#otel-profiles](https://cloud-native.slack.com/archives/C03J794L0BV)
+slack channel for discussions and questions.
+
 ## Development
 
 You can view and edit the source code by cloning this repository:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ repo:
 git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
 ```
 
-This would put the project in the `opentelemetry-go` directory in
+This will put the project in `opentelemetry-ebpf-profiler` in
 current working directory.
 
 Enter the newly created directory and add your fork as a new remote:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,6 @@ A PR is considered **ready to merge** when:
 	* PRs introducing changes that have already been discussed and consensus
 		reached only need one qualified approval. The discussion and resolution
 		needs to be linked to the PR.
-	* Trivial changes[^2] only need one qualified approval.
 
 * All feedback has been addressed.
 	* All PR comments and suggestions are resolved.
@@ -114,8 +113,6 @@ A PR is considered **ready to merge** when:
 
 * It has been open for review for at least one working day. This gives people
 	reasonable time to review.
-	* Trivial changes[^2] do not have to wait for one day and may be merged with
-		a single [Maintainer]'s approval.
 
 * All required GitHub workflows have succeeded.
 * Urgent fix can take exception as long as it has been actively communicated
@@ -125,8 +122,6 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 [^1]: A qualified approval is a GitHub Pull Request review with "Approve"
 	status from an OpenTelemetry Profiler [Approver] or [Maintainer].
-[^2]: Trivial changes include: typo corrections, cosmetic non-substantive
-	changes, documentation corrections or updates, dependency updates, etc.
 
 ## Approvers and Maintainers
 


### PR DESCRIPTION
This adds a CONTRIBUTING file, so new contributors better know what to expect.
I based this on the [otel-go contributing file](https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md), with some adjustements.
Everything is open for comments obviously.