### PR TITLE
Move type PID to libpf

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // TraceHash is used for unique identifiers for traces, and is required to be 64-bits
@@ -55,8 +54,8 @@ type Trace struct {
 	Frames           []Frame
 	Hash             TraceHash
 	KTime            times.KTime
-	PID              util.PID
-	TID              util.PID
+	PID              libpf.PID
+	TID              libpf.PID
 	APMTraceID       libpf.APMTraceID
 	APMTransactionID libpf.APMTransactionID
 }

--- a/interpreter/apmint/apmint.go
+++ b/interpreter/apmint/apmint.go
@@ -17,14 +17,13 @@ import (
 	"regexp"
 	"unsafe"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/interpreter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/pfelf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // #include <stdlib.h>
@@ -108,7 +107,7 @@ type data struct {
 
 var _ interpreter.Data = &data{}
 
-func (d data) Attach(ebpf interpreter.EbpfHandler, pid util.PID,
+func (d data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	bias libpf.Address, rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	procStorage, err := readProcStorage(rm, bias+d.procStorageElfVA)
 	if err != nil {
@@ -146,13 +145,13 @@ type Instance struct {
 var _ interpreter.Instance = &Instance{}
 
 // Detach implements the interpreter.Instance interface.
-func (i *Instance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *Instance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	return ebpf.DeleteProcData(libpf.APMInt, pid)
 }
 
 // NotifyAPMAgent sends out collected traces to the connected APM agent.
 func (i *Instance) NotifyAPMAgent(
-	pid util.PID, rawTrace *host.Trace, umTraceHash libpf.TraceHash, count uint16) {
+	pid libpf.PID, rawTrace *host.Trace, umTraceHash libpf.TraceHash, count uint16) {
 	if rawTrace.APMTransactionID == libpf.InvalidAPMSpanID || i.socket == nil {
 		return
 	}

--- a/interpreter/apmint/socket.go
+++ b/interpreter/apmint/socket.go
@@ -24,7 +24,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/xsync"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/stringutil"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // sendSocket is the shared, unbound socket that we use for communication with
@@ -40,7 +39,7 @@ type apmAgentSocket struct {
 // openAPMAgentSocket opens the APM unix socket in the given PID's root filesystem.
 //
 // This method never blocks.
-func openAPMAgentSocket(pid util.PID, socketPath string) (*apmAgentSocket, error) {
+func openAPMAgentSocket(pid libpf.PID, socketPath string) (*apmAgentSocket, error) {
 	// Ensure that the socket path can't escape our root.
 	socketPath = filepath.Clean(socketPath)
 	for _, segment := range strings.Split(socketPath, "/") {
@@ -123,7 +122,7 @@ func (m *traceCorrMsg) Serialize() []byte {
 }
 
 // readProcessOwner reads the effective UID and GID of the target process.
-func readProcessOwner(pid util.PID) (euid, egid uint32, err error) {
+func readProcessOwner(pid libpf.PID) (euid, egid uint32, err error) {
 	statusFd, err := os.Open(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to open process status: %v", err)

--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -13,10 +13,10 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/elastic/go-freelru"
+
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/interpreter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // #include "../../support/ebpf/types.h"
@@ -32,7 +32,7 @@ type dotnetData struct {
 
 	// method to walk range sections
 	walkRangeSectionsMethod func(i *dotnetInstance, ebpf interpreter.EbpfHandler,
-		pid util.PID) error
+		pid libpf.PID) error
 
 	vmStructs struct {
 		// https://github.com/dotnet/runtime/blob/v7.0.15/src/coreclr/debug/ee/dactable.cpp#L81
@@ -137,7 +137,7 @@ func (d *dotnetData) String() string {
 	return fmt.Sprintf("dotnet %d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff)
 }
 
-func (d *dotnetData) Attach(ebpf interpreter.EbpfHandler, pid util.PID, bias libpf.Address,
+func (d *dotnetData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	log.Debugf("Attach PID %d, bias %x", pid, bias)
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -190,7 +190,7 @@ func (i *dotnetInstance) calculateAndSymbolizeStubID(symbolReporter reporter.Sym
 }
 
 // addRange inserts a known memory mapping along with the needed data of it to ebpf maps
-func (i *dotnetInstance) addRange(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *dotnetInstance) addRange(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	lowAddress, highAddress, mapBase libpf.Address, stubTypeOrHdrMap uint64) {
 	// Inform the unwinder about this range
 	prefixes, err := lpm.CalculatePrefixList(uint64(lowAddress), uint64(highAddress))
@@ -221,7 +221,7 @@ func (i *dotnetInstance) addRange(ebpf interpreter.EbpfHandler, pid util.PID,
 }
 
 // walkRangeList processes stub ranges from a RangeList
-func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	headPtr libpf.Address, codeType uint) {
 	// This hardcodes the layout of RangeList, Range and RangeListBlock from
 	// https://github.com/dotnet/runtime/blob/v7.0.15/src/coreclr/inc/utilcode.h#L3556-L3579
@@ -259,7 +259,7 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid util.PI
 }
 
 // addRangeSection processes a RangeSection structure and calls addRange as needed
-func (i *dotnetInstance) addRangeSection(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *dotnetInstance) addRangeSection(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	rangeSection []byte) error {
 	// Extract interesting fields
 	vms := &i.d.vmStructs
@@ -324,7 +324,7 @@ func (i *dotnetInstance) addRangeSection(ebpf interpreter.EbpfHandler, pid util.
 }
 
 // walkRangeSectionList adds all RangeSections in a list (dotnet6 and dotnet7)
-func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	vms := &i.d.vmStructs
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	// walk the RangeSection list
@@ -343,7 +343,7 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 
 // walkRangeSectionMapFragments walks a RangeSectionMap::RangeSectionFragment list and processes
 // the RangeSections from it.
-func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	fragmentPtr libpf.Address) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L974
 	vms := &i.d.vmStructs
@@ -372,7 +372,7 @@ func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandl
 }
 
 // walkRangeSectionMapLevel walks recursively a level index of a RangeSectionMap.
-func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	levelMapPtr libpf.Address, level uint) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L999-L1002
 	const maxLevel = 5
@@ -402,7 +402,7 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 }
 
 // walkRangeSectionMap processes a dotnet8 RangeSectionMap to enumerate all RangeSections
-func (i *dotnetInstance) walkRangeSectionMap(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *dotnetInstance) walkRangeSectionMap(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	i.rangeSectionSeen = make(map[libpf.Address]libpf.Void)
 	err := i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1)
 	i.rangeSectionSeen = nil
@@ -537,7 +537,7 @@ func (i *dotnetInstance) getMethod(codeHeaderPtr libpf.Address) (*dotnetMethod, 
 	return method, nil
 }
 
-func (i *dotnetInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *dotnetInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	return ebpf.DeleteProcData(libpf.Dotnet, pid)
 }
 

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -26,7 +26,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/lpm"
 	npsr "github.com/open-telemetry/opentelemetry-ebpf-profiler/nopanicslicereader"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // hotspotIntrospectionTable contains the resolved ELF symbols for an introspection table
@@ -338,7 +337,7 @@ func (d *hotspotData) String() string {
 // Attach loads to the ebpf program the needed pointers and sizes to unwind given hotspot process.
 // As the hotspot unwinder depends on the native unwinder, a part of the cleanup is done by the
 // process manager and not the corresponding Detach() function of hotspot objects.
-func (d *hotspotData) Attach(_ interpreter.EbpfHandler, _ util.PID, bias libpf.Address,
+func (d *hotspotData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (ii interpreter.Instance, err error) {
 	// Each function has four symbols: source filename, class name,
 	// method name and signature. However, most of them are shared across

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -498,7 +498,7 @@ func (d *hotspotInstance) getJITInfo(addr libpf.Address,
 }
 
 // Detach removes all information regarding a given process from the eBPF maps.
-func (d *hotspotInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (d *hotspotInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	var err error
 	if d.mainMappingsInserted {
 		err = ebpf.DeleteProcData(libpf.HotSpot, pid)
@@ -599,7 +599,7 @@ func (d *hotspotInstance) gatherHeapInfo(vmd *hotspotVMData) (*heapInfo, error) 
 
 // addJitArea inserts an entry into the PID<->interpreter BPF map.
 func (d *hotspotInstance) addJitArea(ebpf interpreter.EbpfHandler,
-	pid util.PID, area jitArea) error {
+	pid libpf.PID, area jitArea) error {
 	prefixes, err := lpm.CalculatePrefixList(uint64(area.start), uint64(area.end))
 	if err != nil {
 		return fmt.Errorf("LPM prefix calculation error for %x-%x", area.start, area.end)
@@ -632,7 +632,7 @@ func (d *hotspotInstance) addJitArea(ebpf interpreter.EbpfHandler,
 // allows the BPF code to start unwinding even if some more detailed information
 // about e.g. stub routines is not yet available.
 func (d *hotspotInstance) populateMainMappings(vmd *hotspotVMData,
-	ebpf interpreter.EbpfHandler, pid util.PID) error {
+	ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	if d.mainMappingsInserted {
 		// Already populated: nothing to do here.
 		return nil
@@ -704,7 +704,7 @@ func (d *hotspotInstance) populateMainMappings(vmd *hotspotVMData,
 // stubs map and, if necessary on the architecture, inserts unwinding instructions
 // for them in the PID mappings BPF map.
 func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
-	ebpf interpreter.EbpfHandler, pid util.PID) {
+	ebpf interpreter.EbpfHandler, pid libpf.PID) {
 	for _, stub := range findStubBounds(vmd, d.bias, d.rm) {
 		if _, exists := d.stubs[stub.start]; exists {
 			continue

--- a/interpreter/instancestubs.go
+++ b/interpreter/instancestubs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tpbase"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // InstanceStubs provides empty implementations of Instance hooks that are
@@ -26,7 +25,7 @@ func (is *InstanceStubs) SynchronizeMappings(EbpfHandler, reporter.SymbolReporte
 	return nil
 }
 
-func (is *InstanceStubs) UpdateTSDInfo(EbpfHandler, util.PID, tpbase.TSDInfo) error {
+func (is *InstanceStubs) UpdateTSDInfo(EbpfHandler, libpf.PID, tpbase.TSDInfo) error {
 	return nil
 }
 

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -531,7 +531,7 @@ type v8SFI struct {
 	bytecodeLength        uint32
 }
 
-func (i *v8Instance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *v8Instance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	err := ebpf.DeleteProcData(libpf.V8, pid)
 	for prefix := range i.prefixes {
 		if err2 := ebpf.DeletePidInterpreterMapping(pid, prefix); err2 != nil {
@@ -1764,7 +1764,7 @@ func mapFramePointerOffset(relBytes uint8) C.u8 {
 	return C.u8(slotOffset)
 }
 
-func (d *v8Data) Attach(ebpf interpreter.EbpfHandler, pid util.PID, _ libpf.Address,
+func (d *v8Data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, _ libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	vms := &d.vmStructs
 	data := C.V8ProcInfo{

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -18,7 +18,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/pfelf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // #include "../../support/ebpf/types.h"
@@ -128,7 +127,7 @@ func (d *perlData) String() string {
 	return fmt.Sprintf("Perl %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
 }
 
-func (d *perlData) Attach(_ interpreter.EbpfHandler, _ util.PID, bias libpf.Address,
+func (d *perlData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	addrToHEK, err := freelru.New[libpf.Address, string](interpreter.LruFunctionCacheSize,
 		libpf.Address.Hash32)

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -84,7 +84,7 @@ func hashCOPKey(k copKey) uint32 {
 	return uint32(h ^ xxhash.Sum64String(k.funcName))
 }
 
-func (i *perlInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid util.PID,
+func (i *perlInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	tsdInfo tpbase.TSDInfo) error {
 	d := i.d
 	stateInTSD := C.u8(0)
@@ -134,7 +134,7 @@ func (i *perlInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid util.PID,
 	return nil
 }
 
-func (i *perlInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *perlInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	if !i.procInfoInserted {
 		return nil
 	}

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -75,7 +75,7 @@ type phpInstance struct {
 	addrToFunction *freelru.LRU[libpf.Address, *phpFunction]
 }
 
-func (i *phpInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *phpInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	return ebpf.DeleteProcData(libpf.PHP, pid)
 }
 

--- a/interpreter/php/opcache.go
+++ b/interpreter/php/opcache.go
@@ -174,7 +174,7 @@ type opcacheInstance struct {
 	prefixes []lpm.Prefix
 }
 
-func (i *opcacheInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (i *opcacheInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	// Here we just remove the entries relating to the mappings for the
 	// JIT's memory
 	var err error
@@ -240,7 +240,7 @@ func (d *opcacheData) String() string {
 	return fmt.Sprintf("Opcache %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
 }
 
-func (d *opcacheData) Attach(_ interpreter.EbpfHandler, _ util.PID, bias libpf.Address,
+func (d *opcacheData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	return &opcacheInstance{
 		d:    d,

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -23,7 +23,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/pfelf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // #include "../../support/ebpf/types.h"
@@ -112,7 +111,7 @@ func (d *phpData) String() string {
 	return fmt.Sprintf("PHP %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
 }
 
-func (d *phpData) Attach(ebpf interpreter.EbpfHandler, pid util.PID, bias libpf.Address,
+func (d *phpData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	addrToFunction, err :=
 		freelru.New[libpf.Address, *phpFunction](interpreter.LruFunctionCacheSize,

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -123,7 +123,7 @@ func (d *pythonData) String() string {
 	return fmt.Sprintf("Python %d.%d", d.version>>8, d.version&0xff)
 }
 
-func (d *pythonData) Attach(_ interpreter.EbpfHandler, _ util.PID, bias libpf.Address,
+func (d *pythonData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	addrToCodeObject, err :=
 		freelru.New[libpf.Address, *pythonCodeObject](interpreter.LruFunctionCacheSize,
@@ -410,7 +410,7 @@ func (p *pythonInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
 	}, nil
 }
 
-func (p *pythonInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid util.PID,
+func (p *pythonInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	tsdInfo tpbase.TSDInfo) error {
 	d := p.d
 	vm := &d.vmStructs
@@ -447,7 +447,7 @@ func (p *pythonInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid util.PI
 	return err
 }
 
-func (p *pythonInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (p *pythonInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	if !p.procInfoInserted {
 		return nil
 	}

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -182,7 +182,7 @@ func rubyVersion(major, minor, release uint32) uint32 {
 	return major*0x10000 + minor*0x100 + release
 }
 
-func (r *rubyData) Attach(ebpf interpreter.EbpfHandler, pid util.PID, bias libpf.Address,
+func (r *rubyData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	cdata := C.RubyProcInfo{
 		version: C.u32(r.version),
@@ -289,7 +289,7 @@ type rubyInstance struct {
 	maxSize atomic.Uint32
 }
 
-func (r *rubyInstance) Detach(ebpf interpreter.EbpfHandler, pid util.PID) error {
+func (r *rubyInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
 	return ebpf.DeleteProcData(libpf.Ruby, pid)
 }
 

--- a/interpreter/types.go
+++ b/interpreter/types.go
@@ -92,18 +92,18 @@ type EbpfHandler interface {
 		offsetRanges []util.Range) error
 
 	// UpdateProcData adds the given interpreter data to the named eBPF map.
-	UpdateProcData(typ libpf.InterpreterType, pid util.PID, data unsafe.Pointer) error
+	UpdateProcData(typ libpf.InterpreterType, pid libpf.PID, data unsafe.Pointer) error
 
 	// DeleteProcData removes any data from the named eBPF map.
-	DeleteProcData(typ libpf.InterpreterType, pid util.PID) error
+	DeleteProcData(typ libpf.InterpreterType, pid libpf.PID) error
 
 	// UpdatePidInterpreterMapping updates the eBPF map pid_page_to_mapping_info
 	// to call given interpreter unwinder.
-	UpdatePidInterpreterMapping(util.PID, lpm.Prefix, uint8, host.FileID, uint64) error
+	UpdatePidInterpreterMapping(libpf.PID, lpm.Prefix, uint8, host.FileID, uint64) error
 
 	// DeletePidInterpreterMapping removes the element specified by pid, prefix
 	// rom the eBPF map pid_page_to_mapping_info.
-	DeletePidInterpreterMapping(util.PID, lpm.Prefix) error
+	DeletePidInterpreterMapping(libpf.PID, lpm.Prefix) error
 }
 
 // Loader is a function to detect and load data from given interpreter ELF file.
@@ -121,7 +121,7 @@ type Loader func(ebpf EbpfHandler, info *LoaderInfo) (Data, error)
 type Data interface {
 	// Attach checks if the given dso is supported, and loads the information
 	// of it to the ebpf maps.
-	Attach(ebpf EbpfHandler, pid util.PID, bias libpf.Address, rm remotememory.RemoteMemory) (
+	Attach(ebpf EbpfHandler, pid libpf.PID, bias libpf.Address, rm remotememory.RemoteMemory) (
 		Instance, error)
 }
 
@@ -129,7 +129,7 @@ type Data interface {
 type Instance interface {
 	// Detach removes any information from the ebpf maps. The pid is given as argument so
 	// simple interpreters can use the global Data also as the Instance implementation.
-	Detach(ebpf EbpfHandler, pid util.PID) error
+	Detach(ebpf EbpfHandler, pid libpf.PID) error
 
 	// SynchronizeMappings is called when the processmanager has reread process memory
 	// mappings. Interpreters not needing to process these events can simply ignore them
@@ -139,7 +139,7 @@ type Instance interface {
 
 	// UpdateTSDInfo is called when the process C-library Thread Specific Data related
 	// introspection data has been updated.
-	UpdateTSDInfo(ebpf EbpfHandler, pid util.PID, info tpbase.TSDInfo) error
+	UpdateTSDInfo(ebpf EbpfHandler, pid libpf.PID, info tpbase.TSDInfo) error
 
 	// Symbolize requests symbolization of the given frame, and dispatches this symbolization
 	// to the collection agent. The frame's contents (frame type, file ID and line number)

--- a/libpf/pid.go
+++ b/libpf/pid.go
@@ -1,0 +1,8 @@
+package libpf
+
+// PID represent Unix Process ID (pid_t)
+type PID int32
+
+func (p PID) Hash32() uint32 {
+	return uint32(p)
+}

--- a/libpf/pid.go
+++ b/libpf/pid.go
@@ -1,7 +1,7 @@
 package libpf
 
 // PID represent Unix Process ID (pid_t)
-type PID int32
+type PID uint32
 
 func (p PID) Hash32() uint32 {
 	return uint32(p)

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -12,6 +12,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -147,7 +148,7 @@ func ListPIDs() ([]libpf.PID, error) {
 			continue
 		}
 		pid, err := strconv.ParseUint(f.Name(), 10, 32)
-		if err != nil {
+		if err != nil || pid > math.MaxUint32 {
 			continue
 		}
 		pids = append(pids, libpf.PID(pid))

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/stringutil"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 const defaultMountPoint = "/proc"
@@ -136,8 +135,8 @@ func GetKernelModules(modulesPath string,
 }
 
 // ListPIDs from the proc filesystem mount point and return a list of util.PID to be processed
-func ListPIDs() ([]util.PID, error) {
-	pids := make([]util.PID, 0)
+func ListPIDs() ([]libpf.PID, error) {
+	pids := make([]libpf.PID, 0)
 	files, err := os.ReadDir(defaultMountPoint)
 	if err != nil {
 		return nil, err
@@ -151,7 +150,7 @@ func ListPIDs() ([]util.PID, error) {
 		if err != nil {
 			continue
 		}
-		pids = append(pids, util.PID(pid))
+		pids = append(pids, libpf.PID(pid))
 	}
 	return pids, nil
 }
@@ -159,7 +158,7 @@ func ListPIDs() ([]util.PID, error) {
 // IsPIDLive checks if a PID belongs to a live process. It will never produce a false negative but
 // may produce a false positive (e.g. due to permissions) in which case an error will also be
 // returned.
-func IsPIDLive(pid util.PID) (bool, error) {
+func IsPIDLive(pid libpf.PID) (bool, error) {
 	// A kill syscall with a 0 signal is documented to still do the check
 	// whether the process exists: https://linux.die.net/man/2/kill
 	err := unix.Kill(int(pid), 0)

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/pfelf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 const (
@@ -39,7 +38,7 @@ type CoredumpProcess struct {
 	files map[string]*CoredumpFile
 
 	// pid the original PID of the coredump
-	pid util.PID
+	pid libpf.PID
 
 	// machineData contains the parsed machine data
 	machineData MachineData
@@ -252,7 +251,7 @@ func (cd *CoredumpProcess) MainExecutable() string {
 }
 
 // PID implements the Process interface
-func (cd *CoredumpProcess) PID() util.PID {
+func (cd *CoredumpProcess) PID() libpf.PID {
 	return cd.pid
 }
 
@@ -449,7 +448,7 @@ type PrpsInfo64 struct {
 func (cd *CoredumpProcess) parseProcessInfo(desc []byte) error {
 	if len(desc) == int(unsafe.Sizeof(PrpsInfo64{})) {
 		info := (*PrpsInfo64)(unsafe.Pointer(&desc[0]))
-		cd.pid = util.PID(info.PID)
+		cd.pid = libpf.PID(info.PID)
 		return nil
 	}
 	return fmt.Errorf("unsupported NT_PRPSINFO size: %d", len(desc))

--- a/process/debug.go
+++ b/process/debug.go
@@ -15,8 +15,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/remotememory"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 type ptraceProcess struct {
@@ -46,7 +46,7 @@ func ptraceGetRegset(tid, regset int, data []byte) error {
 // from one goroutine. If this is not sufficient in future, the implementation
 // should be refactored to pass all requests via a proxy goroutine through
 // channels so that the kernel requirements are fulfilled.
-func NewPtrace(pid util.PID) (Process, error) {
+func NewPtrace(pid libpf.PID) (Process, error) {
 	// Lock this goroutine to the OS thread. It is ptrace API requirement
 	// that all ptrace calls must come from same thread.
 	runtime.LockOSThread()

--- a/process/process.go
+++ b/process/process.go
@@ -28,7 +28,7 @@ import (
 // systemProcess provides an implementation of the Process interface for a
 // process that is currently running on this machine.
 type systemProcess struct {
-	pid util.PID
+	pid libpf.PID
 
 	remoteMemory remotememory.RemoteMemory
 
@@ -38,14 +38,14 @@ type systemProcess struct {
 var _ Process = &systemProcess{}
 
 // New returns an object with Process interface accessing it
-func New(pid util.PID) Process {
+func New(pid libpf.PID) Process {
 	return &systemProcess{
 		pid:          pid,
 		remoteMemory: remotememory.NewProcessVirtualMemory(pid),
 	}
 }
 
-func (sp *systemProcess) PID() util.PID {
+func (sp *systemProcess) PID() libpf.PID {
 	return sp.pid
 }
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 )
 
 //nolint:lll
@@ -101,7 +101,7 @@ func TestParseMappings(t *testing.T) {
 }
 
 func TestNewPIDOfSelf(t *testing.T) {
-	pr := New(util.PID(os.Getpid()))
+	pr := New(libpf.PID(os.Getpid()))
 	assert.NotNil(t, pr)
 
 	mappings, err := pr.GetMappings()

--- a/process/types.go
+++ b/process/types.go
@@ -98,7 +98,7 @@ type ReadAtCloser interface {
 // GetRemoteMemory object are safe for concurrent use.
 type Process interface {
 	// PID returns the process identifier
-	PID() util.PID
+	PID() libpf.PID
 
 	// GetMachineData reads machine specific data from the target process
 	GetMachineData() MachineData

--- a/processmanager/ebpf/ebpf_integration_test.go
+++ b/processmanager/ebpf/ebpf_integration_test.go
@@ -13,13 +13,13 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/lpm"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/rlimit"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func loadTracers(t *testing.T) *ebpfMapsImpl {
@@ -42,7 +42,7 @@ func loadTracers(t *testing.T) *ebpfMapsImpl {
 
 func TestLPM(t *testing.T) {
 	tests := map[string]struct {
-		pid      util.PID
+		pid      libpf.PID
 		page     uint64
 		pageBits uint32
 		rip      uint64

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -14,8 +14,9 @@ import (
 	"time"
 
 	lru "github.com/elastic/go-freelru"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/interpreter"
@@ -90,14 +91,14 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		return nil, fmt.Errorf("unable to create ExecutableInfoManager: %v", err)
 	}
 
-	interpreters := make(map[util.PID]map[util.OnDiskFileIdentifier]interpreter.Instance)
+	interpreters := make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance)
 
 	pm := &ProcessManager{
 		interpreterTracerEnabled: em.NumInterpreterLoaders() > 0,
 		eim:                      em,
 		interpreters:             interpreters,
-		exitEvents:               make(map[util.PID]times.KTime),
-		pidToProcessInfo:         make(map[util.PID]*processInfo),
+		exitEvents:               make(map[libpf.PID]times.KTime),
+		pidToProcessInfo:         make(map[libpf.PID]*processInfo),
 		ebpf:                     ebpf,
 		FileIDMapper:             fileIDMapper,
 		elfInfoCache:             elfInfoCache,
@@ -297,7 +298,7 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 }
 
 // findMappingForTrace locates the mapping for a given host trace.
-func (pm *ProcessManager) findMappingForTrace(pid util.PID, fid host.FileID,
+func (pm *ProcessManager) findMappingForTrace(pid libpf.PID, fid host.FileID,
 	addr libpf.AddressOrLineno) (m Mapping, found bool) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -40,10 +40,10 @@ import (
 
 // dummyProcess implements pfelf.Process for testing purposes
 type dummyProcess struct {
-	pid util.PID
+	pid libpf.PID
 }
 
-func (d *dummyProcess) PID() util.PID {
+func (d *dummyProcess) PID() libpf.PID {
 	return d.pid
 }
 
@@ -83,7 +83,7 @@ func (d *dummyProcess) Close() error {
 	return nil
 }
 
-func newTestProcess(pid util.PID) process.Process {
+func newTestProcess(pid libpf.PID) process.Process {
 	return &dummyProcess{pid: pid}
 }
 
@@ -142,7 +142,7 @@ func generateDummyFiles(t *testing.T, num int) []string {
 // for the tests.
 type mappingArgs struct {
 	// pid represents the simulated process ID.
-	pid util.PID
+	pid libpf.PID
 	// vaddr represents the simulated start of the mapped memory.
 	vaddr uint64
 	// bias is the load bias to simulate and verify.
@@ -169,7 +169,7 @@ type ebpfMapsMockup struct {
 
 var _ interpreter.EbpfHandler = &ebpfMapsMockup{}
 
-func (mockup *ebpfMapsMockup) RemoveReportedPID(util.PID) {
+func (mockup *ebpfMapsMockup) RemoveReportedPID(libpf.PID) {
 }
 
 func (mockup *ebpfMapsMockup) UpdateInterpreterOffsets(uint16, host.FileID,
@@ -177,23 +177,23 @@ func (mockup *ebpfMapsMockup) UpdateInterpreterOffsets(uint16, host.FileID,
 	return nil
 }
 
-func (mockup *ebpfMapsMockup) UpdateProcData(libpf.InterpreterType, util.PID,
+func (mockup *ebpfMapsMockup) UpdateProcData(libpf.InterpreterType, libpf.PID,
 	unsafe.Pointer) error {
 	mockup.updateProcCount++
 	return nil
 }
 
-func (mockup *ebpfMapsMockup) DeleteProcData(libpf.InterpreterType, util.PID) error {
+func (mockup *ebpfMapsMockup) DeleteProcData(libpf.InterpreterType, libpf.PID) error {
 	mockup.deleteProcCount++
 	return nil
 }
 
-func (mockup *ebpfMapsMockup) UpdatePidInterpreterMapping(util.PID,
+func (mockup *ebpfMapsMockup) UpdatePidInterpreterMapping(libpf.PID,
 	lpm.Prefix, uint8, host.FileID, uint64) error {
 	return nil
 }
 
-func (mockup *ebpfMapsMockup) DeletePidInterpreterMapping(util.PID, lpm.Prefix) error {
+func (mockup *ebpfMapsMockup) DeletePidInterpreterMapping(libpf.PID, lpm.Prefix) error {
 	return nil
 }
 
@@ -222,7 +222,7 @@ func (mockup *ebpfMapsMockup) DeleteStackDeltaPage(host.FileID, uint64) error {
 	return nil
 }
 
-func (mockup *ebpfMapsMockup) UpdatePidPageMappingInfo(pid util.PID, prefix lpm.Prefix,
+func (mockup *ebpfMapsMockup) UpdatePidPageMappingInfo(pid libpf.PID, prefix lpm.Prefix,
 	fileID uint64, bias uint64) error {
 	if prefix.Key == 0 && fileID == 0 && bias == 0 {
 		// If all provided values are 0 the hook was called to create
@@ -240,7 +240,7 @@ func (mockup *ebpfMapsMockup) setExpectedBias(expected uint64) {
 	mockup.expectedBias = expected
 }
 
-func (mockup *ebpfMapsMockup) DeletePidPageMappingInfo(_ util.PID, prefixes []lpm.Prefix) (int,
+func (mockup *ebpfMapsMockup) DeletePidPageMappingInfo(_ libpf.PID, prefixes []lpm.Prefix) (int,
 	error) {
 	mockup.deletePidPageMappingCount += uint8(len(prefixes))
 	return len(prefixes), nil
@@ -461,7 +461,7 @@ func populateManager(t *testing.T, pm *ProcessManager) {
 	t.Helper()
 
 	data := []struct {
-		pid util.PID
+		pid libpf.PID
 
 		mapping Mapping
 	}{
@@ -539,7 +539,7 @@ func populateManager(t *testing.T, pm *ProcessManager) {
 func TestProcExit(t *testing.T) {
 	tests := map[string]struct {
 		// pid represents the ID of a process.
-		pid util.PID
+		pid libpf.PID
 		// deletePidPageMappingCount reflects the number of times
 		// the deletePidPageMappingHook to update the eBPF map was called.
 		deletePidPageMappingCount uint8

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -51,13 +51,13 @@ type ProcessManager struct {
 	// process exits, and various other situations needing interpreter specific attention.
 	// The key of the first map is a process ID, while the key of the second map is
 	// the unique on-disk identifier of the interpreter DSO.
-	interpreters map[util.PID]map[util.OnDiskFileIdentifier]interpreter.Instance
+	interpreters map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance
 
 	// pidToProcessInfo keeps track of the executable memory mappings.
-	pidToProcessInfo map[util.PID]*processInfo
+	pidToProcessInfo map[libpf.PID]*processInfo
 
 	// exitEvents records the pid exit time and is a list of pending exit events to be handled.
-	exitEvents map[util.PID]times.KTime
+	exitEvents map[libpf.PID]times.KTime
 
 	// ebpf contains the interface to manipulate ebpf maps
 	ebpf pmebpf.EbpfHandler

--- a/remotememory/remotememory.go
+++ b/remotememory/remotememory.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // RemoteMemory implements a set of convenience functions to access the remote memory
@@ -129,7 +128,7 @@ func (rm RemoteMemory) StringPtr(addr libpf.Address) string {
 // ProcessVirtualMemory implements RemoteMemory by using process_vm_readv syscalls
 // to read the remote memory.
 type ProcessVirtualMemory struct {
-	pid util.PID
+	pid libpf.PID
 }
 
 func (vm ProcessVirtualMemory) ReadAt(p []byte, off int64) (int, error) {
@@ -150,6 +149,6 @@ func (vm ProcessVirtualMemory) ReadAt(p []byte, off int64) (int, error) {
 }
 
 // NewRemoteMemory returns ProcessVirtualMemory implementation of RemoteMemory.
-func NewProcessVirtualMemory(pid util.PID) RemoteMemory {
+func NewProcessVirtualMemory(pid libpf.PID) RemoteMemory {
 	return RemoteMemory{ReaderAt: ProcessVirtualMemory{pid}}
 }

--- a/remotememory/remotememory_test.go
+++ b/remotememory/remotememory_test.go
@@ -14,11 +14,10 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 )
 
 func RemoteMemTests(t *testing.T, rm RemoteMemory) {
@@ -42,5 +41,5 @@ func RemoteMemTests(t *testing.T, rm RemoteMemory) {
 }
 
 func TestProcessVirtualMemory(t *testing.T) {
-	RemoteMemTests(t, NewProcessVirtualMemory(util.PID(os.Getpid())))
+	RemoteMemTests(t, NewProcessVirtualMemory(libpf.PID(os.Getpid())))
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -32,7 +32,7 @@ type TraceEventMeta struct {
 	Timestamp      libpf.UnixTime64
 	Comm           string
 	APMServiceName string
-	PID, TID       util.PID
+	PID, TID       libpf.PID
 }
 
 type TraceReporter interface {

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -118,7 +118,7 @@ type OTLPReporter struct {
 	executables *lru.SyncedLRU[libpf.FileID, execInfo]
 
 	// cgroupv2ID caches PID to container ID information for cgroupv2 containers.
-	cgroupv2ID *lru.SyncedLRU[util.PID, string]
+	cgroupv2ID *lru.SyncedLRU[libpf.PID, string]
 
 	// frames maps frame information to its source location.
 	frames *lru.SyncedLRU[libpf.FileID, *xsync.RWMutex[map[libpf.AddressOrLineno]sourceInfo]]
@@ -306,8 +306,8 @@ func Start(mainCtx context.Context, cfg *Config) (Reporter, error) {
 		return nil, err
 	}
 
-	cgroupv2ID, err := lru.NewSynced[util.PID, string](cfg.CacheSize,
-		func(pid util.PID) uint32 { return uint32(pid) })
+	cgroupv2ID, err := lru.NewSynced[libpf.PID, string](cfg.CacheSize,
+		func(pid libpf.PID) uint32 { return uint32(pid) })
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func setupGrpcConnection(parent context.Context, cfg *Config,
 }
 
 // lookupCgroupv2 returns the cgroupv2 ID for pid.
-func (r *OTLPReporter) lookupCgroupv2(pid util.PID) (string, error) {
+func (r *OTLPReporter) lookupCgroupv2(pid libpf.PID) (string, error) {
 	id, ok := r.cgroupv2ID.Get(pid)
 	if ok {
 		return id, nil

--- a/tools/coredump/analyze.go
+++ b/tools/coredump/analyze.go
@@ -22,7 +22,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tools/coredump/modulestore"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 type analyzeCmd struct {
@@ -72,7 +71,7 @@ func (cmd *analyzeCmd) exec(context.Context, []string) (err error) {
 		return errors.New("please specify either `-core`, `-case` or `-pid`")
 	}
 
-	lwpFilter := libpf.Set[util.PID]{}
+	lwpFilter := libpf.Set[libpf.PID]{}
 	if cmd.lwpFilter != "" {
 		for _, lwp := range strings.Split(cmd.lwpFilter, ",") {
 			var parsed int64
@@ -80,7 +79,7 @@ func (cmd *analyzeCmd) exec(context.Context, []string) (err error) {
 			if err != nil {
 				return fmt.Errorf("failed to parse LWP: %v", err)
 			}
-			lwpFilter[util.PID(parsed)] = libpf.Void{}
+			lwpFilter[libpf.PID(parsed)] = libpf.Void{}
 		}
 	}
 
@@ -91,7 +90,7 @@ func (cmd *analyzeCmd) exec(context.Context, []string) (err error) {
 	var proc process.Process
 	switch {
 	case cmd.pid != 0:
-		proc, err = process.NewPtrace(util.PID(cmd.pid))
+		proc, err = process.NewPtrace(libpf.PID(cmd.pid))
 		if err != nil {
 			return fmt.Errorf("failed to open pid `%d`: %w", cmd.pid, err)
 		}

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -139,7 +139,7 @@ func (c *symbolizationCache) symbolize(ty libpf.FrameType, fileID libpf.FileID,
 }
 
 func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
-	lwpFilter libpf.Set[util.PID]) ([]ThreadInfo, error) {
+	lwpFilter libpf.Set[libpf.PID]) ([]ThreadInfo, error) {
 	todo, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -211,7 +211,7 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 	info := make([]ThreadInfo, 0, len(threadInfo))
 	for _, thread := range threadInfo {
 		if len(lwpFilter) > 0 {
-			if _, exists := lwpFilter[util.PID(thread.LWP)]; !exists {
+			if _, exists := lwpFilter[libpf.PID(thread.LWP)]; !exists {
 				continue
 			}
 		}

--- a/tools/coredump/ebpfmaps.go
+++ b/tools/coredump/ebpfmaps.go
@@ -38,7 +38,7 @@ type ebpfMapsCoredump struct {
 
 var _ interpreter.EbpfHandler = &ebpfMapsCoredump{}
 
-func (emc *ebpfMapsCoredump) RemoveReportedPID(util.PID) {
+func (emc *ebpfMapsCoredump) RemoveReportedPID(libpf.PID) {
 }
 
 func (emc *ebpfMapsCoredump) CollectMetrics() []metrics.Metric {
@@ -57,7 +57,7 @@ func (emc *ebpfMapsCoredump) UpdateInterpreterOffsets(ebpfProgIndex uint16,
 	return nil
 }
 
-func (emc *ebpfMapsCoredump) UpdateProcData(t libpf.InterpreterType, pid util.PID,
+func (emc *ebpfMapsCoredump) UpdateProcData(t libpf.InterpreterType, pid libpf.PID,
 	ptr unsafe.Pointer) error {
 	switch t {
 	case libpf.Dotnet:
@@ -78,7 +78,7 @@ func (emc *ebpfMapsCoredump) UpdateProcData(t libpf.InterpreterType, pid util.PI
 	return nil
 }
 
-func (emc *ebpfMapsCoredump) DeleteProcData(t libpf.InterpreterType, pid util.PID) error {
+func (emc *ebpfMapsCoredump) DeleteProcData(t libpf.InterpreterType, pid libpf.PID) error {
 	switch t {
 	case libpf.Dotnet:
 		emc.ctx.delMap(&C.dotnet_procs, C.u32(pid))
@@ -98,7 +98,7 @@ func (emc *ebpfMapsCoredump) DeleteProcData(t libpf.InterpreterType, pid util.PI
 	return nil
 }
 
-func (emc *ebpfMapsCoredump) UpdatePidInterpreterMapping(pid util.PID,
+func (emc *ebpfMapsCoredump) UpdatePidInterpreterMapping(pid libpf.PID,
 	prefix lpm.Prefix, interpreterProgram uint8, fileID host.FileID, bias uint64) error {
 	ctx := emc.ctx
 	// pid_page_to_mapping_info is a LPM trie and expects the pid and page
@@ -127,7 +127,7 @@ func (emc *ebpfMapsCoredump) UpdatePidInterpreterMapping(pid util.PID,
 	return nil
 }
 
-func (emc *ebpfMapsCoredump) DeletePidInterpreterMapping(pid util.PID,
+func (emc *ebpfMapsCoredump) DeletePidInterpreterMapping(pid libpf.PID,
 	prefix lpm.Prefix) error {
 	ctx := emc.ctx
 	// pid_page_to_mapping_info is a LPM trie and expects the pid and page
@@ -235,13 +235,13 @@ func (emc *ebpfMapsCoredump) DeleteStackDeltaPage(fileID host.FileID, page uint6
 	return nil
 }
 
-func (emc *ebpfMapsCoredump) UpdatePidPageMappingInfo(pid util.PID, prefix lpm.Prefix,
+func (emc *ebpfMapsCoredump) UpdatePidPageMappingInfo(pid libpf.PID, prefix lpm.Prefix,
 	fileID, bias uint64) error {
 	return emc.UpdatePidInterpreterMapping(pid, prefix, support.ProgUnwindNative,
 		host.FileID(fileID), bias)
 }
 
-func (emc *ebpfMapsCoredump) DeletePidPageMappingInfo(pid util.PID, prefixes []lpm.Prefix) (int,
+func (emc *ebpfMapsCoredump) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (int,
 	error) {
 	var deleted int
 	for _, prefix := range prefixes {

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -14,13 +14,13 @@ import (
 	"time"
 
 	lru "github.com/elastic/go-freelru"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
 // metadataWarnInhibDuration defines the minimum duration between warnings printed
@@ -81,7 +81,7 @@ type traceHandler struct {
 
 	// metadataWarnInhib tracks inhibitions for warnings printed about failure to
 	// update container metadata (rate-limiting).
-	metadataWarnInhib *lru.LRU[util.PID, libpf.Void]
+	metadataWarnInhib *lru.LRU[libpf.PID, libpf.Void]
 
 	times Times
 }
@@ -101,7 +101,7 @@ func newTraceHandler(rep reporter.TraceReporter, traceProcessor TraceProcessor,
 		return nil, err
 	}
 
-	metadataWarnInhib, err := lru.New[util.PID, libpf.Void](64, util.PID.Hash32)
+	metadataWarnInhib, err := lru.New[libpf.PID, libpf.Void](64, libpf.PID.Hash32)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metadata warning inhibitor LRU: %v", err)
 	}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -115,7 +115,7 @@ type Tracer struct {
 	// pidEvents notifies the tracer of new PID events.
 	// It needs to be buffered to avoid locking the writers and stacking up resources when we
 	// read new PIDs at startup or notified via eBPF.
-	pidEvents chan util.PID
+	pidEvents chan libpf.PID
 
 	// intervals provides access to globally configured timers and counters.
 	intervals Intervals
@@ -316,7 +316,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		kernelModules:              kernelModules,
 		transmittedFallbackSymbols: transmittedFallbackSymbols,
 		triggerPIDProcessing:       make(chan bool, 1),
-		pidEvents:                  make(chan util.PID, pidEventBufferSize),
+		pidEvents:                  make(chan libpf.PID, pidEventBufferSize),
 		ebpfMaps:                   ebpfMaps,
 		ebpfProgs:                  ebpfProgs,
 		hooks:                      make(map[hookPoint]link.Link),
@@ -896,8 +896,8 @@ func (t *Tracer) loadBpfTrace(raw []byte) *host.Trace {
 		Comm:             C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
 		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.apm_trace_id)),
 		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.apm_transaction_id)),
-		PID:              util.PID(ptr.pid),
-		TID:              util.PID(ptr.tid),
+		PID:              libpf.PID(ptr.pid),
+		TID:              libpf.PID(ptr.tid),
 		KTime:            times.KTime(ptr.ktime),
 	}
 
@@ -960,7 +960,7 @@ func (t *Tracer) StartMapMonitors(ctx context.Context, traceOutChan chan *host.T
 
 			for _, ev := range pidEvents {
 				log.Debugf("=> PID: %v", ev)
-				t.pidEvents <- util.PID(ev)
+				t.pidEvents <- libpf.PID(ev)
 			}
 
 			// Keep the underlying array alive to avoid GC pressure

--- a/util/util.go
+++ b/util/util.go
@@ -18,13 +18,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/hash"
 )
 
-// PID represent Unix Process ID (pid_t)
-type PID int32
-
-func (p PID) Hash32() uint32 {
-	return uint32(p)
-}
-
 // HexToUint64 is a convenience function to extract a hex string to a uint64 and
 // not worry about errors. Essentially a "mustConvertHexToUint64".
 func HexToUint64(str string) uint64 {


### PR DESCRIPTION
The type `PID` is used in the reporter interface, which is part of the exposed API.

Moving `PID` to `libpf` is a prerequisite for #132.