### PR TITLE
Report debuglink path to ExecutableMetadata

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -633,12 +633,12 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			}
 			symbolReporter.ExecutableMetadata(
 				reporter.ExecutableMetadataArgs{
-					FileID: info.fileID,
-					FileName: path.Base(m.Path),
-					GnuBuildID: info.guid,
+					FileID:            info.fileID,
+					FileName:          path.Base(m.Path),
+					GnuBuildID:        info.guid,
 					DebuglinkFileName: "",
-					Interp: libpf.Dotnet,
-					Open: open,
+					Interp:            libpf.Dotnet,
+					Open:              open,
 				},
 			)
 			info.reported = true

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -631,8 +631,16 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			open := func() (process.ReadAtCloser, error) {
 				return os.Open(m.Path)
 			}
-			symbolReporter.ExecutableMetadata(info.fileID, path.Base(m.Path),
-				info.guid, "", libpf.Dotnet, open)
+			symbolReporter.ExecutableMetadata(
+				reporter.ExecutableMetadataArgs{
+					FileID: info.fileID,
+					FileName: path.Base(m.Path),
+					GnuBuildID: info.guid,
+					DebuglinkFileName: "",
+					Interp: libpf.Dotnet,
+					Open: open,
+				},
+			)
 			info.reported = true
 		}
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -638,7 +638,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 					GnuBuildID:        info.guid,
 					DebuglinkFileName: "",
 					Interp:            libpf.Dotnet,
-					Open: open,
+					Open:              open,
 				},
 			)
 			info.reported = true

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -632,7 +632,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 				return os.Open(m.Path)
 			}
 			symbolReporter.ExecutableMetadata(info.fileID, path.Base(m.Path),
-				info.guid, libpf.Dotnet, open)
+				info.guid, "", libpf.Dotnet, open)
 			info.reported = true
 		}
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -632,13 +632,13 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 				return os.Open(m.Path)
 			}
 			symbolReporter.ExecutableMetadata(
-				reporter.ExecutableMetadataArgs{
+				&reporter.ExecutableMetadataArgs{
 					FileID:            info.fileID,
 					FileName:          path.Base(m.Path),
 					GnuBuildID:        info.guid,
 					DebuglinkFileName: "",
 					Interp:            libpf.Dotnet,
-					Open:              open,
+					Open: open,
 				},
 			)
 			info.reported = true

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -494,8 +494,11 @@ func (f *File) DebuglinkFileName(elfFilePath string, elfOpener ELFOpener) string
 	if f.debuglinkChecked {
 		return f.debuglinkPath
 	}
-	f.OpenDebugLink(elfFilePath, elfOpener)
-	return f.debuglinkPath
+	file, path := f.OpenDebugLink(elfFilePath, elfOpener)
+	if file != nil {
+		file.Close()
+	}
+	return path
 }
 
 // TLSDescriptors returns a map of all TLS descriptor symbol -> address

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -113,6 +113,12 @@ type File struct {
 	Type    elf.Type
 	Machine elf.Machine
 	Entry   uint64
+
+	// Path to the debuglink exe,
+	// or empty if none exists
+	debuglinkPath string
+	// Whether we have checked for a debuglink
+	debuglinkChecked bool
 }
 
 var _ libpf.SymbolFinder = &File{}
@@ -483,6 +489,15 @@ func (f *File) GetBuildID() (string, error) {
 	return getBuildIDFromNotes(data)
 }
 
+// DebuglinkFileName returns the debug file linked by .gnu_debuglink if any
+func (f *File) DebuglinkFileName(elfFilePath string, elfOpener ELFOpener) string {
+	if f.debuglinkChecked {
+		return f.debuglinkPath
+	}
+	f.OpenDebugLink(elfFilePath, elfOpener)
+	return f.debuglinkPath
+}
+
 // TLSDescriptors returns a map of all TLS descriptor symbol -> address
 // mappings in the executable.
 func (f *File) TLSDescriptors() (map[string]libpf.Address, error) {
@@ -590,6 +605,7 @@ func (f *File) GetDebugLink() (linkName string, crc int32, err error) {
 // OpenDebugLink tries to locate and open the corresponding debug ELF for this DSO.
 func (f *File) OpenDebugLink(elfFilePath string, elfOpener ELFOpener) (
 	debugELF *File, debugFile string) {
+	f.debuglinkChecked = true
 	// Get the debug link
 	linkName, linkCRC32, err := f.GetDebugLink()
 	if err != nil {
@@ -605,15 +621,12 @@ func (f *File) OpenDebugLink(elfFilePath string, elfOpener ELFOpener) (
 		if err != nil {
 			continue
 		}
-		if debugELF.Section(".debug_frame") == nil {
-			debugELF.Close()
-			continue
-		}
 		fileCRC32, err := debugELF.CRC32()
 		if err != nil || fileCRC32 != linkCRC32 {
 			debugELF.Close()
 			continue
 		}
+		f.debuglinkPath = debugFile
 		return debugELF, debugFile
 	}
 	return

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -251,7 +251,7 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
-func (s *symbolReporterMockup) ExecutableMetadata(_ libpf.FileID, _, _ string,
+func (s *symbolReporterMockup) ExecutableMetadata(_ libpf.FileID, _, _, _ string,
 	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 }
 

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -251,7 +251,7 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
-func (s *symbolReporterMockup) ExecutableMetadata(_ reporter.ExecutableMetadataArgs) {
+func (s *symbolReporterMockup) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 
 func (s *symbolReporterMockup) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno,

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -251,8 +251,7 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
-func (s *symbolReporterMockup) ExecutableMetadata(_ libpf.FileID, _, _, _ string,
-	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+func (s *symbolReporterMockup) ExecutableMetadata(_ reporter.ExecutableMetadataArgs) {
 }
 
 func (s *symbolReporterMockup) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -302,7 +302,8 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	open := func() (process.ReadAtCloser, error) {
 		return pr.OpenMappingFile(&mapping2)
 	}
-	pm.reporter.ExecutableMetadata(fileID, baseName, gnuBuildID, ef.DebuglinkFileName(elfRef.FileName(), elfRef), libpf.Native, open)
+	pm.reporter.ExecutableMetadata(fileID, baseName, gnuBuildID,
+		ef.DebuglinkFileName(elfRef.FileName(), elfRef), libpf.Native, open)
 
 	return info
 }

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/proc"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	eim "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager/execinfomanager"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tpbase"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
@@ -302,9 +303,14 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	open := func() (process.ReadAtCloser, error) {
 		return pr.OpenMappingFile(&mapping2)
 	}
-	pm.reporter.ExecutableMetadata(fileID, baseName, gnuBuildID,
-		ef.DebuglinkFileName(elfRef.FileName(), elfRef), libpf.Native, open)
-
+	pm.reporter.ExecutableMetadata(reporter.ExecutableMetadataArgs{
+		FileID:            fileID,
+		FileName:          baseName,
+		GnuBuildID:        gnuBuildID,
+		DebuglinkFileName: ef.DebuglinkFileName(elfRef.FileName(), elfRef),
+		Interp:            libpf.Native,
+		Open:              open,
+	})
 	return info
 }
 

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -303,7 +303,7 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	open := func() (process.ReadAtCloser, error) {
 		return pr.OpenMappingFile(&mapping2)
 	}
-	pm.reporter.ExecutableMetadata(reporter.ExecutableMetadataArgs{
+	pm.reporter.ExecutableMetadata(&reporter.ExecutableMetadataArgs{
 		FileID:            fileID,
 		FileName:          baseName,
 		GnuBuildID:        gnuBuildID,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -302,7 +302,7 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	open := func() (process.ReadAtCloser, error) {
 		return pr.OpenMappingFile(&mapping2)
 	}
-	pm.reporter.ExecutableMetadata(fileID, baseName, gnuBuildID, libpf.Native, open)
+	pm.reporter.ExecutableMetadata(fileID, baseName, gnuBuildID, ef.DebuglinkFileName(elfRef.FileName(), elfRef), libpf.Native, open)
 
 	return info
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -63,7 +63,7 @@ type SymbolReporter interface {
 	// that don't support this may pass a `nil` function pointer. Implementations that
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
-	ExecutableMetadata(fileID libpf.FileID, fileName, gnuBuildID string,
+	ExecutableMetadata(fileID libpf.FileID, fileName, gnuBuildID, debuglinkFileName string,
 		interp libpf.InterpreterType, open ExecutableOpener)
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -71,7 +71,7 @@ type SymbolReporter interface {
 	// that don't support this may pass a `nil` function pointer. Implementations that
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
-	ExecutableMetadata(args ExecutableMetadataArgs)
+	ExecutableMetadata(args *ExecutableMetadataArgs)
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before
 	// a periodic reporting to the backend.

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -50,14 +50,27 @@ type TraceReporter interface {
 	SupportsReportTraceEvent() bool
 }
 
+// ExecutableOpener is a function that attempts to open an executable.
 type ExecutableOpener = func() (process.ReadAtCloser, error)
+
+// ExecutableMetadataArgs collects metadata about a discovered
+// executable, for reporting to a SymbolReporter via the ExecutableMetadata function.
 type ExecutableMetadataArgs struct {
-	FileID            libpf.FileID
-	FileName          string
-	GnuBuildID        string
+	// FileID is a unique identifier of the executable.
+	FileID libpf.FileID
+	// FileName is the base filename of the executable.
+	FileName string
+	// GnuBuildID is the GNU build ID from .note.gnu.build-id, if any.
+	GnuBuildID string
+	// DebuglinkFileName is the path to the matching debug file
+	// from the .gnu.debuglink, if any. The caller should
+	// verify that the file in question matches the GnuBuildID of this executable..
 	DebuglinkFileName string
-	Interp            libpf.InterpreterType
-	Open              ExecutableOpener
+	// Interp is the discovered interpreter type of this executable, if any.
+	Interp libpf.InterpreterType
+	// Open is a function that can be used to open the executable for reading,
+	// or nil for interpreters that don't support this.
+	Open ExecutableOpener
 }
 
 type SymbolReporter interface {
@@ -65,7 +78,8 @@ type SymbolReporter interface {
 	ReportFallbackSymbol(frameID libpf.FrameID, symbol string)
 
 	// ExecutableMetadata accepts a FileID with the corresponding filename
-	// and caches this information before a periodic reporting to the backend.
+	// and takes some action with it (for example, it might cache it for
+	// periodic reporting to a backend).
 	//
 	// The `Open` argument can be used to open the executable for reading. Interpreters
 	// that don't support this may pass a `nil` function pointer. Implementations that

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -51,20 +51,27 @@ type TraceReporter interface {
 }
 
 type ExecutableOpener = func() (process.ReadAtCloser, error)
+type ExecutableMetadataArgs struct {
+	FileID libpf.FileID
+	FileName string
+	GnuBuildID string
+	DebuglinkFileName string
+	Interp libpf.InterpreterType
+	Open ExecutableOpener
+}
 
 type SymbolReporter interface {
 	// ReportFallbackSymbol enqueues a fallback symbol for reporting, for a given frame.
 	ReportFallbackSymbol(frameID libpf.FrameID, symbol string)
 
-	// ExecutableMetadata accepts a fileID with the corresponding filename
+	// ExecutableMetadata accepts a FileID with the corresponding filename
 	// and caches this information before a periodic reporting to the backend.
 	//
-	// The `open` argument can be used to open the executable for reading. Interpreters
+	// The `Open` argument can be used to open the executable for reading. Interpreters
 	// that don't support this may pass a `nil` function pointer. Implementations that
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
-	ExecutableMetadata(fileID libpf.FileID, fileName, gnuBuildID, debuglinkFileName string,
-		interp libpf.InterpreterType, open ExecutableOpener)
+	ExecutableMetadata(args ExecutableMetadataArgs)
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before
 	// a periodic reporting to the backend.

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -52,12 +52,12 @@ type TraceReporter interface {
 
 type ExecutableOpener = func() (process.ReadAtCloser, error)
 type ExecutableMetadataArgs struct {
-	FileID libpf.FileID
-	FileName string
-	GnuBuildID string
+	FileID            libpf.FileID
+	FileName          string
+	GnuBuildID        string
 	DebuglinkFileName string
-	Interp libpf.InterpreterType
-	Open ExecutableOpener
+	Interp            libpf.InterpreterType
+	Open              ExecutableOpener
 }
 
 type SymbolReporter interface {

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -208,7 +208,7 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
-func (r *OTLPReporter) ExecutableMetadata(args ExecutableMetadataArgs) {
+func (r *OTLPReporter) ExecutableMetadata(args *ExecutableMetadataArgs) {
 	r.executables.Add(args.FileID, execInfo{
 		fileName:   args.FileName,
 		gnuBuildID: args.GnuBuildID,

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -208,11 +208,10 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
-func (r *OTLPReporter) ExecutableMetadata(fileID libpf.FileID, fileName,
-	gnuBuildID, _ string, _ libpf.InterpreterType, _ ExecutableOpener) {
-	r.executables.Add(fileID, execInfo{
-		fileName:   fileName,
-		gnuBuildID: gnuBuildID,
+func (r *OTLPReporter) ExecutableMetadata(args ExecutableMetadataArgs) {
+	r.executables.Add(args.FileID, execInfo{
+		fileName:   args.FileName,
+		gnuBuildID: args.GnuBuildID,
 	})
 }
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -209,7 +209,7 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
 func (r *OTLPReporter) ExecutableMetadata(fileID libpf.FileID, fileName,
-	gnuBuildID string, _ libpf.InterpreterType, _ ExecutableOpener) {
+	gnuBuildID, _ string, _ libpf.InterpreterType, _ ExecutableOpener) {
 	r.executables.Add(fileID, execInfo{
 		fileName:   fileName,
 		gnuBuildID: gnuBuildID,

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -61,9 +61,8 @@ func newSymbolizationCache() *symbolizationCache {
 	}
 }
 
-func (c *symbolizationCache) ExecutableMetadata(fileID libpf.FileID,
-	fileName, _, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
-	c.files[fileID] = fileName
+func (c *symbolizationCache) ExecutableMetadata(args reporter.ExecutableMetadataArgs) {
+	c.files[args.FileID] = args.FileName
 }
 
 func (c *symbolizationCache) FrameMetadata(fileID libpf.FileID,

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -62,7 +62,7 @@ func newSymbolizationCache() *symbolizationCache {
 }
 
 func (c *symbolizationCache) ExecutableMetadata(fileID libpf.FileID,
-	fileName, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+	fileName, _, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 	c.files[fileID] = fileName
 }
 

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -61,7 +61,7 @@ func newSymbolizationCache() *symbolizationCache {
 	}
 }
 
-func (c *symbolizationCache) ExecutableMetadata(args reporter.ExecutableMetadataArgs) {
+func (c *symbolizationCache) ExecutableMetadata(args *reporter.ExecutableMetadataArgs) {
 	c.files[args.FileID] = args.FileName
 }
 

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -91,7 +91,7 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(args reporter.ExecutableMetadataArgs) {
+func (f mockReporter) ExecutableMetadata(args *reporter.ExecutableMetadataArgs) {
 }
 
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -91,9 +91,9 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(_ libpf.FileID, _, _, _ string,
-	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+func (f mockReporter) ExecutableMetadata(args reporter.ExecutableMetadataArgs) {
 }
+
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 func (f mockReporter) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno, _ libpf.SourceLineno,
 	_ uint32, _, _ string) {

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -91,7 +91,7 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(_ libpf.FileID, _, _ string,
+func (f mockReporter) ExecutableMetadata(_ libpf.FileID, _, _, _ string,
 	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 }
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -91,7 +91,7 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(args *reporter.ExecutableMetadataArgs) {
+func (f mockReporter) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -197,7 +197,7 @@ func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *li
 		}
 
 		result[nameStr] = fileID
-		rep.ExecutableMetadata(fileID, nameStr, buildID, libpf.Kernel, nil)
+		rep.ExecutableMetadata(fileID, nameStr, buildID, "", libpf.Kernel, nil)
 	})
 
 	return result, nil

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -197,7 +197,7 @@ func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *li
 		}
 
 		result[nameStr] = fileID
-		rep.ExecutableMetadata(reporter.ExecutableMetadataArgs{
+		rep.ExecutableMetadata(&reporter.ExecutableMetadataArgs{
 			FileID:            fileID,
 			FileName:          nameStr,
 			GnuBuildID:        buildID,

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -197,7 +197,13 @@ func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *li
 		}
 
 		result[nameStr] = fileID
-		rep.ExecutableMetadata(fileID, nameStr, buildID, "", libpf.Kernel, nil)
+		rep.ExecutableMetadata(reporter.ExecutableMetadataArgs{
+			FileID: fileID,
+			FileName: nameStr,
+			GnuBuildID: buildID,
+			DebuglinkFileName: "",
+			Interp: libpf.Kernel,			
+		})
 	})
 
 	return result, nil

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -198,11 +198,11 @@ func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *li
 
 		result[nameStr] = fileID
 		rep.ExecutableMetadata(reporter.ExecutableMetadataArgs{
-			FileID: fileID,
-			FileName: nameStr,
-			GnuBuildID: buildID,
+			FileID:            fileID,
+			FileName:          nameStr,
+			GnuBuildID:        buildID,
 			DebuglinkFileName: "",
-			Interp: libpf.Kernel,			
+			Interp:            libpf.Kernel,
 		})
 	})
 


### PR DESCRIPTION
This will allow library consumers to do something with the debuginfo discovered via .gnu_debuglink, if they wish to do so.