### PR TITLE
Remove Joel from maintainer list, move Christos to maintainer list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,15 +129,15 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 ### Approvers
 
-- [Christos Kalkanis](https://github.com/christos68k), Elastic
 - [Florian Lehner](https://github.com/florianl), Elastic
+- [Joel Höner](https://github.com/athre0z)
 - [Tim Rühsen](https://github.com/rockdaboot), Elastic
 
 ### Maintainers
 
+- [Christos Kalkanis](https://github.com/christos68k), Elastic
 - [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana
 - [Felix Geisendörfer](https://github.com/felixge), Datadog
-- [Joel Höner](https://github.com/athre0z), Elastic
 - [Timo Teräs](https://github.com/fabled)
 
 ### Become an Approver or a Maintainer


### PR DESCRIPTION
Hi all! Today is my last working day at Elastic. I've been thinking back and forth about whether I'd like to retain the maintainer position as an external contributor in my free time, but eventually decided that I realistically won't have the time to do justice to the role. I would however like to continue contributing to the project in a less critical position.

I'm thus suggesting to simply swap roles with @christos68k, currently an approver, who is effectively taking over my position as an IC responsible for the profiling agent at Elastic.

I appear to have the GitHub permissions to add a new maintainer, as well as the permissions to remove myself. Once all of the other maintainers[^1] have approved this PR, I'd be happy to apply the changes as my last action as a maintainer.

[^1]: Minus Dimitry, who AFAIK is still on paternity leave