### PR TITLE
metrics: add an interface to get the metrics definitions

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,6 +7,9 @@
 package metrics
 
 import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -31,6 +34,9 @@ var (
 
 	// mutex serializes the concurrent calls to AddSlice()
 	mutex sync.RWMutex
+
+	//go:embed metrics.json
+	metricsJSON []byte
 )
 
 // reporterImpl allows swapping out the global metrics reporter.
@@ -151,3 +157,17 @@ func Add(id MetricID, value MetricValue) {
 // If these assumptions change, we can address that by regularly calling AddSlice() with
 // an empty slice. Code can be found in commit 1d01d1ff841891010afaf8d64d4c21a05f19d168
 // and earlier.
+
+// GetDefinitions returns the metric definitions from the embedded metrics.json file.
+func GetDefinitions() ([]MetricDefinition, error) {
+	var definitions []MetricDefinition
+
+	dec := json.NewDecoder(bytes.NewReader(metricsJSON))
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(&definitions)
+	if err != nil {
+		return nil, err
+	}
+	return definitions, nil
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -65,3 +65,8 @@ func TestMetrics(t *testing.T) {
 		assert.Fail(t, "timeout - no metrics received in time")
 	}
 }
+
+func TestGetDefinitions(t *testing.T) {
+	_, err := GetDefinitions()
+	assert.NoError(t, err)
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeReporter struct {
@@ -67,6 +68,7 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestGetDefinitions(t *testing.T) {
-	_, err := GetDefinitions()
-	assert.NoError(t, err)
+	defs, err := GetDefinitions()
+	require.NoError(t, err)
+	assert.Greater(t, len(defs), 1)
 }

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -24,3 +24,20 @@ type Metric struct {
 // Summary helps summarizing metrics of the same ID from different sources before
 // processing it further.
 type Summary map[MetricID]MetricValue
+
+type MetricDefinition struct {
+	ID          MetricID   `json:"id"`
+	Type        MetricType `json:"type"`
+	Description string     `json:"description"`
+	Name        string     `json:"name"`
+	Field       string     `json:"field"`
+	Unit        string     `json:"unit"`
+	Obsolete    bool       `json:"obsolete"`
+}
+
+type MetricType string
+
+const (
+	MetricTypeGauge   MetricType = "gauge"
+	MetricTypeCounter MetricType = "counter"
+)


### PR DESCRIPTION
Fixes #149

This will enable profilers using the ebpf profiler as a library to export some of the internal metrics of the profiler. For example, this should allow getting more data on unwinding errors for interpreted languages.

For the interface, I added a `GetDefinitions()` method in the metrics package, which would require exposing the `metrics` package in https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/132, happy to move this elsewhere though if we think this is not the best place / API for this.