### PR TITLE
interpreters, reporter: refactor towards statelessness

### DIFF
--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -144,11 +144,6 @@ func (d *dotnetData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias li
 		return nil, err
 	}
 
-	symbolizedLRU, err := freelru.New[symbolizedKey, libpf.Void](1024, symbolizedKey.Hash32)
-	if err != nil {
-		return nil, err
-	}
-
 	procInfo := C.DotnetProcInfo{
 		version: C.uint(d.version),
 	}
@@ -163,7 +158,6 @@ func (d *dotnetData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias li
 		ranges:         make(map[libpf.Address]dotnetRangeSection),
 		moduleToPEInfo: make(map[libpf.Address]*peInfo),
 		addrToMethod:   addrToMethod,
-		symbolizedLRU:  symbolizedLRU,
 	}, nil
 }
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -756,9 +756,10 @@ func (i *dotnetInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 		if err != nil {
 			return err
 		}
-		// The Line ID is the Relative Virtual Address (RVA) within into the PE file
-		// where PC is executing. On non-leaf frames it points to the return address.
-		// The instruction after the CALL machine opcode.
+		// The Line ID is the Relative Virtual Address (RVA) within the PE file where
+		// PC is executing:
+		// - on non-leaf frames, it is the return address
+		// - on leaf frames, it is the address after the CALL machine opcode
 		lineID := libpf.AddressOrLineno(pcOffset)
 		frameID := libpf.NewFrameID(module.fileID, lineID)
 		trace.AppendFrameID(libpf.DotnetFrame, frameID)

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -175,7 +175,10 @@ func (i *dotnetInstance) insertAndSymbolizeStubFrame(symbolReporter reporter.Sym
 
 	frameID := libpf.NewFrameID(stubsFileID, lineID)
 	trace.AppendFrameID(libpf.DotnetFrame, frameID)
-	symbolReporter.FrameMetadata(frameID, 0, 0, name, "")
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:      frameID,
+		FunctionName: name,
+	})
 }
 
 // addRange inserts a known memory mapping along with the needed data of it to ebpf maps
@@ -765,7 +768,11 @@ func (i *dotnetInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 		trace.AppendFrameID(libpf.DotnetFrame, frameID)
 		if !symbolReporter.FrameKnown(frameID) {
 			methodName := module.resolveR2RMethodName(pcOffset)
-			symbolReporter.FrameMetadata(frameID, 0, 0, methodName, module.simpleName)
+			symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+				FrameID:      frameID,
+				FunctionName: methodName,
+				SourceFile:   module.simpleName,
+			})
 		}
 	case codeJIT:
 		// JITted frame in anonymous mapping
@@ -791,8 +798,12 @@ func (i *dotnetInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 			trace.AppendFrameID(libpf.DotnetFrame, frameID)
 			if !symbolReporter.FrameKnown(frameID) {
 				methodName := method.module.resolveMethodName(method.index)
-				symbolReporter.FrameMetadata(frameID, 0, ilOffset,
-					methodName, method.module.simpleName)
+				symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+					FrameID:        frameID,
+					SourceFile:     method.module.simpleName,
+					FunctionName:   methodName,
+					FunctionOffset: ilOffset,
+				})
 			}
 		}
 	default:

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -256,7 +256,10 @@ func (d *hotspotInstance) getStubNameID(symbolReporter reporter.SymbolReporter, 
 	_, _ = h.Write([]byte(stubName))
 	nameHash := h.Sum(nil)
 	stubID := libpf.AddressOrLineno(npsr.Uint64(nameHash, 0))
-	symbolReporter.FrameMetadata(libpf.NewFrameID(hotspotStubsFileID, stubID), 0, 0, stubName, "")
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:      libpf.NewFrameID(hotspotStubsFileID, stubID),
+		FunctionName: stubName,
+	})
 	d.addrToStubNameID.Add(addr, stubID)
 
 	return stubID, nil

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -235,7 +235,7 @@ func (d *hotspotInstance) getPoolSymbol(addr libpf.Address, ndx uint16) string {
 }
 
 // getStubNameID read the stub name from the code blob at given address and generates a ID.
-func (d *hotspotInstance) getStubNameID(symbolReporter reporter.SymbolReporter, ripOrBci int32,
+func (d *hotspotInstance) getStubNameID(symbolReporter reporter.SymbolReporter, ripOrBci uint32,
 	addr libpf.Address, _ uint32) (libpf.AddressOrLineno, error) {
 	if value, ok := d.addrToStubNameID.Get(addr); ok {
 		return value, nil
@@ -256,10 +256,9 @@ func (d *hotspotInstance) getStubNameID(symbolReporter reporter.SymbolReporter, 
 	_, _ = h.Write([]byte(stubName))
 	nameHash := h.Sum(nil)
 	stubID := libpf.AddressOrLineno(npsr.Uint64(nameHash, 0))
-
-	symbolReporter.FrameMetadata(hotspotStubsFileID, stubID, 0, 0, stubName, "")
-
+	symbolReporter.FrameMetadata(libpf.NewFrameID(hotspotStubsFileID, stubID), 0, 0, stubName, "")
 	d.addrToStubNameID.Add(addr, stubID)
+
 	return stubID, nil
 }
 
@@ -399,7 +398,6 @@ func (d *hotspotInstance) getMethod(addr libpf.Address, _ uint32) (*hotspotMetho
 		bytecodeSize:   bytecodeSize,
 		lineTable:      lineTable,
 		startLineNo:    uint16(startLine),
-		bciSeen:        make(libpf.Set[uint16]),
 	}
 	d.addrToMethod.Add(addr, sym)
 	return sym, nil
@@ -785,7 +783,7 @@ func (d *hotspotInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	// Extract the HotSpot frame bitfields from the file and line variables
 	ptr := libpf.Address(frame.File)
 	subtype := uint32(frame.Lineno>>60) & 0xf
-	ripOrBci := int32(frame.Lineno>>32) & 0x0fffffff
+	ripOrBci := uint32(frame.Lineno>>32) & 0x0fffffff
 	ptrCheck := uint32(frame.Lineno)
 
 	var err error
@@ -804,15 +802,15 @@ func (d *hotspotInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	case C.FRAME_HOTSPOT_INTERPRETER:
 		method, err1 := d.getMethod(ptr, ptrCheck)
 		if err1 != nil {
-			return err
+			return err1
 		}
-		err = method.symbolize(symbolReporter, ripOrBci, d, trace)
+		method.symbolize(symbolReporter, ripOrBci, d, trace)
 	case C.FRAME_HOTSPOT_NATIVE:
 		jitinfo, err1 := d.getJITInfo(ptr, ptrCheck)
 		if err1 != nil {
 			return err1
 		}
-		err = jitinfo.symbolize(symbolReporter, ripOrBci, d, trace)
+		err = jitinfo.symbolize(symbolReporter, int32(ripOrBci), d, trace)
 	default:
 		return fmt.Errorf("hotspot frame subtype %v is not supported", subtype)
 	}

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	npsr "go.opentelemetry.io/ebpf-profiler/nopanicslicereader"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
@@ -29,46 +27,30 @@ type hotspotMethod struct {
 	bytecodeSize   uint16
 	startLineNo    uint16
 	lineTable      []byte
-	bciSeen        libpf.Set[uint16]
 }
 
 // Symbolize generates symbolization information for given hotspot method and
 // a Byte Code Index (BCI)
-func (m *hotspotMethod) symbolize(symbolReporter reporter.SymbolReporter, bci int32,
-	ii *hotspotInstance, trace *libpf.Trace) error {
+func (m *hotspotMethod) symbolize(symbolReporter reporter.SymbolReporter, bci uint32,
+	ii *hotspotInstance, trace *libpf.Trace) {
 	// Make sure the BCI is within the method range
-	if bci < 0 || bci >= int32(m.bytecodeSize) {
+	if bci >= uint32(m.bytecodeSize) {
 		bci = 0
 	}
-	trace.AppendFrame(libpf.HotSpotFrame, m.objectID, libpf.AddressOrLineno(bci))
 
-	// Check if this is already symbolized
-	if _, ok := m.bciSeen[uint16(bci)]; ok {
-		return nil
+	// Check if this is already known
+	frameID := libpf.NewFrameID(m.objectID, libpf.AddressOrLineno(bci))
+	trace.AppendFrameID(libpf.HotSpotFrame, frameID)
+	if !symbolReporter.FrameKnown(frameID) {
+		dec := ii.d.newUnsigned5Decoder(bytes.NewReader(m.lineTable))
+		lineNo := dec.mapByteCodeIndexToLine(bci)
+		functionOffset := uint32(0)
+		if lineNo > uint32(m.startLineNo) {
+			functionOffset = lineNo - uint32(m.startLineNo)
+		}
+		symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(lineNo), functionOffset,
+			m.methodName, m.sourceFileName)
 	}
-
-	dec := ii.d.newUnsigned5Decoder(bytes.NewReader(m.lineTable))
-	lineNo := dec.mapByteCodeIndexToLine(bci)
-	functionOffset := uint32(0)
-	if lineNo > libpf.SourceLineno(m.startLineNo) {
-		functionOffset = uint32(lineNo) - uint32(m.startLineNo)
-	}
-
-	symbolReporter.FrameMetadata(m.objectID,
-		libpf.AddressOrLineno(bci), lineNo, functionOffset,
-		m.methodName, m.sourceFileName)
-
-	// FIXME: The above FrameMetadata call might fail, but we have no idea of it
-	// due to the requests being queued and send attempts being done asynchronously.
-	// Until the reporting API gets a way to notify failures, just assume it worked.
-	m.bciSeen[uint16(bci)] = libpf.Void{}
-
-	log.Debugf("[%d] [%x] %v+%v at %v:%v", len(trace.FrameTypes),
-		m.objectID,
-		m.methodName, functionOffset,
-		m.sourceFileName, lineNo)
-
-	return nil
 }
 
 // hotspotJITInfo contains symbolization and debug information for one JIT compiled
@@ -125,7 +107,8 @@ func (ji *hotspotJITInfo) symbolize(symbolReporter reporter.SymbolReporter, ripD
 		// It is possible that there is no debug info, or no scope information,
 		// for the given RIP. In this case we can provide the method name
 		// from the metadata.
-		return ji.method.symbolize(symbolReporter, 0, ii, trace)
+		ji.method.symbolize(symbolReporter, 0, ii, trace)
+		return nil
 	}
 
 	// Found scope data. Expand the inlined scope information from it.
@@ -167,10 +150,7 @@ func (ji *hotspotJITInfo) symbolize(symbolReporter reporter.SymbolReporter, ripD
 			if err != nil {
 				return err
 			}
-			err = method.symbolize(symbolReporter, int32(byteCodeIndex), ii, trace)
-			if err != nil {
-				return err
-			}
+			method.symbolize(symbolReporter, byteCodeIndex, ii, trace)
 		}
 	}
 	return nil

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -48,8 +48,13 @@ func (m *hotspotMethod) symbolize(symbolReporter reporter.SymbolReporter, bci ui
 		if lineNo > uint32(m.startLineNo) {
 			functionOffset = lineNo - uint32(m.startLineNo)
 		}
-		symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(lineNo), functionOffset,
-			m.methodName, m.sourceFileName)
+		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+			FrameID:        frameID,
+			FunctionName:   m.methodName,
+			SourceFile:     m.sourceFileName,
+			SourceLine:     libpf.SourceLineno(lineNo),
+			FunctionOffset: functionOffset,
+		})
 	}
 }
 

--- a/interpreter/hotspot/unsigned5.go
+++ b/interpreter/hotspot/unsigned5.go
@@ -6,8 +6,6 @@ package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot
 import (
 	"fmt"
 	"io"
-
-	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
 // unsigned5Decoder is a decoder for UNSIGNED5 based byte streams.
@@ -88,19 +86,19 @@ func (d *unsigned5Decoder) decodeLineTableEntry(bci, line *uint32) error {
 
 // mapByteCodeIndexToLine decodes a line table to map a given Byte Code Index (BCI)
 // to a line number
-func (d *unsigned5Decoder) mapByteCodeIndexToLine(bci int32) libpf.SourceLineno {
+func (d *unsigned5Decoder) mapByteCodeIndexToLine(bci uint32) uint32 {
 	// The line numbers array is a short array of 2-tuples [start_pc, line_number].
 	// Not necessarily sorted. Encoded as delta-encoded numbers.
 	var curBci, curLine, bestBci, bestLine uint32
 
 	for d.decodeLineTableEntry(&curBci, &curLine) == nil {
-		if curBci == uint32(bci) {
-			return libpf.SourceLineno(curLine)
+		if curBci == bci {
+			return curLine
 		}
-		if curBci >= bestBci && curBci < uint32(bci) {
+		if curBci >= bestBci && curBci < bci {
 			bestBci = curBci
 			bestLine = curLine
 		}
 	}
-	return libpf.SourceLineno(bestLine)
+	return bestLine
 }

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -736,7 +736,10 @@ func (i *v8Instance) symbolizeMarkerFrame(symbolReporter reporter.SymbolReporter
 		stubID = calculateStubID(name)
 		frameID = libpf.NewFrameID(v8StubsFileID, stubID)
 		i.d.frametypeToID[marker] = stubID
-		symbolReporter.FrameMetadata(frameID, 0, 0, name, "")
+		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+			FrameID:      frameID,
+			FunctionName: name,
+		})
 	}
 	trace.AppendFrameID(libpf.V8Frame, frameID)
 	return nil
@@ -1453,7 +1456,13 @@ func (i *v8Instance) symbolize(symbolReporter reporter.SymbolReporter, frameID l
 	if lineNo > sfi.funcStartLine {
 		funcOffset = uint32(lineNo - sfi.funcStartLine)
 	}
-	symbolReporter.FrameMetadata(frameID, lineNo, funcOffset, sfi.funcName, sfi.source.fileName)
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:        frameID,
+		FunctionName:   sfi.funcName,
+		SourceFile:     sfi.source.fileName,
+		SourceLine:     lineNo,
+		FunctionOffset: funcOffset,
+	})
 }
 
 const externalFunctionTag = "<external-file>"
@@ -1466,7 +1475,10 @@ func (i *v8Instance) generateNativeFrame(symbolReporter reporter.SymbolReporter,
 	if sourcePos.isExternal() {
 		frameID := libpf.NewFrameID(v8StubsFileID, externalStubID)
 		trace.AppendFrameID(libpf.V8Frame, frameID)
-		symbolReporter.FrameMetadata(frameID, 0, 0, externalFunctionTag, "")
+		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+			FrameID:      frameID,
+			FunctionName: externalFunctionTag,
+		})
 		return
 	}
 

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -706,7 +706,7 @@ func isHeapObject(val libpf.Address) bool {
 	return val&HeapObjectTagMask == HeapObjectTag
 }
 
-// calculateStubID calculates the hash for a given string
+// calculateStubID calculates the hash for a given string.
 func calculateStubID(name string) libpf.AddressOrLineno {
 	h := fnv.New128a()
 	_, _ = h.Write([]byte(name))

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -363,21 +363,21 @@ func (i *perlInstance) getGV(gvAddr libpf.Address, nameOnly bool) (string, error
 	return gvName, nil
 }
 
-// getCOP reads and caches a Control OP from remote interpreter. On success, the COP
-// and a bool if it was cached, is returned. On error, the error.
-func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP, bool, error) {
+// getCOP reads and caches a Control OP from remote interpreter.
+// On success, the COP is returned. On error, the error.
+func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP, error) {
 	key := copKey{
 		copAddr:  copAddr,
 		funcName: funcName,
 	}
 	if value, ok := i.addrToCOP.Get(key); ok {
-		return value, true, nil
+		return value, nil
 	}
 
 	vms := &i.d.vmStructs
 	cop := make([]byte, vms.cop.sizeof)
 	if err := i.rm.Read(copAddr, cop); err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	sourceFileName := interpreter.UnknownSourceFile
@@ -394,13 +394,13 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP,
 			err = fmt.Errorf("sourcefile gv length too small (%d)", len(sourceFileName))
 		}
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		sourceFileName = sourceFileName[2:]
 	}
 	if !util.IsValidString(sourceFileName) {
 		log.Debugf("Extracted invalid source file name '%v'", []byte(sourceFileName))
-		return nil, false, errors.New("extracted invalid source file name")
+		return nil, errors.New("extracted invalid source file name")
 	}
 
 	line := npsr.Uint32(cop, vms.cop.cop_line)
@@ -415,7 +415,7 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP,
 	_, _ = h.Write([]byte(funcName))
 	fileID, err := libpf.FileIDFromBytes(h.Sum(nil))
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to create a file ID: %v", err)
+		return nil, fmt.Errorf("failed to create a file ID: %v", err)
 	}
 
 	c := &perlCOP{
@@ -424,7 +424,7 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP,
 		line:           libpf.AddressOrLineno(line),
 	}
 	i.addrToCOP.Add(key, c)
-	return c, false, nil
+	return c, nil
 }
 
 func (i *perlInstance) Symbolize(symbolReporter reporter.SymbolReporter,
@@ -449,26 +449,17 @@ func (i *perlInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 		functionName = interpreter.TopLevelFunctionName
 	}
 	copAddr := libpf.Address(frame.Lineno)
-	cop, seen, err := i.getCOP(copAddr, functionName)
+	cop, err := i.getCOP(copAddr, functionName)
 	if err != nil {
 		return fmt.Errorf("failed to get Perl COP %x: %v", copAddr, err)
 	}
 
-	lineno := cop.line
-
-	trace.AppendFrame(libpf.PerlFrame, cop.fileID, lineno)
-
-	if !seen {
-		symbolReporter.FrameMetadata(
-			cop.fileID, lineno, libpf.SourceLineno(lineno), 0,
-			functionName, cop.sourceFileName)
-
-		log.Debugf("[%d] [%x] %v at %v:%v",
-			len(trace.FrameTypes),
-			cop.fileID, functionName,
-			cop.sourceFileName, lineno)
-	}
-
+	// Since the COP contains all the data without extra work, just always
+	// send the symbolization information.
+	frameID := libpf.NewFrameID(cop.fileID, cop.line)
+	trace.AppendFrameID(libpf.PerlFrame, frameID)
+	symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(cop.line), 0,
+		functionName, cop.sourceFileName)
 	sfCounter.ReportSuccess()
 	return nil
 }

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -458,8 +458,12 @@ func (i *perlInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	// send the symbolization information.
 	frameID := libpf.NewFrameID(cop.fileID, cop.line)
 	trace.AppendFrameID(libpf.PerlFrame, frameID)
-	symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(cop.line), 0,
-		functionName, cop.sourceFileName)
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:      frameID,
+		FunctionName: functionName,
+		SourceFile:   cop.sourceFileName,
+		SourceLine:   libpf.SourceLineno(cop.line),
+	})
 	sfCounter.ReportSuccess()
 	return nil
 }

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -215,8 +215,13 @@ func (i *phpInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	}
 	frameID := libpf.NewFrameID(f.fileID, line)
 	trace.AppendFrameID(libpf.PHPFrame, frameID)
-	symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(line), funcOff,
-		f.name, f.sourceFileName)
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:        frameID,
+		FunctionName:   f.name,
+		SourceFile:     f.sourceFileName,
+		SourceLine:     libpf.SourceLineno(line),
+		FunctionOffset: funcOff,
+	})
 
 	sfCounter.ReportSuccess()
 	return nil

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -50,9 +50,6 @@ type phpFunction struct {
 
 	// lineStart is the first source code line for this function
 	lineStart uint32
-
-	// lineSeen is a set of line numbers we have already seen and symbolized
-	lineSeen libpf.Set[libpf.AddressOrLineno]
 }
 
 type phpInstance struct {
@@ -184,7 +181,6 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 		sourceFileName: sourceFileName,
 		fileID:         fileID,
 		lineStart:      lineStart,
-		lineSeen:       make(libpf.Set[libpf.AddressOrLineno]),
 	}
 	i.addrToFunction.Add(addr, pf)
 	return pf, nil
@@ -213,26 +209,14 @@ func (i *phpInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 		return fmt.Errorf("failed to get php function %x: %v", funcPtr, err)
 	}
 
-	trace.AppendFrame(libpf.PHPFrame, f.fileID, line)
-
-	if _, ok := f.lineSeen[line]; ok {
-		return nil
-	}
-
 	funcOff := uint32(0)
 	if f.lineStart != 0 && libpf.AddressOrLineno(f.lineStart) <= line {
 		funcOff = uint32(line) - f.lineStart
 	}
-	symbolReporter.FrameMetadata(
-		f.fileID, line, libpf.SourceLineno(line), funcOff,
+	frameID := libpf.NewFrameID(f.fileID, line)
+	trace.AppendFrameID(libpf.PHPFrame, frameID)
+	symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(line), funcOff,
 		f.name, f.sourceFileName)
-
-	f.lineSeen[line] = libpf.Void{}
-
-	log.Debugf("[%d] [%x] %v+%v at %v:%v",
-		len(trace.FrameTypes),
-		f.fileID, f.name, funcOff,
-		f.sourceFileName, line)
 
 	sfCounter.ReportSuccess()
 	return nil

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -321,8 +321,13 @@ func (m *pythonCodeObject) symbolize(symbolReporter reporter.SymbolReporter, bci
 	if !symbolReporter.FrameKnown(frameID) {
 		functionOffset := getFuncOffset(m, bci)
 		lineNo := libpf.SourceLineno(m.firstLineNo + functionOffset)
-		symbolReporter.FrameMetadata(frameID, lineNo, functionOffset,
-			m.name, m.sourceFileName)
+		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+			FrameID:        frameID,
+			FunctionName:   m.name,
+			SourceFile:     m.sourceFileName,
+			SourceLine:     lineNo,
+			FunctionOffset: functionOffset,
+		})
 	}
 }
 

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -178,10 +178,6 @@ type pythonCodeObject struct {
 	// used as the global ID of the PyCodeObject. It is stored as the FileID
 	// part of the Frame in the DB.
 	fileID libpf.FileID
-
-	// bciSeen is a set of "lastI" or byte code index (bci) values we have
-	// already symbolized and sent to the collection agent
-	bciSeen libpf.Set[uint32]
 }
 
 // readVarint returns a variable length encoded unsigned integer from a location table entry.
@@ -319,33 +315,15 @@ func mapByteCodeIndexToLine(m *pythonCodeObject, bci uint32) uint32 {
 }
 
 func (m *pythonCodeObject) symbolize(symbolReporter reporter.SymbolReporter, bci uint32,
-	getFuncOffset getFuncOffsetFunc, trace *libpf.Trace) error {
-	trace.AppendFrame(libpf.PythonFrame, m.fileID, libpf.AddressOrLineno(bci))
-
-	// Check if this is already symbolized
-	if _, ok := m.bciSeen[bci]; ok {
-		return nil
+	getFuncOffset getFuncOffsetFunc, trace *libpf.Trace) {
+	frameID := libpf.NewFrameID(m.fileID, libpf.AddressOrLineno(bci))
+	trace.AppendFrameID(libpf.PythonFrame, frameID)
+	if !symbolReporter.FrameKnown(frameID) {
+		functionOffset := getFuncOffset(m, bci)
+		lineNo := libpf.SourceLineno(m.firstLineNo + functionOffset)
+		symbolReporter.FrameMetadata(frameID, lineNo, functionOffset,
+			m.name, m.sourceFileName)
 	}
-
-	var lineNo libpf.SourceLineno
-	functionOffset := getFuncOffset(m, bci)
-	lineNo = libpf.SourceLineno(m.firstLineNo + functionOffset)
-
-	symbolReporter.FrameMetadata(m.fileID,
-		libpf.AddressOrLineno(bci), lineNo, functionOffset,
-		m.name, m.sourceFileName)
-
-	// FIXME: The above FrameMetadata might fail, but we have no idea of it
-	// due to the requests being queued and send attempts being done asynchronously.
-	// Until the reporting API gets a way to notify failures, just assume it worked.
-	m.bciSeen[bci] = libpf.Void{}
-
-	log.Debugf("[%d] [%x] %v+%v at %v:%v (bci %d)", len(trace.FrameTypes),
-		m.fileID,
-		m.name, functionOffset,
-		m.sourceFileName, lineNo, bci)
-
-	return nil
 }
 
 // getFuncOffsetFunc provides functionality to return a function offset from a PyCodeObject
@@ -586,7 +564,6 @@ func (p *pythonInstance) getCodeObject(addr libpf.Address,
 		lineTable:      lineTable,
 		ebpfChecksum:   ebpfChecksum,
 		fileID:         fileID,
-		bciSeen:        make(libpf.Set[uint32]),
 	}
 	p.addrToCodeObject.Add(addr, pco)
 	return pco, nil
@@ -611,13 +588,7 @@ func (p *pythonInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	if err != nil {
 		return fmt.Errorf("failed to get python object %x: %v", objectID, err)
 	}
-
-	err = method.symbolize(symbolReporter, lastI, p.getFuncOffset, trace)
-	if err != nil {
-		return fmt.Errorf("failed to symbolize python object %x, lastI %v: %v",
-			objectID, lastI, err)
-	}
-
+	method.symbolize(symbolReporter, lastI, p.getFuncOffset, trace)
 	sfCounter.ReportSuccess()
 	return nil
 }

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -721,8 +721,12 @@ func (r *rubyInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	// particular line. So we report 0 for this to our backend.
 	frameID := libpf.NewFrameID(fileID, libpf.AddressOrLineno(lineNo))
 	trace.AppendFrameID(libpf.RubyFrame, frameID)
-	symbolReporter.FrameMetadata(frameID, libpf.SourceLineno(lineNo), 0,
-		functionName, sourceFileName)
+	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
+		FrameID:      frameID,
+		FunctionName: functionName,
+		SourceFile:   sourceFileName,
+		SourceLine:   libpf.SourceLineno(lineNo),
+	})
 	sfCounter.ReportSuccess()
 	return nil
 }

--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -21,6 +21,11 @@ func (trace *Trace) AppendFrame(ty FrameType, file FileID, addrOrLine AddressOrL
 	trace.AppendFrameFull(ty, file, addrOrLine, 0, 0, 0)
 }
 
+// AppendFrameID appends a frame to the columnar frame array without mapping information.
+func (trace *Trace) AppendFrameID(ty FrameType, frameID FrameID) {
+	trace.AppendFrameFull(ty, frameID.FileID(), frameID.AddressOrLine(), 0, 0, 0)
+}
+
 // AppendFrameFull appends a frame with mapping info to the columnar frame array.
 func (trace *Trace) AppendFrameFull(ty FrameType, file FileID, addrOrLine AddressOrLineno,
 	mappingStart Address, mappingEnd Address, mappingFileOffset uint64) {

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -254,8 +254,12 @@ func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {
 func (s *symbolReporterMockup) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 
-func (s *symbolReporterMockup) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno,
-	_ libpf.SourceLineno, _ uint32, _, _ string) {
+func (s *symbolReporterMockup) FrameKnown(_ libpf.FrameID) bool {
+	return true
+}
+
+func (s *symbolReporterMockup) FrameMetadata(_ libpf.FrameID, _ libpf.SourceLineno, _ uint32,
+	_, _ string) {
 }
 
 var _ reporter.SymbolReporter = (*symbolReporterMockup)(nil)

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -258,8 +258,7 @@ func (s *symbolReporterMockup) FrameKnown(_ libpf.FrameID) bool {
 	return true
 }
 
-func (s *symbolReporterMockup) FrameMetadata(_ libpf.FrameID, _ libpf.SourceLineno, _ uint32,
-	_, _ string) {
+func (s *symbolReporterMockup) FrameMetadata(_ *reporter.FrameMetadataArgs) {
 }
 
 var _ reporter.SymbolReporter = (*symbolReporterMockup)(nil)

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -87,10 +87,11 @@ type SymbolReporter interface {
 	// open the file and then enqueue the upload in the background.
 	ExecutableMetadata(args *ExecutableMetadataArgs)
 
-	// FrameKnown may be used to query the reporter if the FrameID is known. This is mainly
-	// used to see if the data is already cached and extra work to resolve the metadata
-	// should not be done. If the reporter returns false, the interpreter plugins will
-	// resolve the frame metadata and submit it to the reporter via a FrameMetdata call.
+	// FrameKnown may be used to query the reporter if the FrameID is known. The interpreter
+	// modules can optionally use this method to determine if the data is already cached
+	// and avoid extra work resolving the metadata. If the reporter returns false,
+	// the intepreter plugin will resolve the frame metadata and submit it to the reporter
+	// via a subsequent FrameMetdata call.
 	FrameKnown(frameID libpf.FrameID) bool
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -87,10 +87,16 @@ type SymbolReporter interface {
 	// open the file and then enqueue the upload in the background.
 	ExecutableMetadata(args *ExecutableMetadataArgs)
 
+	// FrameKnown may be used to query the reporter if the FrameID is known. This is mainly
+	// used to see if the data is already cached and extra work to resolve the metadata
+	// should not be done. If the reporter returns false, the interpreter plugins will
+	// resolve the frame metadata and submit it to the reporter via a FrameMetdata call.
+	FrameKnown(frameID libpf.FrameID) bool
+
 	// FrameMetadata accepts metadata associated with a frame and caches this information before
 	// a periodic reporting to the backend.
-	FrameMetadata(fileID libpf.FileID, addressOrLine libpf.AddressOrLineno,
-		lineNumber libpf.SourceLineno, functionOffset uint32, functionName, filePath string)
+	FrameMetadata(frameID libpf.FrameID, lineNumber libpf.SourceLineno,
+		functionOffset uint32, functionName, filePath string)
 }
 
 type HostMetadataReporter interface {

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -73,6 +73,21 @@ type ExecutableMetadataArgs struct {
 	Open ExecutableOpener
 }
 
+// FrameMetadataArgs collects metadata about a single frame in a trace, for
+// reporting it to a SymbolReporter via the FrameMetadata method.
+type FrameMetadataArgs struct {
+	// FrameID is a unique identifier for the frame.
+	FrameID libpf.FrameID
+	// FunctionName is the name of the function for the frame.
+	FunctionName string
+	// SourceFile is the source code file name for the frame.
+	SourceFile string
+	// SourceLine is the source code level line number of this frame.
+	SourceLine libpf.SourceLineno
+	// FunctionOffset is the line offset from function start line for the frame.
+	FunctionOffset uint32
+}
+
 type SymbolReporter interface {
 	// ReportFallbackSymbol enqueues a fallback symbol for reporting, for a given frame.
 	ReportFallbackSymbol(frameID libpf.FrameID, symbol string)
@@ -96,8 +111,7 @@ type SymbolReporter interface {
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before
 	// a periodic reporting to the backend.
-	FrameMetadata(frameID libpf.FrameID, lineNumber libpf.SourceLineno,
-		functionOffset uint32, functionName, filePath string)
+	FrameMetadata(frameMetadata *FrameMetadataArgs)
 }
 
 type HostMetadataReporter interface {

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -215,7 +215,8 @@ func (r *OTLPReporter) ExecutableMetadata(args *ExecutableMetadataArgs) {
 	})
 }
 
-// FrameKnown determines if the metadata of Frame specified by frameID is required.
+// FrameKnown return true if the metadata of the Frame specified by frameID is
+// cached in the reporter.
 func (r *OTLPReporter) FrameKnown(frameID libpf.FrameID) bool {
 	known := false
 	if frameMapLock, exists := r.frames.Get(frameID.FileID()); exists {

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -35,24 +35,17 @@ func sliceBuffer(buf unsafe.Pointer, sz C.int) []byte {
 	return unsafe.Slice((*byte)(buf), int(sz))
 }
 
-type symbolData struct {
-	lineNumber     libpf.SourceLineno
-	functionOffset uint32
-	functionName   string
-	fileName       string
-}
-
 // symbolizationCache collects and caches the interpreter manager's symbolization
 // callbacks to be used for trace stringification.
 type symbolizationCache struct {
 	files   map[libpf.FileID]string
-	symbols map[libpf.FrameID]symbolData
+	symbols map[libpf.FrameID]*reporter.FrameMetadataArgs
 }
 
 func newSymbolizationCache() *symbolizationCache {
 	return &symbolizationCache{
 		files:   make(map[libpf.FileID]string),
-		symbols: make(map[libpf.FrameID]symbolData),
+		symbols: make(map[libpf.FrameID]*reporter.FrameMetadataArgs),
 	}
 }
 
@@ -65,9 +58,8 @@ func (c *symbolizationCache) FrameKnown(frameID libpf.FrameID) bool {
 	return exists
 }
 
-func (c *symbolizationCache) FrameMetadata(frameID libpf.FrameID, lineNumber libpf.SourceLineno,
-	functionOffset uint32, functionName, filePath string) {
-	c.symbols[frameID] = symbolData{lineNumber, functionOffset, functionName, filePath}
+func (c *symbolizationCache) FrameMetadata(args *reporter.FrameMetadataArgs) {
+	c.symbols[args.FrameID] = args
 }
 
 func (c *symbolizationCache) ReportFallbackSymbol(libpf.FrameID, string) {}
@@ -118,8 +110,8 @@ func (c *symbolizationCache) symbolize(ty libpf.FrameType, fileID libpf.FileID,
 
 	if data, ok := c.symbols[libpf.NewFrameID(fileID, lineNumber)]; ok {
 		return fmt.Sprintf("%s+%d in %s:%d",
-			data.functionName, data.functionOffset,
-			data.fileName, data.lineNumber), nil
+			data.FunctionName, data.FunctionOffset,
+			data.SourceFile, data.SourceLine), nil
 	}
 
 	sourceFile, ok := c.files[fileID]

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -95,9 +95,12 @@ func (f mockReporter) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
-func (f mockReporter) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno, _ libpf.SourceLineno,
-	_ uint32, _, _ string) {
+
+func (f mockReporter) FrameKnown(_ libpf.FrameID) bool {
+	return true
 }
+
+func (f mockReporter) FrameMetadata(_ libpf.FrameID, _ libpf.SourceLineno, _ uint32, _, _ string) {}
 
 func generateMaxLengthTrace() host.Trace {
 	var trace host.Trace

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -100,7 +100,7 @@ func (f mockReporter) FrameKnown(_ libpf.FrameID) bool {
 	return true
 }
 
-func (f mockReporter) FrameMetadata(_ libpf.FrameID, _ libpf.SourceLineno, _ uint32, _, _ string) {}
+func (f mockReporter) FrameMetadata(_ *reporter.FrameMetadataArgs) {}
 
 func generateMaxLengthTrace() host.Trace {
 	var trace host.Trace


### PR DESCRIPTION
Due to legacy reasons, each interpreter kept their own state of which dynamic metadata should be sent to the reporter. Several of these caches would never expire, causing caching issues in the otlp reporter module.

This removes the caching state from all interpreters and pushes it to the reporter module. A new reporter API call FrameNeeded is added to query if a specific Frame is in the cache or not. Not all interpreter modules use the call as all the information might be available with little overhead. FrameMetadata is also updated to use the FrameID type for symmetry.

Improved are:
 - reduced memory overhead as per-interpreter caches are removed
 - reporter module can now control which frames need resolving
 - fixes otlp to get the frames re-symbolized if its internal lru already forgot about the earlier symbolization information

ref #121