### PR TITLE
Update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ VERSION ?= v0.0.0
 BUILD_TIMESTAMP ?= $(shell date +%s)
 REVISION ?= $(BRANCH)-$(COMMIT_SHORT_SHA)
 
-LDFLAGS := -X github.com//open-telemetry/opentelemetry-ebpf-profiler/vc.version=$(VERSION) \
-	-X github.com/open-telemetry/opentelemetry-ebpf-profiler/vc.revision=$(REVISION) \
-	-X github.com/open-telemetry/opentelemetry-ebpf-profiler/vc.buildTimestamp=$(BUILD_TIMESTAMP) \
+LDFLAGS := -X go.opentelemetry.io/ebpf-profiler/vc.version=$(VERSION) \
+	-X go.opentelemetry.io/ebpf-profiler/vc.revision=$(REVISION) \
+	-X go.opentelemetry.io/ebpf-profiler/vc.buildTimestamp=$(BUILD_TIMESTAMP) \
 	-extldflags=-static
 
 GO_TAGS := osusergo,netgo

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The agent can be built with the provided make targets. Docker is required for co
      ```sh
      make agent TARGET_ARCH=arm64
      ```
-The resulting binary will be named <opentelemetry-ebpf-profiler> in the current directory.
+The resulting binary will be named <ebpf-profiler> in the current directory.
 
 ## Other OSes
 Since the profiler is Linux-only, macOS and Windows users need to set up a Linux VM to build and run the agent. Ensure the appropriate architecture is specified if using cross-compilation. Use the same make targets as above after the Linux environment is configured in the VM.
@@ -68,7 +68,7 @@ This will build the profiler natively on your machine.
 You can start the agent with the following command:
 
 ```sh
-sudo ./opentelemetry-ebpf-profiler -collection-agent=127.0.0.1:11000 -disable-tls
+sudo ./ebpf-profiler -collection-agent=127.0.0.1:11000 -disable-tls
 ```
 
 The agent comes with a functional but work-in-progress / evolving implementation
@@ -511,7 +511,7 @@ probabilistic profiling is either enabled or disabled. The default value is 1 mi
 
 The following example shows how to configure the profiling agent with a threshold of 50 and an interval of 2 minutes and 30 seconds:
 ```bash
-sudo ./opentelemetry-ebpf-profiler -probabilistic-threshold=50 -probabilistic-interval=2m30s
+sudo ./ebpf-profiler -probabilistic-threshold=50 -probabilistic-interval=2m30s
 ```
 
 # Legal

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -93,7 +93,7 @@ type arguments struct {
 func parseArgs() (*arguments, error) {
 	var args arguments
 
-	fs := flag.NewFlagSet("opentelemetry-ebpf-profiler", flag.ExitOnError)
+	fs := flag.NewFlagSet("ebpf-profiler", flag.ExitOnError)
 
 	// Please keep the parameters ordered alphabetically in the source-code.
 	fs.UintVar(&args.bpfVerifierLogLevel, "bpf-log-level", 0, bpfVerifierLogLevelHelp)


### PR DESCRIPTION
Binary name has changed to `ebpf-profiler` after #164. Also fixes `vc` breakage.