### PR TITLE
kernel frames, reporter: refactor towards statelessness

### DIFF
--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -89,9 +89,6 @@ type FrameMetadataArgs struct {
 }
 
 type SymbolReporter interface {
-	// ReportFallbackSymbol enqueues a fallback symbol for reporting, for a given frame.
-	ReportFallbackSymbol(frameID libpf.FrameID, symbol string)
-
 	// ExecutableMetadata accepts a FileID with the corresponding filename
 	// and takes some action with it (for example, it might cache it for
 	// periodic reporting to a backend).

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -230,28 +230,18 @@ func (r *OTLPReporter) FrameMetadata(args *FrameMetadataArgs) {
 		defer frameMapLock.WUnlock(&frameMap)
 
 		sourceFile := args.SourceFile
-		sourceLine := args.SourceLine
-		functionOffset := args.FunctionOffset
-		if sourceFile == "" || sourceLine == 0 || functionOffset == 0 {
-			// Some of the new metadata fields may be unset, and we don't want to overwrite
-			// existing data with it.
+		if sourceFile == "" {
+			// The new SourceFile may be empty, and we don't want to overwrite
+			// an existing filePath with it.
 			if s, exists := (*frameMap)[addressOrLine]; exists {
-				if sourceFile == "" {
-					sourceFile = s.filePath
-				}
-				if sourceLine == 0 {
-					sourceLine = s.lineNumber
-				}
-				if functionOffset == 0 {
-					functionOffset = s.functionOffset
-				}
+				sourceFile = s.filePath
 			}
 		}
 
 		(*frameMap)[addressOrLine] = sourceInfo{
-			lineNumber:     sourceLine,
+			lineNumber:     args.SourceLine,
 			filePath:       sourceFile,
-			functionOffset: functionOffset,
+			functionOffset: args.FunctionOffset,
 			functionName:   args.FunctionName,
 		}
 		return

--- a/support/debugtracer_amd64.go
+++ b/support/debugtracer_amd64.go
@@ -3,7 +3,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package support
+package support // import "go.opentelemetry.io/ebpf-profiler/support"
 
 import (
 	_ "embed"

--- a/support/debugtracer_arm64.go
+++ b/support/debugtracer_arm64.go
@@ -3,7 +3,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package support
+package support // import "go.opentelemetry.io/ebpf-profiler/support"
 
 import (
 	_ "embed"

--- a/support/debugtracer_dummy.go
+++ b/support/debugtracer_dummy.go
@@ -3,7 +3,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package support
+package support // import "go.opentelemetry.io/ebpf-profiler/support"
 
 // debugtracer_dummy.go satisfies build requirements where the eBPF debug tracers
 // file does not exist.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -704,7 +704,6 @@ func (t *Tracer) insertKernelFrames(trace *host.Trace, ustackLen uint32,
 		}
 
 		if !foundFileID {
-			kernelSymbolCacheMiss++
 			continue
 		}
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -20,7 +20,6 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	lru "github.com/elastic/go-freelru"
 	"github.com/elastic/go-perf"
 	log "github.com/sirupsen/logrus"
 	"github.com/zeebo/xxh3"
@@ -99,10 +98,6 @@ type Tracer struct {
 	// that is required to unwind processes in the kernel. This includes maintaining the
 	// associated eBPF maps.
 	processManager *pm.ProcessManager
-
-	// transmittedFallbackSymbols keeps track of the already-transmitted fallback symbols.
-	// It is not thread-safe: concurrent accesses must be synchronized.
-	transmittedFallbackSymbols *lru.LRU[libpf.FrameID, libpf.Void]
 
 	// triggerPIDProcessing is used as manual trigger channel to request immediate
 	// processing of pending PIDs. This is requested on notifications from eBPF code
@@ -300,12 +295,6 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to read kernel modules: %v", err)
 	}
 
-	transmittedFallbackSymbols, err :=
-		lru.New[libpf.FrameID, libpf.Void](fallbackSymbolsCacheSize, libpf.FrameID.Hash32)
-	if err != nil {
-		return nil, fmt.Errorf("unable to instantiate transmitted fallback symbols cache: %v", err)
-	}
-
 	moduleFileIDs, err := processKernelModulesMetadata(cfg.Reporter, kernelModules, kernelSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract kernel modules metadata: %v", err)
@@ -314,23 +303,22 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	perfEventList := []*perf.Event{}
 
 	return &Tracer{
-		processManager:             processManager,
-		kernelSymbols:              kernelSymbols,
-		kernelModules:              kernelModules,
-		transmittedFallbackSymbols: transmittedFallbackSymbols,
-		triggerPIDProcessing:       make(chan bool, 1),
-		pidEvents:                  make(chan libpf.PID, pidEventBufferSize),
-		ebpfMaps:                   ebpfMaps,
-		ebpfProgs:                  ebpfProgs,
-		hooks:                      make(map[hookPoint]link.Link),
-		intervals:                  cfg.Intervals,
-		hasBatchOperations:         hasBatchOperations,
-		perfEntrypoints:            xsync.NewRWMutex(perfEventList),
-		moduleFileIDs:              moduleFileIDs,
-		reporter:                   cfg.Reporter,
-		samplesPerSecond:           cfg.SamplesPerSecond,
-		probabilisticInterval:      cfg.ProbabilisticInterval,
-		probabilisticThreshold:     cfg.ProbabilisticThreshold,
+		processManager:         processManager,
+		kernelSymbols:          kernelSymbols,
+		kernelModules:          kernelModules,
+		triggerPIDProcessing:   make(chan bool, 1),
+		pidEvents:              make(chan libpf.PID, pidEventBufferSize),
+		ebpfMaps:               ebpfMaps,
+		ebpfProgs:              ebpfProgs,
+		hooks:                  make(map[hookPoint]link.Link),
+		intervals:              cfg.Intervals,
+		hasBatchOperations:     hasBatchOperations,
+		perfEntrypoints:        xsync.NewRWMutex(perfEventList),
+		moduleFileIDs:          moduleFileIDs,
+		reporter:               cfg.Reporter,
+		samplesPerSecond:       cfg.SamplesPerSecond,
+		probabilisticInterval:  cfg.ProbabilisticInterval,
+		probabilisticThreshold: cfg.ProbabilisticThreshold,
 	}, nil
 }
 
@@ -723,35 +711,22 @@ func (t *Tracer) insertKernelFrames(trace *host.Trace, ustackLen uint32,
 		// Kernel frame PCs need to be adjusted by -1. This duplicates logic done in the trace
 		// converter. This should be fixed with PF-1042.
 		if foundSymbol && foundFileID {
-			t.reportFallbackKernelSymbol(fileID, symbol, trace.Frames[i].Lineno-1,
-				&kernelSymbolCacheHit, &kernelSymbolCacheMiss)
+			frameID := libpf.NewFrameID(fileID, trace.Frames[i].Lineno-1)
+			if t.reporter.FrameKnown(frameID) {
+				kernelSymbolCacheHit++
+			} else {
+				t.reporter.FrameMetadata(&reporter.FrameMetadataArgs{
+					FrameID:      frameID,
+					FunctionName: string(symbol),
+				})
+				kernelSymbolCacheMiss++
+			}
 		}
 	}
 	t.fallbackSymbolMiss.Add(kernelSymbolCacheMiss)
 	t.fallbackSymbolHit.Add(kernelSymbolCacheHit)
 
 	return kstackLen, nil
-}
-
-// reportFallbackKernelSymbol reports fallback symbols for kernel frames, after checking if the
-// symbols were previously sent.
-func (t *Tracer) reportFallbackKernelSymbol(
-	fileID libpf.FileID, symbolName libpf.SymbolName, frameAddress libpf.AddressOrLineno,
-	kernelSymbolCacheHit, kernelSymbolCacheMiss *uint64) {
-	frameID := libpf.NewFrameID(fileID, frameAddress)
-
-	// Only report it if it's not in our LRU list of transmitted symbols.
-	if !t.transmittedFallbackSymbols.Contains(frameID) {
-		t.reporter.ReportFallbackSymbol(frameID, string(symbolName))
-
-		// There is no guarantee that the above report will be successfully delivered, but this
-		// should be sufficient for the time being. Other machines may succeed, and it's no big deal
-		// if we can't deliver 100% of symbols.
-		t.transmittedFallbackSymbols.Add(frameID, libpf.Void{})
-		(*kernelSymbolCacheMiss)++
-		return
-	}
-	(*kernelSymbolCacheHit)++
 }
 
 // enableEvent removes the entry of given eventType from the inhibitEvents map


### PR DESCRIPTION
Based on #171, refactor reporting of kernel symbols in order to use reporter.FrameKnown() and reporter.FrameMetadata(). This allows dropping ReportFallbackSymbol from the SymbolReporter interface. As a consequence, drop special handling of kernel frames in getProfile().

ref #121