### PR TITLE
git: ignore compiled executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .cache
 /.idea
 /go
-opentelemetry-ebpf-profiler
+ebpf-profiler
 ci-kernels


### PR DESCRIPTION
Binary name has changed to ebpf-profiler after #164.