### PR TITLE
Reduce memory footprint of kernel symbols 

### DIFF
--- a/libpf/symbol.go
+++ b/libpf/symbol.go
@@ -43,6 +43,12 @@ type SymbolMap struct {
 	addressToSymbol []Symbol
 }
 
+func NewSymbolMap(initialSize int) *SymbolMap {
+	return &SymbolMap{
+		addressToSymbol: make([]Symbol, 0, initialSize),
+	}
+}
+
 // Add a symbol to the map
 func (symmap *SymbolMap) Add(s Symbol) {
 	symmap.addressToSymbol = append(symmap.addressToSymbol, s)
@@ -51,10 +57,16 @@ func (symmap *SymbolMap) Add(s Symbol) {
 // Finalize symbol map by sorting and constructing the nameToSymbol table after
 // all symbols are inserted via Add() calls
 func (symmap *SymbolMap) Finalize() {
+	// Adjust the overcommitted capacity
+	a := make([]Symbol, len(symmap.addressToSymbol))
+	copy(a, symmap.addressToSymbol)
+	symmap.addressToSymbol = a
+
 	sort.Slice(symmap.addressToSymbol,
 		func(i, j int) bool {
 			return symmap.addressToSymbol[i].Address > symmap.addressToSymbol[j].Address
 		})
+
 	symmap.nameToSymbol = make(map[SymbolName]*Symbol, len(symmap.addressToSymbol))
 	for i, s := range symmap.addressToSymbol {
 		symmap.nameToSymbol[s.Name] = &symmap.addressToSymbol[i]

--- a/libpf/symbol.go
+++ b/libpf/symbol.go
@@ -43,9 +43,9 @@ type SymbolMap struct {
 	addressToSymbol []Symbol
 }
 
-func NewSymbolMap(initialSize int) *SymbolMap {
+func NewSymbolMap(capacity int) *SymbolMap {
 	return &SymbolMap{
-		addressToSymbol: make([]Symbol, 0, initialSize),
+		addressToSymbol: make([]Symbol, 0, capacity),
 	}
 }
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -53,12 +53,9 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 			return nil, fmt.Errorf("unexpected line in kallsyms: '%s'", line)
 		}
 
-		if fields[2] == "_stext" || fields[2] == "_etext" {
-			log.Info("for debugging: " + line)
-		}
-
-		// Skip non-text symbols, see 'man nm'
-		if strings.IndexByte("TtVvWwA", fields[1][0]) == -1 {
+		// Skip non-text symbols, see 'man nm'.
+		// Special case for 'etext', which can be of type `D` (data) in some kernels.
+		if strings.IndexByte("TtVvWwA", fields[1][0]) == -1 && fields[2] != "_etext" {
 			continue
 		}
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -28,6 +28,7 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 	var address uint64
 	var symbol string
 
+	// As an example, the Debian 6.10.11 kernel has ~180k text symbols.
 	symmap := libpf.NewSymbolMap(200 * 1024)
 	noSymbols := true
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -53,6 +53,10 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 			return nil, fmt.Errorf("unexpected line in kallsyms: '%s'", line)
 		}
 
+		if fields[2] == "_stext" || fields[2] == "_etext" {
+			log.Info("for debugging: " + line)
+		}
+
 		// Skip non-text symbols, see 'man nm'
 		if strings.IndexByte("TtVvWwA", fields[1][0]) == -1 {
 			continue

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -28,7 +28,7 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 	var address uint64
 	var symbol string
 
-	symmap := libpf.SymbolMap{}
+	symmap := libpf.NewSymbolMap(200 * 1024)
 	noSymbols := true
 
 	file, err := os.Open(kallsymsPath)
@@ -50,6 +50,11 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 
 		if nFields < 3 {
 			return nil, fmt.Errorf("unexpected line in kallsyms: '%s'", line)
+		}
+
+		// Skip non-text symbols, see 'man nm'
+		if strings.IndexByte("TtVvWwA", fields[1][0]) == -1 {
+			continue
 		}
 
 		if address, err = strconv.ParseUint(fields[0], 16, 64); err != nil {
@@ -74,7 +79,7 @@ func GetKallsyms(kallsymsPath string) (*libpf.SymbolMap, error) {
 			"all addresses from kallsyms are zero - check process permissions")
 	}
 
-	return &symmap, nil
+	return symmap, nil
 }
 
 // GetKernelModules returns SymbolMap for kernel modules from /proc/modules.

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -4,8 +4,6 @@
 package proc
 
 import (
-	"fmt"
-	"runtime"
 	"testing"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -39,30 +37,4 @@ func TestParseKallSyms(t *testing.T) {
 
 	assertSymbol(t, symmap, "cpu_tss_rw", 0x6000)
 	assertSymbol(t, symmap, "hid_add_device", 0xffffffffc033e550)
-}
-
-func printMemUsage() {
-	runtime.GC()
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
-	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
-	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
-	fmt.Printf("\tNumGC = %v\n", m.NumGC)
-}
-
-func bToMb(b uint64) uint64 {
-	return b / 1024 / 1024
-}
-
-func TestGetKallsymsMemoryUsage(t *testing.T) {
-	fmt.Println("Memory usage before calling GetKallsyms:")
-	printMemUsage()
-
-	symmap, err := GetKallsyms("/proc/kallsyms")
-	require.NoError(t, err)
-	require.NotNil(t, symmap)
-
-	fmt.Println("Memory usage after calling GetKallsyms:")
-	printMemUsage()
 }

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -4,6 +4,8 @@
 package proc
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -37,4 +39,30 @@ func TestParseKallSyms(t *testing.T) {
 
 	assertSymbol(t, symmap, "cpu_tss_rw", 0x6000)
 	assertSymbol(t, symmap, "hid_add_device", 0xffffffffc033e550)
+}
+
+func printMemUsage() {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
+	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+}
+
+func bToMb(b uint64) uint64 {
+	return b / 1024 / 1024
+}
+
+func TestGetKallsymsMemoryUsage(t *testing.T) {
+	fmt.Println("Memory usage before calling GetKallsyms:")
+	printMemUsage()
+
+	symmap, err := GetKallsyms("/proc/kallsyms")
+	require.NoError(t, err)
+	require.NotNil(t, symmap)
+
+	fmt.Println("Memory usage after calling GetKallsyms:")
+	printMemUsage()
 }


### PR DESCRIPTION
Reducing the kernel symbols' memory footprint by
- skipping non-text symbols when reading from `/proc/kallsyms`
- adjusting overcommitted symbols array

Additionally, we pre-allocate a relatively large symbols array to begin with parsing to avoid re-allocations.

The added test is for reproducibility / review purposes and is meant to be removed before merging.
**The test needs to be run as root / with sudo, otherwise all addresses are 0 and the test fails (as in the CI).**

Not yet measured: the effect on loading symbols from executables (pre-allocation of symbol maps may also reduce CPU overhead).

Tested on Debian 6.10.11-amd64 x86_64 with ~284k entries in `proc/kallsyms` (180k+ text symbols).

### Before the actual code change
```
Memory usage before calling GetKallsyms:
Alloc = 0 MiB   TotalAlloc = 0 MiB      Sys = 8 MiB     NumGC = 1
Memory usage after calling GetKallsyms:
Alloc = 0 MiB   TotalAlloc = 75 MiB     Sys = 68 MiB    NumGC = 9
```

### After
```
Memory usage before calling GetKallsyms:
Alloc = 0 MiB   TotalAlloc = 19 MiB     Sys = 32 MiB    NumGC = 3
Memory usage after calling GetKallsyms:
Alloc = 0 MiB   TotalAlloc = 43 MiB     Sys = 33 MiB    NumGC = 6
```
