### PR TITLE
coredump/new: allow importing cores without backing file found

### DIFF
--- a/process/coredump.go
+++ b/process/coredump.go
@@ -408,7 +408,7 @@ func (cd *CoredumpProcess) parseAuxVector(desc []byte, vaddrToMappings map[uint6
 
 			vm := &cd.mappings[m.mappingIndex]
 			vm.Inode = vdsoInode
-			vm.Path = vdsoPathName
+			vm.Path = VdsoPathName
 
 			cf := cd.getFile(vm.Path)
 			cm := CoredumpMapping{

--- a/process/process.go
+++ b/process/process.go
@@ -109,7 +109,7 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 		if inode == 0 {
 			if path == "[vdso]" {
 				// Map to something filename looking with synthesized inode
-				path = vdsoPathName
+				path = VdsoPathName
 				device = 0
 				inode = vdsoInode
 			} else if path != "" {

--- a/process/types.go
+++ b/process/types.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
-// vdsoPathName is the path to use for VDSO mappings
-const vdsoPathName = "linux-vdso.1.so"
+// VdsoPathName is the path to use for VDSO mappings
+const VdsoPathName = "linux-vdso.1.so"
 
 // vdsoInode is the synthesized inode number for VDSO mappings
 const vdsoInode = 50
@@ -53,7 +53,7 @@ func (m *Mapping) IsMemFD() bool {
 }
 
 func (m *Mapping) IsVDSO() bool {
-	return m.Path == vdsoPathName
+	return m.Path == VdsoPathName
 }
 
 func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {


### PR DESCRIPTION
The fixes the 'new' command to fallback to the coredump methods so that the coredump backed memory can be used even if the file on disk is not found. This is especially important for the vDSO, but also in case we want to import a standalone core.

Additional add an informative message once for each module which cannot be found.