### PR TITLE
executables, reporter: refactor towards statelessness

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -6,7 +6,6 @@ package dotnet // import "go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
 import (
 	"fmt"
 	"hash/fnv"
-	"os"
 	"path"
 	"slices"
 	"strings"

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -624,7 +624,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 
 		if !symbolReporter.ExecutableKnown(info.fileID) {
 			open := func() (process.ReadAtCloser, error) {
-				return os.Open(m.Path)
+				return pr.OpenMappingFile(m)
 			}
 			symbolReporter.ExecutableMetadata(
 				&reporter.ExecutableMetadataArgs{

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -622,7 +622,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			info.fileID, m.Path,
 			info.simpleName, info.guid)
 
-		if !info.reported {
+		if !symbolReporter.ExecutableKnown(info.fileID) {
 			open := func() (process.ReadAtCloser, error) {
 				return os.Open(m.Path)
 			}
@@ -636,7 +636,6 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 					Open:              open,
 				},
 			)
-			info.reported = true
 		}
 
 		dotnetMappings = append(dotnetMappings, dotnetMapping{

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-freelru"
+
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/readatbuf"
 	"go.opentelemetry.io/ebpf-profiler/process"
@@ -261,7 +262,6 @@ type peInfo struct {
 	typeSpecs    []peTypeSpec
 	methodSpecs  []peMethodSpec
 	sizeOfImage  uint32
-	reported     bool
 
 	// strings contains the preloaded strings from dotnet string heap.
 	// If this consumes too much memory, this could be converted to LRU and on-demand

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -251,6 +251,10 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
+func (s *symbolReporterMockup) ExecutableKnown(_ libpf.FileID) bool {
+	return true
+}
+
 func (s *symbolReporterMockup) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -289,6 +289,10 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	}
 	pm.FileIDMapper.Set(hostFileID, fileID)
 
+	if pm.reporter.ExecutableKnown(fileID) {
+		return info
+	}
+
 	baseName := path.Base(mapping.Path)
 	if baseName == "/" {
 		// There are circumstances where there is no filename.

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -89,6 +89,13 @@ type FrameMetadataArgs struct {
 }
 
 type SymbolReporter interface {
+	// ExecutableKnown may be used to query the reporter if the FileID is known.
+	// The callers of ExecutableMetadata can optionally use this method to determine if the data
+	// is already cached and avoid extra work resolving the metadata. If the reporter returns false,
+	// the caller will resolve the executable metadata and submit it to the reporter
+	// via a subsequent ExecutableMetadata call.
+	ExecutableKnown(fileID libpf.FileID) bool
+
 	// ExecutableMetadata accepts a FileID with the corresponding filename
 	// and takes some action with it (for example, it might cache it for
 	// periodic reporting to a backend).
@@ -102,8 +109,8 @@ type SymbolReporter interface {
 	// FrameKnown may be used to query the reporter if the FrameID is known. The interpreter
 	// modules can optionally use this method to determine if the data is already cached
 	// and avoid extra work resolving the metadata. If the reporter returns false,
-	// the intepreter plugin will resolve the frame metadata and submit it to the reporter
-	// via a subsequent FrameMetdata call.
+	// the interpreter plugin will resolve the frame metadata and submit it to the reporter
+	// via a subsequent FrameMetadata call.
 	FrameKnown(frameID libpf.FrameID) bool
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -195,6 +195,13 @@ func (r *OTLPReporter) ReportFramesForTrace(_ *libpf.Trace) {}
 func (r *OTLPReporter) ReportCountForTrace(_ libpf.TraceHash, _ uint16, _ *TraceEventMeta) {
 }
 
+// ExecutableKnown returns true if the metadata of the Executable specified by fileID is
+// cached in the reporter.
+func (r *OTLPReporter) ExecutableKnown(fileID libpf.FileID) bool {
+	_, known := r.executables.Get(fileID)
+	return known
+}
+
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
 func (r *OTLPReporter) ExecutableMetadata(args *ExecutableMetadataArgs) {
@@ -204,7 +211,7 @@ func (r *OTLPReporter) ExecutableMetadata(args *ExecutableMetadataArgs) {
 	})
 }
 
-// FrameKnown return true if the metadata of the Frame specified by frameID is
+// FrameKnown returns true if the metadata of the Frame specified by frameID is
 // cached in the reporter.
 func (r *OTLPReporter) FrameKnown(frameID libpf.FrameID) bool {
 	known := false

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -49,6 +49,11 @@ func newSymbolizationCache() *symbolizationCache {
 	}
 }
 
+func (c *symbolizationCache) ExecutableKnown(fileID libpf.FileID) bool {
+	_, exists := c.files[fileID]
+	return exists
+}
+
 func (c *symbolizationCache) ExecutableMetadata(args *reporter.ExecutableMetadataArgs) {
 	c.files[args.FileID] = args.FileName
 }

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -91,6 +91,10 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
+func (f mockReporter) ExecutableKnown(_ libpf.FileID) bool {
+	return true
+}
+
 func (f mockReporter) ExecutableMetadata(_ *reporter.ExecutableMetadataArgs) {
 }
 


### PR DESCRIPTION
Expose the cached status for executable metadata to callers of `SymbolReporter.ExecutableMetadata()`.

Improvements
- the reporter module can now control which executable metadata needs to be fetched
- fixes OTLP to re-fetch executable metadata if its internal lru already evicted earlier metadata

reference: #121