### PR TITLE
integration tests: add test that loads all maps and programs

### DIFF
--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -247,4 +248,12 @@ Loop:
 			validateTrace(t, numKernelFrames, &testcase.userSpaceTrace, trace)
 		})
 	}
+}
+
+func TestAllTracers(t *testing.T) {
+	coll, err := support.LoadCollectionSpec(false)
+	require.NoError(t, err)
+
+	_, _, err = initializeMapsAndPrograms(coll, tracertypes.AllTracers(), nil, false, 1, false, 0)
+	require.NoError(t, err)
 }

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/proc"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/rlimit"
 	"go.opentelemetry.io/ebpf-profiler/support"
@@ -254,6 +255,10 @@ func TestAllTracers(t *testing.T) {
 	coll, err := support.LoadCollectionSpec(false)
 	require.NoError(t, err)
 
-	_, _, err = initializeMapsAndPrograms(coll, tracertypes.AllTracers(), nil, false, 1, false, 0)
+	kernelSymbols, err := proc.GetKallsyms("/proc/kallsyms")
+	require.NoError(t, err)
+
+	_, _, err = initializeMapsAndPrograms(coll, tracertypes.AllTracers(), kernelSymbols,
+		false, 1, false, 0)
 	require.NoError(t, err)
 }

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -252,13 +252,10 @@ Loop:
 }
 
 func TestAllTracers(t *testing.T) {
-	coll, err := support.LoadCollectionSpec(false)
-	require.NoError(t, err)
-
 	kernelSymbols, err := proc.GetKallsyms("/proc/kallsyms")
 	require.NoError(t, err)
 
-	_, _, err = initializeMapsAndPrograms(coll, tracertypes.AllTracers(), kernelSymbols,
-		false, 1, false, 0)
+	_, _, err = initializeMapsAndPrograms(tracertypes.AllTracers(), kernelSymbols,
+		false, 1, false, false, 0)
 	require.NoError(t, err)
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -266,20 +266,10 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to read kernel symbols: %v", err)
 	}
 
-	// Loading specifications about eBPF programs and maps from the embedded elf file
-	// does not load them into the kernel.
-	// A collection specification holds the information about eBPF programs and maps.
-	// References to eBPF maps in the eBPF programs are just placeholders that need to be
-	// replaced by the actual loaded maps later on with RewriteMaps before loading the
-	// programs into the kernel.
-	coll, err := support.LoadCollectionSpec(cfg.DebugTracer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load specification for tracers: %v", err)
-	}
-
 	// Based on includeTracers we decide later which are loaded into the kernel.
-	ebpfMaps, ebpfProgs, err := initializeMapsAndPrograms(coll, cfg.IncludeTracers, kernelSymbols,
-		cfg.FilterErrorFrames, cfg.MapScaleFactor, cfg.KernelVersionCheck, cfg.BPFVerifierLogLevel)
+	ebpfMaps, ebpfProgs, err := initializeMapsAndPrograms(cfg.IncludeTracers, kernelSymbols,
+		cfg.FilterErrorFrames, cfg.MapScaleFactor, cfg.KernelVersionCheck, cfg.DebugTracer,
+		cfg.BPFVerifierLogLevel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eBPF code: %v", err)
 	}
@@ -379,10 +369,20 @@ func buildStackDeltaTemplates(coll *cebpf.CollectionSpec) error {
 
 // initializeMapsAndPrograms loads the definitions for the eBPF maps and programs provided
 // by the embedded elf file and loads these into the kernel.
-func initializeMapsAndPrograms(coll *cebpf.CollectionSpec, includeTracers types.IncludedTracers,
+func initializeMapsAndPrograms(includeTracers types.IncludedTracers,
 	kernelSymbols *libpf.SymbolMap, filterErrorFrames bool, mapScaleFactor int,
-	kernelVersionCheck bool, bpfVerifierLogLevel uint32) (
+	kernelVersionCheck bool, debugTracer bool, bpfVerifierLogLevel uint32) (
 	ebpfMaps map[string]*cebpf.Map, ebpfProgs map[string]*cebpf.Program, err error) {
+	// Loading specifications about eBPF programs and maps from the embedded elf file
+	// does not load them into the kernel.
+	// A collection specification holds the information about eBPF programs and maps.
+	// References to eBPF maps in the eBPF programs are just placeholders that need to be
+	// replaced by the actual loaded maps later on with RewriteMaps before loading the
+	// programs into the kernel.
+	coll, err := support.LoadCollectionSpec(debugTracer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load specification for tracers: %v", err)
+	}
 
 	err = buildStackDeltaTemplates(coll)
 	if err != nil {

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -156,3 +156,11 @@ func Parse(tracers string) (IncludedTracers, error) {
 
 	return result, nil
 }
+
+// AllTracers is a shortcut that returns an element with all
+// tracers enabled.
+func AllTracers() IncludedTracers {
+	var result IncludedTracers
+	result.enableAll()
+	return result
+}


### PR DESCRIPTION
initializeMapsAndPrograms() provides core functionality in sizing and loading eBPF maps and programs. So far per-kernel tests only load specific named eBPF programs and therefore could not catch Linux kernel version specific issues with eBPF programs that were not loaded.