### PR TITLE
Add PID as an attribute in each sample

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -81,6 +81,7 @@ type traceEvents struct {
 	mappingEnds        []libpf.Address
 	mappingFileOffsets []uint64
 	timestamps         []uint64 // in nanoseconds
+	pid                uint64
 }
 
 // attrKeyValue is a helper to populate Profile.attribute_table.
@@ -185,6 +186,7 @@ func (r *OTLPReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 		mappingEnds:        trace.MappingEnd,
 		mappingFileOffsets: trace.MappingFileOffsets,
 		timestamps:         []uint64{uint64(meta.Timestamp)},
+		pid:                uint64(meta.PID),
 	}
 }
 
@@ -652,6 +654,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 			{key: string(semconv.ContainerIDKey), value: traceKey.containerID},
 			{key: string(semconv.ThreadNameKey), value: traceKey.comm},
 			{key: string(semconv.ServiceNameKey), value: traceKey.apmServiceName},
+			{key: string(semconv.ProcessPIDKey), value: strconv.FormatUint(traceInfo.pid, 10)},
 		}, attributeMap)
 		sample.LocationsLength = uint64(len(traceInfo.frameTypes))
 		locationIndex += sample.LocationsLength

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -743,7 +743,7 @@ func addProfileAttributes[T string | int64](profile *profiles.Profile,
 			attributeCompositeKey = attr.key + "_" + strconv.Itoa(int(val))
 			attributeValue = common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: val}}
 		default:
-			log.Error("Unsupported attribute value type. Only string and int64 are supported at this time.")
+			log.Error("Unsupported attribute value type. Only string and int64 are supported.")
 			return
 		}
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -737,18 +737,13 @@ func addProfileAttributes[T string | int64](profile *profiles.Profile,
 
 		switch val := any(attr.value).(type) {
 		case string:
-			if val == "" {
-				return
-			}
 			attributeCompositeKey = attr.key + "_" + val
 			attributeValue = common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: val}}
 		case int64:
-			if val == 0 {
-				return
-			}
 			attributeCompositeKey = attr.key + "_" + strconv.Itoa(int(val))
 			attributeValue = common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: val}}
 		default:
+			log.Error("Unsupported attribute value type. Only string and int64 are supported at this time.")
 			return
 		}
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -735,8 +734,10 @@ func addProfileAttributes(profile *profiles.Profile,
 		var attributeCompositeKey string
 		var attributeValue common.AnyValue
 
-		valueType := reflect.TypeOf(attr.value)
-		if valueType != reflect.TypeOf("") && valueType != reflect.TypeOf(int64(0)) {
+		switch attr.value.(type) {
+		case string, int64:
+			//Supported types, continue to handling below
+		default:
 			return
 		}
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -747,7 +747,7 @@ func addProfileAttributes[T string | int64](profile *profiles.Profile,
 				return
 			}
 			attributeCompositeKey = attr.key + "_" + strconv.Itoa(int(val))
-			attributeValue = common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: int64(val)}}
+			attributeValue = common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: val}}
 		default:
 			return
 		}

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -70,6 +70,7 @@ type traceAndMetaKey struct {
 	apmServiceName string
 	// containerID is annotated based on PID information
 	containerID string
+	pid         string
 }
 
 // traceEvents holds known information about a trace.
@@ -81,7 +82,6 @@ type traceEvents struct {
 	mappingEnds        []libpf.Address
 	mappingFileOffsets []uint64
 	timestamps         []uint64 // in nanoseconds
-	pid                uint64
 }
 
 // attrKeyValue is a helper to populate Profile.attribute_table.
@@ -170,6 +170,7 @@ func (r *OTLPReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 		comm:           meta.Comm,
 		apmServiceName: meta.APMServiceName,
 		containerID:    containerID,
+		pid:            strconv.FormatUint(uint64(meta.PID), 10),
 	}
 
 	if events, exists := (*traceEventsMap)[key]; exists {
@@ -186,7 +187,6 @@ func (r *OTLPReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 		mappingEnds:        trace.MappingEnd,
 		mappingFileOffsets: trace.MappingFileOffsets,
 		timestamps:         []uint64{uint64(meta.Timestamp)},
-		pid:                uint64(meta.PID),
 	}
 }
 
@@ -654,7 +654,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 			{key: string(semconv.ContainerIDKey), value: traceKey.containerID},
 			{key: string(semconv.ThreadNameKey), value: traceKey.comm},
 			{key: string(semconv.ServiceNameKey), value: traceKey.apmServiceName},
-			{key: string(semconv.ProcessPIDKey), value: strconv.FormatUint(traceInfo.pid, 10)},
+			{key: string(semconv.ProcessPIDKey), value: traceKey.pid},
 		}, attributeMap)
 		sample.LocationsLength = uint64(len(traceInfo.frameTypes))
 		locationIndex += sample.LocationsLength

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -159,12 +159,16 @@ func TestGetSampleAttributes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			indices := make([][]uint64, 0)
 			for _, k := range tc.k {
-				indices = append(indices, addProfileAttributes(tc.profile, []attrKeyValue{
-					{key: string(semconv.ContainerIDKey), value: k.containerID},
-					{key: string(semconv.ThreadNameKey), value: k.comm},
-					{key: string(semconv.ServiceNameKey), value: k.apmServiceName},
-					{key: string(semconv.ProcessPIDKey), value: k.pid},
-				}, tc.attributeMap))
+				indices = append(indices, append(addProfileAttributes(tc.profile,
+					[]attrKeyValue[string]{
+						{key: string(semconv.ContainerIDKey), value: k.containerID},
+						{key: string(semconv.ThreadNameKey), value: k.comm},
+						{key: string(semconv.ServiceNameKey), value: k.apmServiceName},
+					}, tc.attributeMap),
+					addProfileAttributes(tc.profile,
+						[]attrKeyValue[int64]{
+							{key: string(semconv.ProcessPIDKey), value: k.pid},
+						}, tc.attributeMap)...))
 			}
 			require.Equal(t, tc.expectedIndices, indices)
 			require.Equal(t, tc.expectedAttributeTable, tc.profile.AttributeTable)

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -26,6 +26,7 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "",
 					apmServiceName: "",
 					containerID:    "",
+					pid:            "",
 				},
 			},
 			attributeMap:           make(map[string]uint64),
@@ -40,16 +41,18 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
+					pid:            "pid1",
 				},
 				{
 					hash:           libpf.TraceHash{},
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
+					pid:            "pid1",
 				},
 			},
 			attributeMap:    make(map[string]uint64),
-			expectedIndices: [][]uint64{{0, 1, 2}, {0, 1, 2}},
+			expectedIndices: [][]uint64{{0, 1, 2, 3}, {0, 1, 2, 3}},
 			expectedAttributeTable: []*common.KeyValue{
 				{
 					Key: "container.id",
@@ -67,6 +70,12 @@ func TestGetSampleAttributes(t *testing.T) {
 					Key: "service.name",
 					Value: &common.AnyValue{
 						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"},
+					},
+				},
+				{
+					Key: "process.pid",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "pid1"},
 					},
 				},
 			},
@@ -79,16 +88,18 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
+					pid:            "pid1",
 				},
 				{
 					hash:           libpf.TraceHash{},
 					comm:           "comm2",
 					apmServiceName: "apmServiceName2",
 					containerID:    "containerID2",
+					pid:            "pid2",
 				},
 			},
 			attributeMap:    make(map[string]uint64),
-			expectedIndices: [][]uint64{{0, 1, 2}, {3, 4, 5}},
+			expectedIndices: [][]uint64{{0, 1, 2, 3}, {4, 5, 6, 7}},
 			expectedAttributeTable: []*common.KeyValue{
 				{
 					Key: "container.id",
@@ -106,6 +117,12 @@ func TestGetSampleAttributes(t *testing.T) {
 					Key: "service.name",
 					Value: &common.AnyValue{
 						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName1"},
+					},
+				},
+				{
+					Key: "process.pid",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "pid1"},
 					},
 				},
 				{
@@ -126,6 +143,12 @@ func TestGetSampleAttributes(t *testing.T) {
 						Value: &common.AnyValue_StringValue{StringValue: "apmServiceName2"},
 					},
 				},
+				{
+					Key: "process.pid",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "pid2"},
+					},
+				},
 			},
 		},
 	}
@@ -140,6 +163,7 @@ func TestGetSampleAttributes(t *testing.T) {
 					{key: string(semconv.ContainerIDKey), value: k.containerID},
 					{key: string(semconv.ThreadNameKey), value: k.comm},
 					{key: string(semconv.ServiceNameKey), value: k.apmServiceName},
+					{key: string(semconv.ProcessPIDKey), value: k.pid},
 				}, tc.attributeMap))
 			}
 			require.Equal(t, tc.expectedIndices, indices)

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -26,7 +26,7 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "",
 					apmServiceName: "",
 					containerID:    "",
-					pid:            "",
+					pid:            0,
 				},
 			},
 			attributeMap:           make(map[string]uint64),
@@ -41,14 +41,14 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
-					pid:            "pid1",
+					pid:            1234,
 				},
 				{
 					hash:           libpf.TraceHash{},
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
-					pid:            "pid1",
+					pid:            1234,
 				},
 			},
 			attributeMap:    make(map[string]uint64),
@@ -75,7 +75,7 @@ func TestGetSampleAttributes(t *testing.T) {
 				{
 					Key: "process.pid",
 					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "pid1"},
+						Value: &common.AnyValue_IntValue{IntValue: 1234},
 					},
 				},
 			},
@@ -88,14 +88,14 @@ func TestGetSampleAttributes(t *testing.T) {
 					comm:           "comm1",
 					apmServiceName: "apmServiceName1",
 					containerID:    "containerID1",
-					pid:            "pid1",
+					pid:            1234,
 				},
 				{
 					hash:           libpf.TraceHash{},
 					comm:           "comm2",
 					apmServiceName: "apmServiceName2",
 					containerID:    "containerID2",
-					pid:            "pid2",
+					pid:            6789,
 				},
 			},
 			attributeMap:    make(map[string]uint64),
@@ -122,7 +122,7 @@ func TestGetSampleAttributes(t *testing.T) {
 				{
 					Key: "process.pid",
 					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "pid1"},
+						Value: &common.AnyValue_IntValue{IntValue: 1234},
 					},
 				},
 				{
@@ -146,7 +146,7 @@ func TestGetSampleAttributes(t *testing.T) {
 				{
 					Key: "process.pid",
 					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "pid2"},
+						Value: &common.AnyValue_IntValue{IntValue: 6789},
 					},
 				},
 			},

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -29,9 +29,34 @@ func TestGetSampleAttributes(t *testing.T) {
 					pid:            0,
 				},
 			},
-			attributeMap:           make(map[string]uint64),
-			expectedIndices:        [][]uint64{make([]uint64, 0, 4)},
-			expectedAttributeTable: nil,
+			attributeMap:    make(map[string]uint64),
+			expectedIndices: [][]uint64{{0, 1, 2, 3}},
+			expectedAttributeTable: []*common.KeyValue{
+				{
+					Key: "container.id",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: ""},
+					},
+				},
+				{
+					Key: "thread.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: ""},
+					},
+				},
+				{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: ""},
+					},
+				},
+				{
+					Key: "process.pid",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_IntValue{IntValue: 0},
+					},
+				},
+			},
 		},
 		"duplicate": {
 			profile: &profiles.Profile{},


### PR DESCRIPTION
**What:**
This PR aims to add process Id as an attribute for each sample. This would be an addition to other attributes such as containerId, threadName etc. being sent currently.

**Why:**
Tools/services consuming the profiles sent by opentelemetry-ebpf-profiler could utilize the PID as an identifier for a process in their software/implementations.