### PR TITLE
Metrics: Drop unused reporter metrics

### DIFF
--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -134,27 +134,6 @@ const (
 	// Number of times that PC hold a value smaller than 0x1000
 	IDUnwindNativeSmallPC = 59
 
-	// Indicator for whether the exeMetadata queue has been overwritten
-	IDExeMetadataOverwrite = 60
-
-	// Indicator for whether the countsForTraces queue has been overwritten
-	IDCountsForTracesOverwrite = 61
-
-	// Indicator for whether the metrics queue has been overwritten
-	IDMetricsOverwrite = 62
-
-	// Indicator for whether the framesForTraces queue has been overwritten
-	IDFramesForTracesOverwrite = 63
-
-	// Indicator for whether the frameMetadata queue has been overwritten
-	IDFrameMetadataOverwrite = 64
-
-	// Indicator for whether the hostMetadata queue has been overwritten
-	IDHostMetadataOverwrite = 65
-
-	// Indicator for whether the fallbackSymbols queue has been overwritten
-	IDFallbackSymbolsOverwrite = 66
-
 	// Number of lost perf events in the communication between kernel and user space (report_events)
 	IDPerfEventLost = 67
 

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -434,6 +434,7 @@
     "id": 59
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the exeMetadata queue has been overwritten",
     "type": "counter",
     "name": "ExeMetadataOverwrite",
@@ -441,6 +442,7 @@
     "id": 60
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the countsForTraces queue has been overwritten",
     "type": "counter",
     "name": "CountsForTracesOverwrite",
@@ -448,6 +450,7 @@
     "id": 61
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the metrics queue has been overwritten",
     "type": "counter",
     "name": "MetricsOverwrite",
@@ -455,6 +458,7 @@
     "id": 62
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the framesForTraces queue has been overwritten",
     "type": "counter",
     "name": "FramesForTracesOverwrite",
@@ -462,6 +466,7 @@
     "id": 63
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the frameMetadata queue has been overwritten",
     "type": "counter",
     "name": "FrameMetadataOverwrite",
@@ -469,6 +474,7 @@
     "id": 64
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the hostMetadata queue has been overwritten",
     "type": "counter",
     "name": "HostMetadataOverwrite",
@@ -476,6 +482,7 @@
     "id": 65
   },
   {
+    "obsolete": true,
     "description": "Indicator for whether the fallbackSymbols queue has been overwritten",
     "type": "counter",
     "name": "FallbackSymbolsOverwrite",

--- a/reporter/metrics.go
+++ b/reporter/metrics.go
@@ -179,15 +179,8 @@ func (sh *StatsHandlerImpl) getMethodWireBytesIn() map[string]uint64 {
 
 // Metrics holds the metric counters for the reporter package.
 type Metrics struct {
-	CountsForTracesOverwriteCount uint32
-	ExeMetadataOverwriteCount     uint32
-	FrameMetadataOverwriteCount   uint32
-	FramesForTracesOverwriteCount uint32
-	HostMetadataOverwriteCount    uint32
-	MetricsOverwriteCount         uint32
-	FallbackSymbolsOverwriteCount uint32
-	RPCBytesOutCount              int64
-	RPCBytesInCount               int64
-	WireBytesOutCount             int64
-	WireBytesInCount              int64
+	RPCBytesOutCount  int64
+	RPCBytesInCount   int64
+	WireBytesOutCount int64
+	WireBytesInCount  int64
 }


### PR DESCRIPTION
Remove/obsolete left-overs of the Elastic reporter implementation.