### PR TITLE
Refine reporter caches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.62.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cilium/ebpf v0.16.0
-	github.com/elastic/go-freelru v0.13.0
+	github.com/elastic/go-freelru v0.15.0
 	github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a
 	github.com/google/uuid v1.6.0
 	github.com/jsimonetti/rtnetlink v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-freelru v0.13.0 h1:TKKY6yCfNNNky7Pj9xZAOEpBcdNgZJfihEftOb55omg=
 github.com/elastic/go-freelru v0.13.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
+github.com/elastic/go-freelru v0.15.0 h1:Jo1aY8JAvpyxbTDJEudrsBfjFDaALpfVv8mxuh9sfvI=
+github.com/elastic/go-freelru v0.15.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a h1:ymmtaN4bVCmKKeu4XEf6JEWNZKRXPMng1zjpKd+8rCU=
 github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a/go.mod h1:Nt+pnRYvf0POC+7pXsrv8ubsEOSsaipJP0zlz1Ms1RM=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -24,8 +24,12 @@ type Config struct {
 
 	// Disable secure communication with Collection Agent.
 	DisableTLS bool
-	// CacheSize defines the size of the reporter caches.
-	CacheSize uint32
+	// ExecutablesCacheSize defines the size of the executables cache.
+	ExecutablesCacheSize uint32
+	// FramesCacheSize defines the size of the frames cache.
+	FramesCacheSize uint32
+	// CgroupCacheSize defines the size of the cgroup cache.
+	CGroupCacheSize uint32
 	// samplesPerSecond defines the number of samples per second.
 	SamplesPerSecond int
 	// HostID is the host ID to be sent to the collection agent.


### PR DESCRIPTION
- separate sizes of reporter caches and size of tracehandler cache
- reduce memory consumption by using smaller but still sufficient cache sizes
- add a lifetime for cache items
- regularly purge expired cache items to avoid memory leaks
