### PR TITLE
Extract lookupcgroupv2 out of the otlp reporter

### DIFF
--- a/reporter/cgroupv2.go
+++ b/reporter/cgroupv2.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	lru "github.com/elastic/go-freelru"
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+// lookupCgroupv2 returns the cgroupv2 ID for pid.
+func lookupCgroupv2(cgrouplru *lru.SyncedLRU[libpf.PID, string], pid libpf.PID) (string, error) {
+	id, ok := cgrouplru.Get(pid)
+	if ok {
+		return id, nil
+	}
+
+	// Slow path
+	f, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var genericCgroupv2 string
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 512)
+	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
+	// We can do that and also set a maximum allocation size on the following call.
+	// With a maximum of 4096 characters path in the kernel, 8192 should be fine here. We don't
+	// expect lines in /proc/<PID>/cgroup to be longer than that.
+	scanner.Buffer(buf, 8192)
+	var pathParts []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		pathParts = cgroupv2PathPattern.FindStringSubmatch(line)
+		if pathParts == nil {
+			log.Debugf("Could not extract cgroupv2 path from line: %s", line)
+			continue
+		}
+		genericCgroupv2 = pathParts[1]
+		break
+	}
+
+	// Cache the cgroupv2 information.
+	// To avoid busy lookups, also empty cgroupv2 information is cached.
+	cgrouplru.Add(pid, genericCgroupv2)
+
+	return genericCgroupv2, nil
+}

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -4,13 +4,10 @@
 package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
-	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
-	"fmt"
 	"maps"
-	"os"
 	"regexp"
 	"slices"
 	"strconv"
@@ -214,7 +211,7 @@ func (r *OTLPReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 	traceEventsMap := r.traceEvents.WLock()
 	defer r.traceEvents.WUnlock(&traceEventsMap)
 
-	containerID, err := r.lookupCgroupv2(meta.PID)
+	containerID, err := lookupCgroupv2(r.cgroupv2ID, meta.PID)
 	if err != nil {
 		log.Debugf("Failed to get a cgroupv2 ID as container ID for PID %d: %v",
 			meta.PID, err)
@@ -866,45 +863,4 @@ func setupGrpcConnection(parent context.Context, cfg *Config,
 	defer cancel()
 	//nolint:staticcheck
 	return grpc.DialContext(ctx, cfg.CollAgentAddr, opts...)
-}
-
-// lookupCgroupv2 returns the cgroupv2 ID for pid.
-func (r *OTLPReporter) lookupCgroupv2(pid libpf.PID) (string, error) {
-	id, ok := r.cgroupv2ID.Get(pid)
-	if ok {
-		return id, nil
-	}
-
-	// Slow path
-	f, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	var genericCgroupv2 string
-	scanner := bufio.NewScanner(f)
-	buf := make([]byte, 512)
-	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
-	// We can do that and also set a maximum allocation size on the following call.
-	// With a maximum of 4096 characters path in the kernel, 8192 should be fine here. We don't
-	// expect lines in /proc/<PID>/cgroup to be longer than that.
-	scanner.Buffer(buf, 8192)
-	var pathParts []string
-	for scanner.Scan() {
-		line := scanner.Text()
-		pathParts = cgroupv2PathPattern.FindStringSubmatch(line)
-		if pathParts == nil {
-			log.Debugf("Could not extract cgroupv2 path from line: %s", line)
-			continue
-		}
-		genericCgroupv2 = pathParts[1]
-		break
-	}
-
-	// Cache the cgroupv2 information.
-	// To avoid busy lookups, also empty cgroupv2 information is cached.
-	r.cgroupv2ID.Add(pid, genericCgroupv2)
-
-	return genericCgroupv2, nil
 }


### PR DESCRIPTION
So it can be reused by several reporters.