### PR TITLE
reporter: do not add empty attributes

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -86,8 +86,10 @@ type traceEvents struct {
 
 // attrKeyValue is a helper to populate Profile.attribute_table.
 type attrKeyValue[T string | int64] struct {
-	key   string
-	value T
+	key string
+	// Set to true for OTel SemConv attributes with RequirementL: Required
+	required bool
+	value    T
 }
 
 // OTLPReporter receives and transforms information to be OTLP/profiles compliant.
@@ -753,7 +755,7 @@ func addProfileAttributes[T string | int64](profile *profiles.Profile,
 
 		switch val := any(attr.value).(type) {
 		case string:
-			if val == "" {
+			if !attr.required && val == "" {
 				return
 			}
 			attributeCompositeKey = attr.key + "_" + val

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -87,7 +87,7 @@ type traceEvents struct {
 // attrKeyValue is a helper to populate Profile.attribute_table.
 type attrKeyValue[T string | int64] struct {
 	key string
-	// Set to true for OTel SemConv attributes with RequirementL: Required
+	// Set to true for OTel SemConv attributes with requirement level: Required
 	required bool
 	value    T
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -753,6 +753,9 @@ func addProfileAttributes[T string | int64](profile *profiles.Profile,
 
 		switch val := any(attr.value).(type) {
 		case string:
+			if val == "" {
+				return
+			}
 			attributeCompositeKey = attr.key + "_" + val
 			attributeValue = common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: val}}
 		case int64:

--- a/reporter/otlp_reporter_test.go
+++ b/reporter/otlp_reporter_test.go
@@ -30,26 +30,8 @@ func TestGetSampleAttributes(t *testing.T) {
 				},
 			},
 			attributeMap:    make(map[string]uint64),
-			expectedIndices: [][]uint64{{0, 1, 2, 3}},
+			expectedIndices: [][]uint64{{0}},
 			expectedAttributeTable: []*common.KeyValue{
-				{
-					Key: "container.id",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: ""},
-					},
-				},
-				{
-					Key: "thread.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: ""},
-					},
-				},
-				{
-					Key: "service.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: ""},
-					},
-				},
 				{
 					Key: "process.pid",
 					Value: &common.AnyValue{


### PR DESCRIPTION
PR #212 changed the behaviour of addProfileAttributes(). Before adding an attribute the length of the string was checked - see https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/0c58efd41280bce80cca9804896c76874d383b35/reporter/otlp_reporter.go#L747-L749

This returns to the original behaivour, where string attributes with no values are not added.