### PR TITLE
reporter: use htlhash attribute for profiling specific hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ devfiler spins up a local server that listens on `0.0.0.0:11000`.
 
 To run it, simply download and unpack the archive from the following URL:
 
-https://upload.elastic.co/d/87e7697991940ec37f0c6e39ac38d213f65e8dc1ef9dbedff6aab9cba0adfaba
+https://upload.elastic.co/d/f8aa0c386baa808a616ca29f86b34c726edb5af36f8840a4cf28468ad534a4b5
 
-Authentication token: `c74dfc4db2212015`
+Authentication token: `2635c0750bf8ea69`
 
 
 The archive contains a build for each of the following platforms:

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -606,7 +606,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 						// semantic convention for build_id, replace these hard coded
 						// strings.
 						{key: "process.executable.build_id.gnu", value: execInfo.gnuBuildID},
-						{key: "process.executable.build_id.profiling",
+						{key: "process.executable.build_id.htlhash",
 							value: traceInfo.files[i].StringNoQuotes()},
 					}, attributeMap)
 


### PR DESCRIPTION
With https://github.com/open-telemetry/semantic-conventions/pull/1520 `process.executable.build_id.profiling` got deprecated and renamed to `process.executable.build_id.htlhash`.