### PR TITLE
tracehandler: set lifetime for cache

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -17,13 +17,14 @@ import (
 
 const (
 	// Default values for CLI flags
-	defaultArgSamplesPerSecond    = 20
-	defaultArgReporterInterval    = 5.0 * time.Second
-	defaultArgMonitorInterval     = 5.0 * time.Second
-	defaultClockSyncInterval      = 3 * time.Minute
-	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
-	defaultProbabilisticInterval  = 1 * time.Minute
-	defaultArgSendErrorFrames     = false
+	defaultArgSamplesPerSecond       = 20
+	defaultArgReporterInterval       = 5.0 * time.Second
+	defaultArgMonitorInterval        = 5.0 * time.Second
+	defaultClockSyncInterval         = 3 * time.Minute
+	defaultProbabilisticThreshold    = tracer.ProbabilisticThresholdMax
+	defaultProbabilisticInterval     = 1 * time.Minute
+	defaultArgSendErrorFrames        = false
+	defaultTraceHandlerCacheLifetime = 12 * time.Hour
 
 	// This is the X in 2^(n + x) where n is the default hardcoded map size value
 	defaultArgMapScaleFactor = 0
@@ -53,10 +54,13 @@ var (
 		tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1)
 	probabilisticIntervalHelp = "Time interval for which probabilistic profiling will be " +
 		"enabled or disabled."
-	pprofHelp             = "Listening address (e.g. localhost:6060) to serve pprof information."
-	samplesPerSecondHelp  = "Set the frequency (in Hz) of stack trace sampling."
-	reporterIntervalHelp  = "Set the reporter's interval in seconds."
-	monitorIntervalHelp   = "Set the monitor interval in seconds."
+	pprofHelp = "Listening address (e.g. localhost:6060) to serve " +
+		"pprof information."
+	samplesPerSecondHelp          = "Set the frequency (in Hz) of stack trace sampling."
+	reporterIntervalHelp          = "Set the reporter's interval in seconds."
+	monitorIntervalHelp           = "Set the monitor interval in seconds."
+	traceHandlerCacheLifetimeHelp = "Set the lifetime for trace information being cached " +
+		"before getting resend."
 	clockSyncIntervalHelp = "Set the sync interval with the realtime clock. " +
 		"If zero, monotonic-realtime clock sync will be performed once, " +
 		"on agent startup, but not periodically."
@@ -84,6 +88,9 @@ func parseArgs() (*controller.Config, error) {
 
 	fs.DurationVar(&args.MonitorInterval, "monitor-interval", defaultArgMonitorInterval,
 		monitorIntervalHelp)
+
+	fs.DurationVar(&args.TraceHandlerCacheLifetime, "tracehandler-cache-lifetime",
+		defaultTraceHandlerCacheLifetime, traceHandlerCacheLifetimeHelp)
 
 	fs.DurationVar(&args.ClockSyncInterval, "clock-sync-interval", defaultClockSyncInterval,
 		clockSyncIntervalHelp)

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -13,23 +13,24 @@ import (
 )
 
 type Config struct {
-	BpfVerifierLogLevel    uint
-	CollAgentAddr          string
-	Copyright              bool
-	DisableTLS             bool
-	MapScaleFactor         uint
-	MonitorInterval        time.Duration
-	ClockSyncInterval      time.Duration
-	NoKernelVersionCheck   bool
-	PprofAddr              string
-	ProbabilisticInterval  time.Duration
-	ProbabilisticThreshold uint
-	ReporterInterval       time.Duration
-	SamplesPerSecond       int
-	SendErrorFrames        bool
-	Tracers                string
-	VerboseMode            bool
-	Version                bool
+	BpfVerifierLogLevel       uint
+	CollAgentAddr             string
+	Copyright                 bool
+	DisableTLS                bool
+	MapScaleFactor            uint
+	MonitorInterval           time.Duration
+	ClockSyncInterval         time.Duration
+	NoKernelVersionCheck      bool
+	PprofAddr                 string
+	ProbabilisticInterval     time.Duration
+	ProbabilisticThreshold    uint
+	ReporterInterval          time.Duration
+	TraceHandlerCacheLifetime time.Duration
+	SamplesPerSecond          int
+	SendErrorFrames           bool
+	Tracers                   string
+	VerboseMode               bool
+	Version                   bool
 
 	Reporter reporter.Reporter
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -57,7 +57,8 @@ func (c *Controller) Start(ctx context.Context) error {
 		traceCacheSize(c.config.MonitorInterval, c.config.SamplesPerSecond, uint16(presentCores))
 
 	intervals := times.New(c.config.MonitorInterval,
-		c.config.ReporterInterval, c.config.ProbabilisticInterval)
+		c.config.ReporterInterval, c.config.ProbabilisticInterval,
+		c.config.TraceHandlerCacheLifetime)
 
 	// Start periodic synchronization with the realtime clock
 	times.StartRealtimeSync(ctx, c.config.ClockSyncInterval)

--- a/main.go
+++ b/main.go
@@ -100,7 +100,8 @@ func mainWithExitCode() exitCode {
 	}
 
 	intervals := times.New(cfg.MonitorInterval,
-		cfg.ReporterInterval, cfg.ProbabilisticInterval)
+		cfg.ReporterInterval, cfg.ProbabilisticInterval,
+		cfg.TraceHandlerCacheLifetime)
 
 	kernelVersion, err := helpers.GetKernelVersion()
 	if err != nil {

--- a/times/times.go
+++ b/times/times.go
@@ -50,6 +50,7 @@ type Times struct {
 	grpcAuthErrorDelay        time.Duration
 	pidCleanupInterval        time.Duration
 	probabilisticInterval     time.Duration
+	traceHandlerCacheLifetime time.Duration
 }
 
 // IntervalsAndTimers is a meta-interface that exists purely to document its functionality.
@@ -79,6 +80,9 @@ type IntervalsAndTimers interface {
 	// ProbabilisticInterval defines the interval for which probabilistic profiling will
 	// be enabled or disabled.
 	ProbabilisticInterval() time.Duration
+	// TraceHandlerCacheLifetime defines the duration for how long trace information is cached
+	// in the trace handler before it gets resend.
+	TraceHandlerCacheLifetime() time.Duration
 }
 
 func (t *Times) MonitorInterval() time.Duration { return t.monitorInterval }
@@ -101,6 +105,8 @@ func (t *Times) PIDCleanupInterval() time.Duration { return t.pidCleanupInterval
 
 func (t *Times) ProbabilisticInterval() time.Duration { return t.probabilisticInterval }
 
+func (t *Times) TraceHandlerCacheLifetime() time.Duration { return t.traceHandlerCacheLifetime }
+
 // StartRealtimeSync calculates a delta between the monotonic clock
 // (CLOCK_MONOTONIC, rebased to unixtime) and the realtime clock. If syncInterval is
 // greater than zero, it also starts a goroutine to perform that calculation periodically.
@@ -115,7 +121,8 @@ func StartRealtimeSync(ctx context.Context, syncInterval time.Duration) {
 }
 
 // New returns a new Times instance.
-func New(reportInterval, monitorInterval, probabilisticInterval time.Duration) *Times {
+func New(reportInterval, monitorInterval, probabilisticInterval,
+	traceHandlerCacheLifetime time.Duration) *Times {
 	return &Times{
 		reportMetricsInterval:     1 * time.Minute,
 		grpcAuthErrorDelay:        GRPCAuthErrorDelay,
@@ -127,6 +134,7 @@ func New(reportInterval, monitorInterval, probabilisticInterval time.Duration) *
 		reportInterval:            reportInterval,
 		monitorInterval:           monitorInterval,
 		probabilisticInterval:     probabilisticInterval,
+		traceHandlerCacheLifetime: traceHandlerCacheLifetime,
 	}
 }
 

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -30,6 +30,7 @@ var _ Times = (*times.Times)(nil)
 // Times is a subset of config.IntervalsAndTimers.
 type Times interface {
 	MonitorInterval() time.Duration
+	TraceHandlerCacheLifetime() time.Duration
 }
 
 // TraceProcessor is an interface used by traceHandler to convert traces
@@ -97,6 +98,7 @@ func newTraceHandler(rep reporter.TraceReporter, traceProcessor TraceProcessor,
 	if err != nil {
 		return nil, err
 	}
+	umTraceCache.SetLifetime(intervals.TraceHandlerCacheLifetime())
 
 	metadataWarnInhib, err := lru.New[libpf.PID, libpf.Void](64, libpf.PID.Hash32)
 	if err != nil {

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -19,14 +19,21 @@ import (
 )
 
 type fakeTimes struct {
-	monitorInterval time.Duration
+	monitorInterval           time.Duration
+	traceHandlerCacheLifetime time.Duration
 }
 
 func defaultTimes() *fakeTimes {
-	return &fakeTimes{monitorInterval: 1 * time.Hour}
+	return &fakeTimes{
+		monitorInterval:           1 * time.Hour,
+		traceHandlerCacheLifetime: 1 * time.Hour,
+	}
 }
 
 func (ft *fakeTimes) MonitorInterval() time.Duration { return ft.monitorInterval }
+func (ft *fakeTimes) TraceHandlerCacheLifetime() time.Duration {
+	return ft.traceHandlerCacheLifetime
+}
 
 // fakeTraceProcessor implements a fake TraceProcessor used only within the test scope.
 type fakeTraceProcessor struct{}


### PR DESCRIPTION
package tracehandler uses a cache to decide wheter frames for traces should be reported or not. Currently, the lifetime for elements in this cache is indefinetly, unless the element gets evicted if too many elements are added to the cache.
Holding back frames for traces can lead to issues with the backend missing information, if the backend was restarted or there was an issue sending the frame information for a trace in the first place.