### PR TITLE
controller: fix reporter interval mix up with monitor interval

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -56,8 +56,8 @@ func (c *Controller) Start(ctx context.Context) error {
 	traceHandlerCacheSize :=
 		traceCacheSize(c.config.MonitorInterval, c.config.SamplesPerSecond, uint16(presentCores))
 
-	intervals := times.New(c.config.MonitorInterval,
-		c.config.ReporterInterval, c.config.ProbabilisticInterval)
+	intervals := times.New(c.config.ReporterInterval, c.config.MonitorInterval,
+		c.config.ProbabilisticInterval)
 
 	// Start periodic synchronization with the realtime clock
 	times.StartRealtimeSync(ctx, c.config.ClockSyncInterval)


### PR DESCRIPTION
In the `times.New` function signature, reporter interval is first: https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/times/times.go#L117-L118.

However, in the `controller` package we provide monitor interval first. Currently this causes both to be mixed up when provided via the command line interface.

Let me know if you'd prefer we switch this to a struct so that we can explicitly specific which attribute is which.