### PR TITLE
Add CPU id to trace and trace metadata

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -55,4 +55,5 @@ type Trace struct {
 	TID              libpf.PID
 	APMTraceID       libpf.APMTraceID
 	APMTransactionID libpf.APMTransactionID
+	CPU              int
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -36,6 +36,7 @@ type TraceEventMeta struct {
 	Comm           string
 	APMServiceName string
 	PID, TID       libpf.PID
+	CPU            int
 }
 
 type TraceReporter interface {

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -126,6 +126,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 		PID:            bpfTrace.PID,
 		TID:            bpfTrace.TID,
 		APMServiceName: "", // filled in below
+		CPU:            bpfTrace.CPU,
 	}
 
 	if !m.reporter.SupportsReportTraceEvent() {

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -134,7 +134,7 @@ func startPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
 // calls. Returns a function that can be called to retrieve perf event array
 // error counts.
 func startPollingPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
-	pollFrequency time.Duration, perCPUBufferSize int, triggerFunc func([]byte),
+	pollFrequency time.Duration, perCPUBufferSize int, triggerFunc func([]byte, int),
 ) func() (lost, noData, readError uint64) {
 	eventReader, err := perf.NewReader(perfEventMap, perCPUBufferSize)
 	if err != nil {
@@ -178,7 +178,7 @@ func startPollingPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
 					noDataCount.Add(1)
 					continue
 				}
-				triggerFunc(data.RawSample)
+				triggerFunc(data.RawSample, data.CPU)
 			}
 		}
 	}()


### PR DESCRIPTION
Requested by customers: https://github.com/parca-dev/parca-agent/issues/2778

The idea is cpuid combined w/ timestamps can enable go trace style CPU core utilization graphs and give some limited insight into scheduler workings.