### PR TITLE
Send executable path with every stack trace

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -48,6 +48,7 @@ type Frame struct {
 
 type Trace struct {
 	Comm             string
+	Executable       string
 	Frames           []Frame
 	Hash             TraceHash
 	KTime            times.KTime

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -82,7 +82,9 @@ func (pm *ProcessManager) updatePidInformation(pid libpf.PID, m *Mapping) (bool,
 	if !ok {
 		// We don't have information for this pid, so we first need to
 		// allocate the embedded map for this process.
+		executable, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
 		info = &processInfo{
+			executable:       executable,
 			mappings:         make(map[libpf.Address]*Mapping),
 			mappingsByFileID: make(map[host.FileID]map[libpf.Address]*Mapping),
 			tsdInfo:          nil,
@@ -637,4 +639,18 @@ func (pm *ProcessManager) CleanupPIDs() {
 	if len(deadPids) > 0 {
 		log.Debugf("Cleaned up %d dead PIDs", len(deadPids))
 	}
+}
+
+// ExePathForPID returns the full executable path for given PID.
+// If the PID is not tracked or belongs to a kernel worker,
+// it returns the empty string.
+func (pm *ProcessManager) ExePathForPID(pid libpf.PID) string {
+	var executable string
+
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
+		executable = procInfo.executable
+	}
+	return executable
 }

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -138,6 +138,8 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
+	// executable path retrieved from /proc/PID/exe
+	executable string
 	// executable mappings keyed by start address.
 	mappings map[libpf.Address]*Mapping
 	// executable mappings keyed by host file ID.

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -34,6 +34,7 @@ type Reporter interface {
 type TraceEventMeta struct {
 	Timestamp      libpf.UnixTime64
 	Comm           string
+	Executable     string
 	APMServiceName string
 	PID, TID       libpf.PID
 	CPU            int

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -68,6 +68,8 @@ type traceAndMetaKey struct {
 	// containerID is annotated based on PID information
 	containerID string
 	pid         int64
+	// executable path is retrieved from /proc/PID/exe
+	executable string
 	// extraMeta stores extra meta info that may have been produced by a
 	// `SampleAttrProducer` instance. May be nil.
 	extraMeta any
@@ -224,6 +226,7 @@ func (r *OTLPReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 	key := traceAndMetaKey{
 		hash:           trace.Hash,
 		comm:           meta.Comm,
+		executable:     meta.Executable,
 		apmServiceName: meta.APMServiceName,
 		containerID:    containerID,
 		pid:            int64(meta.PID),
@@ -659,6 +662,8 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 			semconv.ContainerIDKey, traceKey.containerID)
 		attrMgr.AppendOptionalString(&sample.Attributes,
 			semconv.ThreadNameKey, traceKey.comm)
+		attrMgr.AppendOptionalString(&sample.Attributes,
+			semconv.ProcessExecutablePathKey, traceKey.executable)
 		attrMgr.AppendOptionalString(&sample.Attributes,
 			semconv.ServiceNameKey, traceKey.apmServiceName)
 		attrMgr.AppendInt(&sample.Attributes,

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -127,6 +127,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 		TID:            bpfTrace.TID,
 		APMServiceName: "", // filled in below
 		CPU:            bpfTrace.CPU,
+		Executable:     bpfTrace.Executable,
 	}
 
 	if !m.reporter.SupportsReportTraceEvent() {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -856,11 +856,13 @@ func (t *Tracer) loadBpfTrace(raw []byte, cpu int) *host.Trace {
 		panic("unexpected record size")
 	}
 
+	pid := libpf.PID(ptr.pid)
 	trace := &host.Trace{
 		Comm:             C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
+		Executable:       t.processManager.ExePathForPID(pid),
 		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.apm_trace_id)),
 		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.apm_transaction_id)),
-		PID:              libpf.PID(ptr.pid),
+		PID:              pid,
 		TID:              libpf.PID(ptr.tid),
 		KTime:            times.KTime(ptr.ktime),
 		CPU:              cpu,


### PR DESCRIPTION
### Summary

1. Added executable path collection to `processmanager`
2. Tracer will now enrich host traces with executable path
3. Reporter will report executable path with every stack trace


**TODO:**

- ~Retrieve name from `/proc/PID/status` instead of `/proc/PID/exe` to be semconv compliant (`/proc/PID/status` will have the filename truncated to `TASK_COMM_LEN-1` characters)~

Decided not to retrieve/send [process.executable.name](https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/#process-executable-name) in the way that semantic conventions dictate (`Name` in `/proc/PID/status`) as this is not the executable name but the process name (see [proc_pid_status(5)](https://man7.org/linux/man-pages/man5/proc_pid_status.5.html)), which can be changed by the application (e.g. through `prctl` or direct stack write). So the semantic conventions for `process.executable.name` are either confusingly misleading or wrong, depending on interpretation.

We can add this in another PR if we decide it's something we want / clarify what the semantics should be for this key.
