### PR TITLE
Turn kernel module file parsing errors into warnings

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -124,7 +124,7 @@ func GetKernelModules(modulesPath string,
 		nFields, err := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
 			&name, &size, &refcount, &dependencies, &state, &address)
 		if err != nil {
-			log.Warnf("err parsing line in modules: '%s'", err)
+			log.Warnf("error parsing line '%s' in modules: '%s'", line, err)
 			continue
 		}
 		if nFields < 6 {

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -121,10 +121,15 @@ func GetKernelModules(modulesPath string,
 
 		count++
 
-		nFields, _ := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
+		nFields, err := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
 			&name, &size, &refcount, &dependencies, &state, &address)
+		if err != nil {
+			log.Warnf("err parsing line in modules: '%s'", err)
+			continue
+		}
 		if nFields < 6 {
-			return nil, fmt.Errorf("unexpected line in modules: '%s'", line)
+			log.Warnf("unexpected line in modules: '%s'", line)
+			continue
 		}
 		if address == 0 {
 			continue


### PR DESCRIPTION
We've seen multiple instances of this file being malformed and usually
we just want to skip lines that don't parse correctly.
