### PR TITLE
readatbuf: add missing check when reading from tail chunk

### DIFF
--- a/libpf/readatbuf/readatbuf.go
+++ b/libpf/readatbuf/readatbuf.go
@@ -111,6 +111,9 @@ func (reader *Reader) ReadAt(p []byte, off int64) (int, error) {
 		if err != nil {
 			return int(writeOffset), err
 		}
+		if skipOffset > uint(len(data)) {
+			return 0, io.EOF
+		}
 
 		copyLen := min(remaining, uint(len(data))-skipOffset)
 		copy(p[writeOffset:][:copyLen], data[skipOffset:][:copyLen])

--- a/libpf/readatbuf/readatbuf_test.go
+++ b/libpf/readatbuf/readatbuf_test.go
@@ -5,6 +5,7 @@ package readatbuf_test
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,4 +25,19 @@ func TestCaching(t *testing.T) {
 	testVariant(t, 1024, 64, 1)
 	testVariant(t, 1346, 11, 55)
 	testVariant(t, 889, 34, 111)
+}
+
+func TestOutOfBoundsTail(t *testing.T) {
+	buf := bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7})
+	r, err := readatbuf.New(buf, 5, 10)
+	require.NoError(t, err)
+	b := make([]byte, 1)
+	for i := int64(0); i < 32; i++ {
+		_, err = r.ReadAt(b, i)
+		if i > 7 {
+			require.ErrorIs(t, err, io.EOF)
+		} else {
+			require.NoError(t, err)
+		}
+	}
 }


### PR DESCRIPTION
Slightly simpler alternative to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/258. Also added a test case that catches the previous crash.