### PR TITLE
Send thread name as ThreadNameKey not ProcessCommandKey

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -658,7 +658,7 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 		attrMgr.AppendOptionalString(&sample.Attributes,
 			semconv.ContainerIDKey, traceKey.containerID)
 		attrMgr.AppendOptionalString(&sample.Attributes,
-			semconv.ProcessCommandKey, traceKey.comm)
+			semconv.ThreadNameKey, traceKey.comm)
 		attrMgr.AppendOptionalString(&sample.Attributes,
 			semconv.ServiceNameKey, traceKey.apmServiceName)
 		attrMgr.AppendInt(&sample.Attributes,


### PR DESCRIPTION
### Summary
 
Noticed this while I was working on #253, change was recently introduced in d6fd2ec (original commit is [here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/237/commits/cd17b591df7f13f2abbb4c78c0b2c5027328c792)).