### PR TITLE
proc: handle nvidia kernel modules

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -166,7 +166,8 @@ type kernelModule struct {
 
 func parseKernelModuleLine(line string) (kernelModule, error) {
 	// The format is: "name size refcount dependencies state address"
-	parts := strings.SplitN(line, " ", 6)
+	// The string is split into 7 parts as after address there can be an optional string.
+	parts := strings.SplitN(line, " ", 7)
 	if len(parts) < 6 {
 		return kernelModule{}, fmt.Errorf("unexpected line in modules: '%s'", line)
 	}
@@ -189,15 +190,10 @@ func parseKernelModuleLine(line string) (kernelModule, error) {
 }
 
 func parseAddress(addressStr string) (uint64, error) {
-	addrParts := strings.SplitAfter(addressStr, " ")
-	if len(addrParts) == 0 {
-		return 0, fmt.Errorf("failed to handle '%s' as address string", addressStr)
-	}
-	address, err := strconv.ParseUint(strings.TrimPrefix(
-		strings.TrimSpace(addrParts[0]), "0x"), 16, 64)
+	address, err := strconv.ParseUint(strings.TrimPrefix(addressStr, "0x"), 16, 64)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse address '%s' as hex value: %v",
-			addrParts[0], err)
+			addressStr, err)
 	}
 
 	return address, nil

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -94,12 +94,35 @@ k10temp 12288 - - Live 0xffffffffc0254000`)
 }
 
 func TestParseKernelModuleLine(t *testing.T) {
-	line := "i40e 589824 - - Live 0xffffffffc0364000"
-	kmod, err := parseKernelModuleLine(line)
-	require.NoError(t, err)
-	require.Equal(t, kernelModule{
-		name:    "i40e",
-		size:    589824,
-		address: 0xffffffffc0364000,
-	}, kmod)
+	tests := map[string]struct {
+		line     string
+		expected kernelModule
+	}{
+		"i40e": {
+			line: "i40e 589824 - - Live 0xffffffffc0364000",
+			expected: kernelModule{
+				name:    "i40e",
+				size:    589824,
+				address: 0xffffffffc0364000,
+			},
+		},
+		"nvidia": {
+			line: "nvidia_drm 102400 2 - Live 0xffffffffc11c0000 (POE)",
+			expected: kernelModule{
+				name:    "nvidia_drm",
+				size:    102400,
+				address: 0xffffffffc11c0000,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name := name
+		test := test
+		t.Run(name, func(t *testing.T) {
+			kmod, err := parseKernelModuleLine(test.line)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, kmod)
+		})
+	}
 }


### PR DESCRIPTION
parseKernelModuleLine currently fails to parse lines for nvidia kernel modules.