### PR TITLE
Make the CollAgentAddr config optional in controller

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	Tracers                string
 	VerboseMode            bool
 	Version                bool
+	// HostName is the name of the host.
+	HostName string
+	// IPAddress is the IP address of the host.
+	IPAddress string
 
 	Reporter reporter.Reporter
 

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	Version                bool
 	// HostName is the name of the host.
 	HostName string
-	// IPAddress is the IP address of the host.
+	// IPAddress is the IP address of the host that sends data to CollAgentAddr.
 	IPAddress string
 
 	Reporter reporter.Reporter

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -78,13 +78,15 @@ func (c *Controller) Start(ctx context.Context) error {
 	// OTel semantic introduced in https://github.com/open-telemetry/semantic-conventions/issues/66
 	metadataCollector.AddCustomData("os.kernel.release", kernelVersion)
 
-	// hostname and sourceIP will be populated from the root namespace.
-	hostname, sourceIP, err := helpers.GetHostnameAndSourceIP(c.config.CollAgentAddr)
-	if err != nil {
-		log.Warnf("Failed to fetch metadata information in the root namespace: %v", err)
+	if c.config.CollAgentAddr != "" {
+		// hostname and sourceIP will be populated from the root namespace.
+		hostname, sourceIP, err := helpers.GetHostnameAndSourceIP(c.config.CollAgentAddr)
+		if err != nil {
+			log.Warnf("Failed to fetch metadata information in the root namespace: %v", err)
+		}
+		metadataCollector.AddCustomData("host.name", hostname)
+		metadataCollector.AddCustomData("host.ip", sourceIP)
 	}
-	metadataCollector.AddCustomData("host.name", hostname)
-	metadataCollector.AddCustomData("host.ip", sourceIP)
 
 	err = c.reporter.Start(ctx)
 	if err != nil {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -78,16 +78,8 @@ func (c *Controller) Start(ctx context.Context) error {
 	// OTel semantic introduced in https://github.com/open-telemetry/semantic-conventions/issues/66
 	metadataCollector.AddCustomData("os.kernel.release", kernelVersion)
 
-	if c.config.CollAgentAddr != "" {
-		// hostname and sourceIP will be populated from the root namespace.
-		hostname, sourceIP,
-			err := //nolint:govet // shadowing err is fine, previous errors have been handled
-			helpers.GetHostnameAndSourceIP(c.config.CollAgentAddr)
-		if err != nil {
-			log.Warnf("Failed to fetch metadata information in the root namespace: %v", err)
-		}
-		metadataCollector.AddCustomData("host.name", hostname)
-		metadataCollector.AddCustomData("host.ip", sourceIP)
+	metadataCollector.AddCustomData("host.name", c.config.HostName)
+	metadataCollector.AddCustomData("host.ip", c.config.IPAddress)
 	}
 
 	err = c.reporter.Start(ctx)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -80,7 +80,9 @@ func (c *Controller) Start(ctx context.Context) error {
 
 	if c.config.CollAgentAddr != "" {
 		// hostname and sourceIP will be populated from the root namespace.
-		hostname, sourceIP, err := helpers.GetHostnameAndSourceIP(c.config.CollAgentAddr)
+		hostname, sourceIP,
+			err := //nolint:govet // shadowing err is fine, previous errors have been handled
+			helpers.GetHostnameAndSourceIP(c.config.CollAgentAddr)
 		if err != nil {
 			log.Warnf("Failed to fetch metadata information in the root namespace: %v", err)
 		}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -80,7 +80,6 @@ func (c *Controller) Start(ctx context.Context) error {
 
 	metadataCollector.AddCustomData("host.name", c.config.HostName)
 	metadataCollector.AddCustomData("host.ip", c.config.IPAddress)
-	}
 
 	err = c.reporter.Start(ctx)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func mainWithExitCode() exitCode {
 		log.Error(err)
 		return exitFailure
 	}
+	cfg.HostName, cfg.IPAddress = hostname, sourceIP
 
 	rep, err := reporter.NewOTLP(&reporter.Config{
 		CollAgentAddr:            cfg.CollAgentAddr,


### PR DESCRIPTION
When running the agent as a collector receiver, the `CollAgentAddr` config isn't used, since we don't start any HTTP/gRPC server.
We therefore should make this config optional.

This isn't tested because the controller currently requires root to run, and therefore can't be started in the context of tests.