### PR TITLE
Pin the build container to Debian 12.8 so it works reliably

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:12.8
 
 WORKDIR /agent
 


### PR DESCRIPTION
When I got started working on this project a while back, `debian:testing` was working fine, but when I set it up more recently on a different computer, it didn't work anymore. After some troubleshooting, I believe I've determined that the issue is that Debian has started working on a pre-release of `13.0` in the `testing` branch, so it's no longer the `12.x` version we were expecting here, and the symptom was some missing packages (in my case, it was `clang-16`).

Pinning it to `12.8` (currently the latest release) seems to work in practice, and I think that pinning it like this will keep it working more reliably, and make it a more explicit decision when we want to upgrade it to something new.