### PR TITLE
Initial support for BEAM (Erlang/Elixir)

### DIFF
--- a/interpreter/beam/beam.go
+++ b/interpreter/beam/beam.go
@@ -10,6 +10,7 @@ package beam // import "go.opentelemetry.io/ebpf-profiler/interpreter/beam"
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -19,6 +20,8 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/lpm"
+	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/support"
@@ -40,6 +43,12 @@ type beamInstance struct {
 
 	data *beamData
 	rm   remotememory.RemoteMemory
+	// mappings is indexed by the Mapping to its generation
+	mappings map[process.Mapping]*uint32
+	// prefixes is indexed by the prefix added to ebpf maps (to be cleaned up) to its generation
+	prefixes map[lpm.Prefix]*uint32
+	// mappingGeneration is the current generation (so old entries can be pruned)
+	mappingGeneration uint32
 }
 
 func readSymbolValue(ef *pfelf.File, name libpf.SymbolName) ([]byte, error) {
@@ -116,9 +125,124 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 func (d *beamData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address, rm remotememory.RemoteMemory) (interpreter.Instance, error) {
 	log.Infof("BEAM interpreter attaching")
 	return &beamInstance{
-		data: d,
-		rm:   rm,
+		data:     d,
+		rm:       rm,
+		mappings: make(map[process.Mapping]*uint32),
+		prefixes: make(map[lpm.Prefix]*uint32),
 	}, nil
+}
+
+func (i *beamInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
+	_ reporter.SymbolReporter, pr process.Process, mappings []process.Mapping) error {
+	pid := pr.PID()
+	i.mappingGeneration++
+	for idx := range mappings {
+		m := &mappings[idx]
+		if !m.IsExecutable() || !m.IsAnonymous() {
+			continue
+		}
+
+		if _, exists := i.mappings[*m]; exists {
+			*i.mappings[*m] = i.mappingGeneration
+			continue
+		}
+
+		// Generate a new uint32 pointer which is shared for mapping and the prefixes it owns
+		// so updating the mapping above will reflect to prefixes also.
+		mappingGeneration := i.mappingGeneration
+		i.mappings[*m] = &mappingGeneration
+
+		// Just assume all anonymous and executable mappings are BEAM for now
+		log.Infof("Enabling BEAM for %#x/%#x", m.Vaddr, m.Length)
+
+		prefixes, err := lpm.CalculatePrefixList(m.Vaddr, m.Vaddr+m.Length)
+		if err != nil {
+			return fmt.Errorf("new anonymous mapping lpm failure %#x/%#x", m.Vaddr, m.Length)
+		}
+
+		for _, prefix := range prefixes {
+			_, exists := i.prefixes[prefix]
+			if !exists {
+				err := ebpf.UpdatePidInterpreterMapping(pid, prefix, support.ProgUnwindBEAM, 0, 0)
+				if err != nil {
+					return err
+				}
+			}
+			i.prefixes[prefix] = &mappingGeneration
+		}
+	}
+
+	// Remove prefixes not seen
+	for prefix, generationPtr := range i.prefixes {
+		if *generationPtr == i.mappingGeneration {
+			continue
+		}
+		log.Infof("Delete BEAM prefix %#v", prefix)
+		_ = ebpf.DeletePidInterpreterMapping(pid, prefix)
+		delete(i.prefixes, prefix)
+	}
+	for m, generationPtr := range i.mappings {
+		if *generationPtr == i.mappingGeneration {
+			continue
+		}
+		log.Infof("Disabling BEAM for %#x/%#x", m.Vaddr, m.Length)
+		delete(i.mappings, m)
+	}
+
+	return nil
+}
+
+func (i *beamInstance) SynchronizeMappingsFromJITDump(ebpf interpreter.EbpfHandler,
+	_ reporter.SymbolReporter, pr process.Process, mappings []process.Mapping) error {
+	pid := pr.PID()
+	file, err := os.Open(fmt.Sprintf("/tmp/jit-%d.dump", uint32(pid)))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	header, err := ReadJITDumpHeader(file)
+	if err != nil {
+		return err
+	}
+	log.Infof("Parsed header: %v", *header)
+
+	for recordHeader, err := ReadJITDumpRecordHeader(file); err == nil; recordHeader, err = ReadJITDumpRecordHeader(file) {
+		switch recordHeader.ID {
+		case JITCodeLoad:
+			record, name, err := ReadJITDumpRecordCodeLoad(file, recordHeader)
+			if err != nil {
+				return err
+			}
+
+			log.Infof("JITDump Code Load %s @ 0x%x (%d bytes)", name, record.CodeAddr, record.CodeSize)
+
+			prefixes, err := lpm.CalculatePrefixList(record.CodeAddr, record.CodeAddr+record.CodeSize)
+			if err != nil {
+				return fmt.Errorf("lpm failure %#x/%#x", record.CodeAddr, record.CodeSize)
+			}
+
+			for _, prefix := range prefixes {
+				// TODO: Include FileID
+				err := ebpf.UpdatePidInterpreterMapping(pid, prefix, support.ProgUnwindBEAM, 0, 0)
+				if err != nil {
+					return err
+				}
+			}
+
+			// TODO: remove mappings that have been moved/unloaded
+
+		default:
+			log.Warnf("Ignoring JITDump record type %d", recordHeader.ID)
+			SkipJITDumpRecord(file, recordHeader)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (i *beamInstance) Detach(interpreter.EbpfHandler, libpf.PID) error {

--- a/interpreter/beam/beam.go
+++ b/interpreter/beam/beam.go
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package beam // import "go.opentelemetry.io/ebpf-profiler/interpreter/beam"
+
+// BEAM VM Unwinder support code
+
+// The BEAM VM is an interpreter for Erlang, as well as several other languages
+// that share the same bytecode, such as Elixir and Gleam.
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+
+	"go.opentelemetry.io/ebpf-profiler/host"
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/support"
+)
+
+var (
+	// regex for matching the process name
+	beamRegex                      = regexp.MustCompile(`beam.smp`)
+	_         interpreter.Data     = &beamData{}
+	_         interpreter.Instance = &beamInstance{}
+)
+
+type beamData struct {
+	version uint32
+}
+
+type beamInstance struct {
+	interpreter.InstanceStubs
+
+	data *beamData
+	rm   remotememory.RemoteMemory
+}
+
+func readSymbolValue(ef *pfelf.File, name libpf.SymbolName) ([]byte, error) {
+	sym, err := ef.LookupSymbol(name)
+	if err != nil {
+		return nil, fmt.Errorf("symbol not found: %v", err)
+	}
+
+	memory := make([]byte, sym.Size)
+	if _, err := ef.ReadVirtualMemory(memory, int64(sym.Address)); err != nil {
+		return nil, fmt.Errorf("failed to read process memory at 0x%x:%v", sym.Address, err)
+	}
+
+	log.Infof("read symbol value %s: %s", sym.Name, memory)
+	return memory, nil
+}
+func readReleaseVersion(ef *pfelf.File) (uint32, []byte, error) {
+	otp_release, err := readSymbolValue(ef, "etp_otp_release")
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read OTP release: %v", err)
+	}
+
+	// Slice off the null termination before converting
+	otp_major, err := strconv.Atoi(string(otp_release[:len(otp_release)-1]))
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to parse OTP version: %v", err)
+	}
+
+	erts_version, err := readSymbolValue(ef, "etp_erts_version")
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read erts version: %v", err)
+	}
+
+	return uint32(otp_major), erts_version, nil
+}
+
+func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpreter.Data, error) {
+	matches := beamRegex.FindStringSubmatch(info.FileName())
+	if matches == nil {
+		return nil, nil
+	}
+	log.Infof("BEAM interpreter found: %v", matches)
+
+	ef, err := info.GetELF()
+	if err != nil {
+		return nil, err
+	}
+
+	otp_version, _, err := readReleaseVersion(ef)
+	if err != nil {
+		return nil, err
+	}
+
+	symbolName := libpf.SymbolName("process_main")
+	interpRanges, err := info.GetSymbolAsRanges(symbolName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = ebpf.UpdateInterpreterOffsets(support.ProgUnwindBEAM, info.FileID(), interpRanges); err != nil {
+		return nil, err
+	}
+
+	d := &beamData{
+		version: otp_version,
+	}
+
+	log.Infof("BEAM loaded, otp_version: %d, interpRanges: %v", otp_version, interpRanges)
+	//d.loadIntrospectionData()
+
+	return d, nil
+}
+
+func (d *beamData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address, rm remotememory.RemoteMemory) (interpreter.Instance, error) {
+	log.Infof("BEAM interpreter attaching")
+	return &beamInstance{
+		data: d,
+		rm:   rm,
+	}, nil
+}
+
+func (r *beamInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
+	return nil
+}
+
+func (r *beamInstance) Symbolize(symbolReporter reporter.SymbolReporter, frame *host.Frame, trace *libpf.Trace) error {
+	if !frame.Type.IsInterpType(libpf.BEAM) {
+		log.Warnf("BEAM failed to symbolize")
+		return interpreter.ErrMismatchInterpreterType
+	}
+	log.Infof("BEAM symbolizing")
+	return nil
+}

--- a/interpreter/beam/jitdumpreader.go
+++ b/interpreter/beam/jitdumpreader.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package beam // import "go.opentelemetry.io/ebpf-profiler/interpreter/beam"
+
+// Minimal JITDUMP file reader for BEAM
+
+// This has the minimal code we need to read the JITDUMP files that the BEAM
+// writes to `/tmp/jit-<pid>.dump`. It isn't BEAM-specific, so it could probably
+// be used more generally. The spec for this file format is at:
+// https://raw.githubusercontent.com/torvalds/linux/refs/heads/master/tools/perf/Documentation/jitdump-specification.txt
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type JITDumpHeader struct {
+	Magic     uint32 // the ASCII string "JiTD", written is as 0x4A695444. The reader will detect an endian mismatch when it reads 0x4454694a
+	Version   uint32 // a 4-byte value representing the format version. It is currently set to 1
+	TotalSize uint32 // size in bytes of file header
+	ELFMach   uint32 // ELF architecture encoding (ELF e_machine value as specified in /usr/include/elf.h)
+	Pad1      uint32 // padding. Reserved for future use
+	Pid       uint32 // JIT runtime process identification (OS specific)
+	Timestamp uint64 // timestamp of when the file was created
+	Flags     uint64 // a bitmask of flags
+}
+
+type JITDumpRecordHeader struct {
+	ID        uint32 // a value identifying the record type (e.g. beam.JITCodeLoad)
+	TotalSize uint32 // the size in bytes of the record including this header
+	Timestamp uint64 // a timestamp of when the record was created
+}
+
+const (
+	JITCodeLoad          = 0 // record describing a jitted function
+	JITCodeMove          = 1 // record describing an already jitted function which is moved
+	JITCodeDebugInfo     = 2 // record describing the debug information for a jitted function
+	JITCodeClose         = 3 // record marking the end of the jit runtime (optional)
+	JITCodeUnwindingInfo = 4 // record describing a function unwinding information
+)
+
+type JITDumpRecordCodeLoad struct {
+	PID       uint32 // OS process id of the runtime generating the jitted code
+	TID       uint32 // OS thread identification of the runtime thread generating the jitted code
+	VMA       uint64 // virtual address of jitted code start
+	CodeAddr  uint64 // code start address for the jitted code. By default vma = code_addr
+	CodeSize  uint64 // size in bytes of the generated jitted code
+	CodeIndex uint64 // unique identifier for the jitted code
+}
+
+func ReadJITDumpHeader(file io.ReadSeeker) (*JITDumpHeader, error) {
+	header := JITDumpHeader{}
+	err := binary.Read(file, binary.LittleEndian, &header)
+	if err != nil {
+		return nil, err
+	}
+
+	if header.Magic != 0x4A695444 {
+		return nil, fmt.Errorf("File malformed, or maybe wrong endianness. Found magic number: %x", header.Magic)
+	}
+
+	return &header, nil
+}
+
+func ReadJITDumpRecordHeader(file io.ReadSeeker) (*JITDumpRecordHeader, error) {
+	header := JITDumpRecordHeader{}
+	err := binary.Read(file, binary.LittleEndian, &header)
+	if err != nil {
+		return nil, err
+	}
+	return &header, nil
+}
+
+func ReadJITDumpRecordCodeLoad(file io.ReadSeeker, header *JITDumpRecordHeader) (*JITDumpRecordCodeLoad, string, error) {
+	record := JITDumpRecordCodeLoad{}
+	err := binary.Read(file, binary.LittleEndian, &record)
+	if err != nil {
+		return nil, "", err
+	}
+
+	recordHeaderSize := uint32(16)
+	codeLoadRecordHeaderSize := uint32(40)
+	nameSize := header.TotalSize - uint32(record.CodeSize) - recordHeaderSize - codeLoadRecordHeaderSize
+	name := make([]byte, nameSize)
+	err = binary.Read(file, binary.LittleEndian, &name)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if name[nameSize-1] != '\x00' {
+		return nil, "", fmt.Errorf("Expected null terminated string, found %c", name[nameSize-1])
+	}
+
+	// Skip over the actual native code because we don't need it but we
+	// probably do want to read the next record.
+	_, err = file.Seek(int64(record.CodeSize), io.SeekCurrent)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &record, string(name), nil
+}
+
+func SkipJITDumpRecord(file io.ReadSeeker, header *JITDumpRecordHeader) error {
+	recordHeaderSize := uint64(16)
+	_, err := file.Seek(int64(header.TotalSize)-int64(recordHeaderSize), io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/libpf/frametype.go
+++ b/libpf/frametype.go
@@ -49,6 +49,8 @@ const (
 	V8Frame FrameType = support.FrameMarkerV8
 	// DotnetFrame identifies the Dotnet interpreter frames.
 	DotnetFrame FrameType = support.FrameMarkerDotnet
+	// BEAMFrame identifies the BEAM interpreter frames.
+	BEAMFrame FrameType = support.FrameMarkerBEAM
 	// AbortFrame identifies frames that report that further unwinding was aborted due to an error.
 	AbortFrame FrameType = support.FrameMarkerAbort
 )

--- a/libpf/interpretertype.go
+++ b/libpf/interpretertype.go
@@ -31,6 +31,8 @@ const (
 	V8 InterpreterType = support.FrameMarkerV8
 	// Dotnet identifies the Dotnet interpreter.
 	Dotnet InterpreterType = support.FrameMarkerDotnet
+	// BEAM identifies the BEAM interpreter.
+	BEAM InterpreterType = support.FrameMarkerBEAM
 )
 
 // Pseudo-interpreters without a corresponding frame type.
@@ -64,6 +66,7 @@ var interpreterTypeToString = map[InterpreterType]string{
 	Perl:    "perl",
 	V8:      "v8js",
 	Dotnet:  "dotnet",
+	BEAM:    "beam",
 	APMInt:  "apm-integration",
 }
 

--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -102,6 +102,7 @@ type ebpfMapsImpl struct {
 	phpProcs           *cebpf.Map
 	rubyProcs          *cebpf.Map
 	v8Procs            *cebpf.Map
+	beamProcs          *cebpf.Map
 	apmIntProcs        *cebpf.Map
 
 	// Stackdelta and process related eBPF maps
@@ -199,6 +200,12 @@ func LoadMaps(ctx context.Context, maps map[string]*cebpf.Map) (EbpfHandler, err
 	}
 	impl.v8Procs = v8Procs
 
+	beamProcs, ok := maps["beam_procs"]
+	if !ok {
+		log.Fatalf("Map beam_procs is not available")
+	}
+	impl.beamProcs = beamProcs
+
 	apmIntProcs, ok := maps["apm_int_procs"]
 	if !ok {
 		log.Fatalf("Map apm_int_procs is not available")
@@ -294,6 +301,8 @@ func (impl *ebpfMapsImpl) getInterpreterTypeMap(typ libpf.InterpreterType) (*ceb
 		return impl.rubyProcs, nil
 	case libpf.V8:
 		return impl.v8Procs, nil
+	case libpf.BEAM:
+		return impl.beamProcs, nil
 	case libpf.APMInt:
 		return impl.apmIntProcs, nil
 	default:

--- a/processmanager/execinfomanager/manager.go
+++ b/processmanager/execinfomanager/manager.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/apmint"
+	"go.opentelemetry.io/ebpf-profiler/interpreter/beam"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/hotspot"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/nodev8"
@@ -123,6 +124,9 @@ func NewExecutableInfoManager(
 	}
 	if includeTracers.Has(types.DotnetTracer) {
 		interpreterLoaders = append(interpreterLoaders, dotnet.Loader)
+	}
+	if includeTracers.Has(types.BEAMTracer) {
+		interpreterLoaders = append(interpreterLoaders, beam.Loader)
 	}
 
 	interpreterLoaders = append(interpreterLoaders, apmint.Loader)

--- a/support/ebpf/beam_tracer.ebpf.c
+++ b/support/ebpf/beam_tracer.ebpf.c
@@ -1,0 +1,37 @@
+#include "bpfdefs.h"
+#include "tracemgmt.h"
+#include "types.h"
+
+bpf_map_def SEC("maps") beam_procs = {
+  .type = BPF_MAP_TYPE_HASH,
+  .key_size = sizeof(pid_t),
+  .value_size = sizeof(BEAMProcInfo),
+  .max_entries = 1024,
+};
+
+SEC("perf_event/unwind_beam")
+int unwind_beam(struct pt_regs *ctx) {
+  static const char fmt[] = "Unwinding BEAM stack";
+  bpf_trace_printk(fmt, sizeof(fmt));
+  DEBUG_PRINT("Unwinding BEAM stack");
+
+  PerCPURecord *record = get_per_cpu_record();
+  if (!record) {
+    return -1;
+  }
+
+  int unwinder = get_next_unwinder_after_interpreter(record);
+  u32 pid = record->trace.pid;
+
+  BEAMProcInfo *beaminfo = bpf_map_lookup_elem(&beam_procs, &pid);
+  if (!beaminfo) {
+    DEBUG_PRINT("No BEAM introspection data");
+    goto exit;
+  }
+
+  DEBUG_PRINT("==== unwind_beam stack_len: %d, pid: %d ====", record->trace.stack_len, record->trace.pid);
+
+exit:
+  tail_call(ctx, unwinder);
+  return -1;
+}

--- a/support/ebpf/frametypes.h
+++ b/support/ebpf/frametypes.h
@@ -33,6 +33,8 @@
 #define FRAME_MARKER_PHP_JIT       0x9
 // Indicates a Dotnet frame
 #define FRAME_MARKER_DOTNET        0xA
+// Indicates a BEAM frame
+#define FRAME_MARKER_BEAM          0xB
 
 // Indicates a frame containing information about a critical unwinding error
 // that caused further unwinding to be aborted.

--- a/support/ebpf/types.h
+++ b/support/ebpf/types.h
@@ -328,6 +328,7 @@ typedef enum TracePrograms {
   PROG_UNWIND_RUBY,
   PROG_UNWIND_V8,
   PROG_UNWIND_DOTNET,
+  PROG_UNWIND_BEAM,
   NUM_TRACER_PROGS,
 } TracePrograms;
 
@@ -476,6 +477,11 @@ typedef struct V8ProcInfo {
   u8 fp_marker, fp_function, fp_bytecode_offset;
   u8 codekind_shift, codekind_mask, codekind_baseline;
 } V8ProcInfo;
+
+// BEAMProcInfo is a container for the data needed to build a stack trace for a BEAM process.
+typedef struct BEAMProcInfo {
+  u32 version;
+} BEAMProcInfo;
 
 // COMM_LEN defines the maximum length we will receive for the comm of a task.
 #define COMM_LEN 16

--- a/support/types.go
+++ b/support/types.go
@@ -24,6 +24,7 @@ const (
 	FrameMarkerPerl     = C.FRAME_MARKER_PERL
 	FrameMarkerV8       = C.FRAME_MARKER_V8
 	FrameMarkerDotnet   = C.FRAME_MARKER_DOTNET
+	FrameMarkerBEAM     = C.FRAME_MARKER_BEAM
 	FrameMarkerAbort    = C.FRAME_MARKER_ABORT
 )
 
@@ -37,6 +38,7 @@ const (
 	ProgUnwindPerl    = C.PROG_UNWIND_PERL
 	ProgUnwindV8      = C.PROG_UNWIND_V8
 	ProgUnwindDotnet  = C.PROG_UNWIND_DOTNET
+	ProgUnwindBEAM    = C.PROG_UNWIND_BEAM
 )
 
 const (

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -22,6 +22,7 @@ const (
 	RubyTracer
 	V8Tracer
 	DotnetTracer
+	BEAMTracer
 
 	// maxTracers indicates the max. number of different tracers
 	maxTracers
@@ -35,6 +36,7 @@ var tracerTypeToName = map[tracerType]string{
 	RubyTracer:    "ruby",
 	V8Tracer:      "v8",
 	DotnetTracer:  "dotnet",
+	BEAMTracer:    "beam",
 }
 
 var tracerNameToType = make(map[string]tracerType, maxTracers)


### PR DESCRIPTION
> [!NOTE]
> The first commit in the PR is so that this branch stacks on top of #288 while I work on this one.

I have begun to work on support for BEAM languages like Erlang and Elixir, and wanted to open this PR early as a draft, so that I can get any feedback you may have to help the process go more smoothly. I don't have much experience with Go or eBPF, so any feedback you have is very welcome. What I have so far is mostly based on digging through the existing support for other languages as well as the BEAM / OTP source code, and trying to understand how all the parts fit together.

I have also been digging through the [BEAM / OTP source code, and also the `gdb` scripts that it includes](https://github.com/erlang/otp/blob/master/erts/etc/unix/etp-commands.in) for working directly with the memory image of a running system or core dump.

So far, I am able to see the logs from my Go code coming through, and confirming that it's working correctly as far as loading and attaching the interpreter support, like this:

```
$ sudo ./ebpf-profiler -collection-agent=127.0.0.1:11000 -disable-tls
INFO[0000] Starting OTEL profiling agent v0.0.0 (revision main-67f28f2b, build timestamp 1735697412)
INFO[0000] Interpreter tracers: perl,php,python,hotspot,ruby,beam
INFO[0000] Determined PAC mask to be 0x007F000000000000
INFO[0000] Found offsets: task stack 0x38, pt_regs 0x3eb0, tpbase 0x1c30
INFO[0000] Supports generic eBPF map batch operations
INFO[0000] Supports LPM trie eBPF map batch operations
INFO[0000] eBPF tracer loaded
INFO[0000] Attached tracer program
INFO[0000] Attached sched monitor
INFO[0026] BEAM interpreter found: [beam.smp]
INFO[0026] read symbol value etp_otp_release: 27
INFO[0026] read symbol value etp_erts_version: 15.1.3
INFO[0026] BEAM loaded, otp_version: 27, interpRanges: [{718368 718496}]
INFO[0026] BEAM interpreter attaching
```

However, I can't seem to get any tracing logs out of the eBPF program, so I suspect that it's never being run. If I modify the `native` eBPF script to write the same kind of log there, I can confirm that I'm seeing it in `/sys/kernel/tracing/trace_pipe` after doing the following to narrow down the logs I want to see, but the same doesn't work for my `beam` program:

```
# echo 1 > /sys/kernel/tracing/tracing_on
# echo 0 > /sys/kernel/tracing/events/enable
# echo 1 > /sys/kernel/tracing/events/bpf_trace/bpf_trace_printk/enable
```

I was thinking that this was because OTP 27 includes a JIT, so the interpreter might never be used, but I am also not seeing any frames for the native JIT code executing, so I'd love any advice you may have there in terms of how I might go about troubleshooting that. Maybe the native unwinder is just missing some heuristic that's needed for the way the ASMJIT / BEAMJIT works? I'm not clear on how the profiler resolves symbols for JIT code or how those should show up in `devfiler`, so maybe it is working and I just don't know how to use to the tool... 😅 But from what I can tell, I don't think the frames are showing up there for anything but the C code for Erlang itself (and built-in C functions). I was expecting to be able to see which Erlang code was running, for example.

I also tried building OTP 27 with the JIT disabled to confirm my theory that it just wasn't working, but it behaved the same (though with a different memory address showing for the `interpRanges`, which confirms that it really did build a different set of code).