### PR TITLE
Fix cross-compilation (#282)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 	@rm -rf go .cache
 
 generate:
-	go generate ./...
+	GOARCH=$(NATIVE_ARCH) go generate ./...
 
 ebpf:
 	$(MAKE) $(EBPF_FLAGS) -C support/ebpf


### PR DESCRIPTION
### Summary

Always use `NATIVE_ARCH` as `GOARCH` for `go:generate`. The previous approach will fail on systems that can't execute cross-compiled binaries on the build host (e.g. if an appropriate `qemu` binary is not installed).
 
Fixes #282.
