### PR TITLE
docker: build and push docker builder image

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,36 @@
+name: "Update builder docker image"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/workflows/env
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set current timestamp tag
+        id: tag
+        run: |
+          echo "tag=$(date +%Y%m%d%H%M)" >> $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: otel/opentelemetry-ebpf-profiler-dev:latest,otel/opentelemetry-ebpf-profiler-dev:${{ steps.tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:testing-20241223-slim
 
 WORKDIR /agent
 

--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,11 @@ docker-image:
 	docker build -t profiling-agent -f Dockerfile .
 
 agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) profiling-agent \
+	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
 	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
 
 debug-agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) profiling-agent \
+	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
 	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) debug"
 
 legal:


### PR DESCRIPTION
With https://github.com/open-telemetry/community/issues/2283 a Docker repo was requested and provided to host docker images for this project.

This PR helps bringing back reproducible builds. As this project does not yet produce releases the tags `latest`, that will be overwritten every time, and a timestamp are used instead.