### PR TITLE
Send process name as process.executable.name (/proc/PID/comm)

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -48,7 +48,8 @@ type Frame struct {
 
 type Trace struct {
 	Comm             string
-	Executable       string
+	ProcessName      string
+	ExecutablePath   string
 	Frames           []Frame
 	Hash             TraceHash
 	KTime            times.KTime

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -649,14 +649,12 @@ func (pm *ProcessManager) CleanupPIDs() {
 // NameForPID returns the process name for given PID.
 // If the PID is not tracked it returns the empty string.
 func (pm *ProcessManager) NameForPID(pid libpf.PID) string {
-	var name string
-
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		name = procInfo.name
+		return procInfo.name
 	}
-	return name
+	return ""
 }
 
 // ExePathForPID returns the full executable path for given PID.

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -82,9 +82,14 @@ func (pm *ProcessManager) updatePidInformation(pid libpf.PID, m *Mapping) (bool,
 	if !ok {
 		// We don't have information for this pid, so we first need to
 		// allocate the embedded map for this process.
-		executable, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+		var processName string
+		exePath, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+		if name, err := os.ReadFile(fmt.Sprintf("/prod/%d/comm", pid)); err == nil {
+			processName = string(name)
+		}
 		info = &processInfo{
-			executable:       executable,
+			name:             processName,
+			executable:       exePath,
 			mappings:         make(map[libpf.Address]*Mapping),
 			mappingsByFileID: make(map[host.FileID]map[libpf.Address]*Mapping),
 			tsdInfo:          nil,
@@ -639,6 +644,19 @@ func (pm *ProcessManager) CleanupPIDs() {
 	if len(deadPids) > 0 {
 		log.Debugf("Cleaned up %d dead PIDs", len(deadPids))
 	}
+}
+
+// NameForPID returns the process name for given PID.
+// If the PID is not tracked it returns the empty string.
+func (pm *ProcessManager) NameForPID(pid libpf.PID) string {
+	var name string
+
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
+		name = procInfo.name
+	}
+	return name
 }
 
 // ExePathForPID returns the full executable path for given PID.

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -138,6 +138,8 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
+	// process name retrieved from /proc/PID/comm
+	name string
 	// executable path retrieved from /proc/PID/exe
 	executable string
 	// executable mappings keyed by start address.

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -114,7 +114,8 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *TraceEventMeta
 	key := samples.TraceAndMetaKey{
 		Hash:           trace.Hash,
 		Comm:           meta.Comm,
-		Executable:     meta.Executable,
+		ProcessName:    meta.ProcessName,
+		ExecutablePath: meta.ExecutablePath,
 		ApmServiceName: meta.APMServiceName,
 		ContainerID:    containerID,
 		Pid:            int64(meta.PID),

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -178,7 +178,9 @@ func (p *Pdata) setProfile(
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ThreadNameKey, traceKey.Comm)
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
-			semconv.ProcessExecutablePathKey, traceKey.Executable)
+			semconv.ProcessExecutableNameKey, traceKey.ProcessName)
+		attrMgr.AppendOptionalString(sample.AttributeIndices(),
+			semconv.ProcessExecutablePathKey, traceKey.ExecutablePath)
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ServiceNameKey, traceKey.ApmServiceName)
 		attrMgr.AppendInt(sample.AttributeIndices(),

--- a/reporter/internal/samples/samples.go
+++ b/reporter/internal/samples/samples.go
@@ -8,7 +8,8 @@ import "go.opentelemetry.io/ebpf-profiler/libpf"
 type TraceEventMeta struct {
 	Timestamp      libpf.UnixTime64
 	Comm           string
-	Executable     string
+	ProcessName    string
+	ExecutablePath string
 	APMServiceName string
 	PID, TID       libpf.PID
 	CPU            int
@@ -36,8 +37,10 @@ type TraceAndMetaKey struct {
 	// containerID is annotated based on PID information
 	ContainerID string
 	Pid         int64
+	// Process name is retrieved from /proc/PID/comm
+	ProcessName string
 	// Executable path is retrieved from /proc/PID/exe
-	Executable string
+	ExecutablePath string
 	// ExtraMeta stores extra meta info that may have been produced by a
 	// `SampleAttrProducer` instance. May be nil.
 	ExtraMeta any

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -127,7 +127,8 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 		TID:            bpfTrace.TID,
 		APMServiceName: "", // filled in below
 		CPU:            bpfTrace.CPU,
-		Executable:     bpfTrace.Executable,
+		ProcessName:    bpfTrace.ProcessName,
+		ExecutablePath: bpfTrace.ExecutablePath,
 	}
 
 	if !m.reporter.SupportsReportTraceEvent() {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -859,7 +859,8 @@ func (t *Tracer) loadBpfTrace(raw []byte, cpu int) *host.Trace {
 	pid := libpf.PID(ptr.pid)
 	trace := &host.Trace{
 		Comm:             C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
-		Executable:       t.processManager.ExePathForPID(pid),
+		ExecutablePath:   t.processManager.ExePathForPID(pid),
+		ProcessName:      t.processManager.NameForPID(pid),
 		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.apm_trace_id)),
 		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.apm_transaction_id)),
 		PID:              pid,


### PR DESCRIPTION
### Summary

This PR adds support for sending process name as `process.executable.name`, abiding by current OTel [semantics](https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/#process-executable-name) for that key. Instead of `Name` in `/prod/PID/status` as semconv dictates, I'm using [/proc/PID/comm](https://man7.org/linux/man-pages/man5/proc_pid_comm.5.html) which contains the same value and is simpler to parse.

Regarding these semantics, I also started a discussion in semconv WG to improve clarity as `process.executable.name` is misleading/confusing/wrong depending on interpretation so we may end up changing the key in the future.