### PR TITLE
Switch semantics for process.executable.name

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -5,6 +5,7 @@ package pdata // import "go.opentelemetry.io/ebpf-profiler/reporter/internal/pda
 
 import (
 	"crypto/rand"
+	"path/filepath"
 	"slices"
 	"time"
 
@@ -198,14 +199,21 @@ func (p *Pdata) setProfile(
 			}
 		}
 
+		exeName := traceKey.ExecutablePath
+		if exeName != "" {
+			_, exeName = filepath.Split(exeName)
+		}
+
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ContainerIDKey, traceKey.ContainerID)
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ThreadNameKey, traceKey.Comm)
+
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
-			semconv.ProcessExecutableNameKey, traceKey.ProcessName)
+			semconv.ProcessExecutableNameKey, exeName)
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ProcessExecutablePathKey, traceKey.ExecutablePath)
+
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ServiceNameKey, traceKey.ApmServiceName)
 		attrMgr.AppendInt(sample.AttributeIndices(),


### PR DESCRIPTION
### Summary

`process.executable.name` is now the base executable name, instead of process name.

**TODO**:

~1. Use newly introduced key (`process.name`) for process name~ No consensus in semconv for that key, yet.

We can review/merge this PR now and introduce `process.name` if/when it gets merged in semconv.

**Also see**:

- https://github.com/open-telemetry/semantic-conventions/issues/1736
- https://github.com/open-telemetry/semantic-conventions/issues/1928