### PR TITLE
Rework SymbolizationComplete

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -353,7 +353,7 @@ func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime times.KTime) {
 	defer pm.mu.Unlock()
 
 	nowKTime := times.GetKTime()
-	log.Warnf("SymbolizationComplete captureKT: %v latency: %v ms",
+	log.Debugf("SymbolizationComplete captureKT: %v latency: %v ms",
 		traceCaptureKTime, (nowKTime-traceCaptureKTime)/1e6)
 
 	for pid, pidExitKTime := range pm.exitEvents {

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -353,6 +353,8 @@ func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime times.KTime) {
 	defer pm.mu.Unlock()
 
 	nowKTime := times.GetKTime()
+	log.Warnf("SymbolizationComplete captureKT: %v latency: %v ms",
+		traceCaptureKTime, (nowKTime-traceCaptureKTime)/1e6)
 
 	for pid, pidExitKTime := range pm.exitEvents {
 		if pidExitKTime > traceCaptureKTime {

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -192,7 +192,9 @@ func Start(ctx context.Context, rep reporter.TraceReporter, traceProcessor Trace
 		for {
 			select {
 			case traceUpdate := <-traceInChan:
-				handler.HandleTrace(traceUpdate)
+				if traceUpdate != nil {
+					handler.HandleTrace(traceUpdate)
+				}
 			case <-metricsTicker.C:
 				handler.collectMetrics()
 			case <-ctx.Done():

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -118,14 +118,8 @@ func newTraceHandler(rep reporter.TraceReporter, traceProcessor TraceProcessor,
 }
 
 func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
-	if bpfTrace == nil {
-		return
-	}
-	defer m.traceProcessor.SymbolizationComplete(bpfTrace.KTime)
-	timestamp := libpf.UnixTime64(bpfTrace.KTime.UnixNano())
-
 	meta := &samples.TraceEventMeta{
-		Timestamp:      timestamp,
+		Timestamp:      libpf.UnixTime64(bpfTrace.KTime.UnixNano()),
 		Comm:           bpfTrace.Comm,
 		PID:            bpfTrace.PID,
 		TID:            bpfTrace.TID,

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -199,14 +199,14 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 			// smaller than the former) to take into account scheduling delays
 			// that could in theory result in observed KTime going back in time.
 			if oldKTime > 0 {
-				kt := oldKTime
-				if minKTime > 0 && minKTime < kt {
-					// If current minKTime is smaller than oldKTime, use it
-					// instead of oldKTime (and set it to 0 to avoid a repeat).
-					kt = minKTime
+				if oldKTime <= minKTime {
+					t.TraceProcessor().SymbolizationComplete(oldKTime)
+				} else {
+					// If minKTime is smaller than oldKTime, use it
+					// and reset it to avoid a repeat.
+					t.TraceProcessor().SymbolizationComplete(minKTime)
 					minKTime = 0
 				}
-				t.TraceProcessor().SymbolizationComplete(kt)
 			}
 			oldKTime = minKTime
 		}

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -208,13 +208,13 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 			// the current iteration minKTime we'll call
 			// SymbolizationComplete(t1) first and t0 next, with t0 < t1.
 			if oldKTime > 0 {
-				if oldKTime <= minKTime {
-					t.TraceProcessor().SymbolizationComplete(oldKTime)
-				} else {
-					// If minKTime is smaller than oldKTime, use it
-					// and reset it to avoid a repeat.
+				if minKTime > 0 && minKTime <= oldKTime {
+					// If minKTime is smaller than oldKTime, use it and reset it
+					// to avoid a repeat during next iteration.
 					t.TraceProcessor().SymbolizationComplete(minKTime)
 					minKTime = 0
+				} else {
+					t.TraceProcessor().SymbolizationComplete(oldKTime)
 				}
 			}
 			oldKTime = minKTime

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -208,6 +208,9 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 			// the current iteration minKTime we'll call
 			// SymbolizationComplete(t1) first and t0 next, with t0 < t1.
 			if oldKTime > 0 {
+				// Ensure that all previously sent trace events have been processed
+				traceOutChan <- nil
+
 				if minKTime > 0 && minKTime <= oldKTime {
 					// If minKTime is smaller than oldKTime, use it and reset it
 					// to avoid a repeat during next iteration.


### PR DESCRIPTION
### Summary

Updated `SymbolizationComplete` mechanism to reflect current semantics around trace processing and timestamping (no batching, in-kernel high resolution timestamps):

- Don't call `SymbolizationComplete` per-Trace, instead call it after each iteration of the perf event batch-drain loop. This introduces a call frequency upper bound (currently: 4Hz).
- Keep track of minimum `KTime` seen during trace event retrieval and report the minimum `KTime` belonging to the previous processing iteration with `SymbolizationComplete`.
- `startPollingPerfEventMonitor` is now specialized to trace event processing, this also simplifies caller logic.


**TODO:**

1. ~Generify `SymbolizationComplete`, fix #278~ Will open new PR for this.

**Also see:**
- #301 
