### PR TITLE
Bump golangci-lint to 1.63.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,13 @@ issues:
     - virt-tests
     - vm-images
 
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Don't complain about integer overflows
+    - text: "G115:"
+      linters:
+        - gosec
+
 linters:
   enable-all: true
   disable:
@@ -58,7 +65,6 @@ linters:
     - godot
     - godox # complains about TODO etc
     - gofumpt
-    - gomnd
     - gomoddirectives
     - inamedparam
     - interfacebloat
@@ -86,7 +92,7 @@ linters:
     - wsl
     - wrapcheck
     # the following linters are deprecated
-    - execinquery
+    - exportloopref
     # we don't want to change code to Go 1.22+ yet
     - intrange
     - copyloopvar

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ebpf:
 ebpf-profiler: generate ebpf
 	go build $(GO_FLAGS) -tags $(GO_TAGS)
 
-GOLANGCI_LINT_VERSION = "v1.60.1"
+GOLANGCI_LINT_VERSION = "v1.63.4"
 lint: generate vanity-import-check
 	$(MAKE) lint -C support/ebpf
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version

--- a/libpf/basehash/hash128.go
+++ b/libpf/basehash/hash128.go
@@ -19,7 +19,7 @@ import (
 //
 // hi represents the most significant 64 bits and lo represents the least
 // significant 64 bits.
-type Hash128 struct {
+type Hash128 struct { //nolint:recvcheck
 	hi uint64
 	lo uint64
 }

--- a/libpf/frameid.go
+++ b/libpf/frameid.go
@@ -113,7 +113,7 @@ func (f FrameID) AddressOrLine() AddressOrLineno {
 
 // AsIP returns the FrameID as a net.IP type to be used
 // for the PC range in profiling-symbols-*.
-func (f *FrameID) AsIP() net.IP {
+func (f FrameID) AsIP() net.IP {
 	bytes := f.Bytes()
 	ip := make([]byte, 16)
 	copy(ip[:8], bytes[:8])  // first 64bits of FileID

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -120,7 +120,7 @@ func generateDummyFiles(t *testing.T, num int) []string {
 
 	for i := 0; i < num; i++ {
 		name := fmt.Sprintf("dummy%d", i)
-		tmpfile, err := os.CreateTemp("", "*"+name)
+		tmpfile, err := os.CreateTemp(t.TempDir(), "*"+name)
 		require.NoError(t, err)
 
 		// The generated fileID is based on the content of the file.
@@ -381,10 +381,6 @@ func TestNewMapping(t *testing.T) {
 			expectedStackDeltas: 27},
 	}
 
-	cacheDir, err := os.MkdirTemp("", "*_cacheDir")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
-
 	for name, testcase := range tests {
 		testcase := testcase
 		t.Run(name, func(t *testing.T) {
@@ -419,11 +415,6 @@ func TestNewMapping(t *testing.T) {
 			}
 
 			execs := generateDummyFiles(t, len(testcase.newMapping))
-			defer func() {
-				for _, exe := range execs {
-					os.Remove(exe)
-				}
-			}()
 
 			if testcase.duplicate {
 				execs = append(execs, execs...)

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -25,7 +25,7 @@ const (
 
 // Generate generates a pdata request out of internal profiles data, to be
 // exported.
-func (p Pdata) Generate(events map[libpf.Origin]samples.KeyToEventMapping) pprofile.Profiles {
+func (p *Pdata) Generate(events map[libpf.Origin]samples.KeyToEventMapping) pprofile.Profiles {
 	profiles := pprofile.NewProfiles()
 	rp := profiles.ResourceProfiles().AppendEmpty()
 	sp := rp.ScopeProfiles().AppendEmpty()

--- a/reporter/internal/pdata/pdata.go
+++ b/reporter/internal/pdata/pdata.go
@@ -57,7 +57,7 @@ func New(samplesPerSecond int, executablesCacheElements, framesCacheElements uin
 }
 
 // Purge purges all the expired data
-func (p Pdata) Purge() {
+func (p *Pdata) Purge() {
 	p.Executables.PurgeExpired()
 	p.Frames.PurgeExpired()
 }

--- a/tools/zstpak/lib/zstpak_test.go
+++ b/tools/zstpak/lib/zstpak_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/ebpf-profiler/testsupport"
 	zstpak "go.opentelemetry.io/ebpf-profiler/tools/zstpak/lib"
 )
@@ -27,9 +28,8 @@ func testRandomAccesses(t *testing.T, seqLen uint8, fileSize uint64,
 	file := generateInputFile(seqLen, fileSize)
 	reader := bytes.NewReader(file)
 
-	temp, err := os.CreateTemp("", "")
+	temp, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
-	defer os.Remove(temp.Name())
 
 	err = zstpak.CompressInto(reader, temp, chunkSize)
 	require.NoError(t, err)


### PR DESCRIPTION
Update golangci-lint to 1.63.4.

**Noteworthy changes**

- Fixing `.golangci-lint` for
```
WARN [lintersdb] The linter "gomnd" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "execinquery" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```

- Suppressing `gosec` integer overflow warnings (G115 rule), following https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36913
  Fixing the reported integer overflows mostly ends up with disabling the `gosec` linter.
  Instead of doing so, this should be well thought of case-by-case in follow-up PRs.
