### PR TITLE
CI: reduce boiler plate of environment

### DIFF
--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -27,7 +27,7 @@ runs:
         sudo dpkg --add-architecture arm64
         sudo apt-get update -y
 
-        sudo apt-get install -y llvm clang dwz curl unzip gcc-aarch64-linux-gnu \
+        sudo apt-get install -y curl unzip gcc-aarch64-linux-gnu \
           libc6-arm64-cross qemu-user-binfmt libc6:arm64
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -32,7 +32,6 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.23"
-        check-latest: true
+        go-version-file: go.mod
         cache-dependency-path: go.sum
       id: go

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -1,7 +1,6 @@
 package pdata
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -210,11 +209,35 @@ func TestFunctionTableOrder(t *testing.T) {
 							libpf.AddressOrLineno(0x3ef),
 							libpf.AddressOrLineno(0x4ef),
 						},
-						FrameTypes:         slices.Repeat([]libpf.FrameType{libpf.KernelFrame}, 5),
-						MappingStarts:      slices.Repeat([]libpf.Address{libpf.Address(0)}, 5),
-						MappingEnds:        slices.Repeat([]libpf.Address{libpf.Address(0)}, 5),
-						MappingFileOffsets: slices.Repeat([]uint64{0}, 5),
-						Timestamps:         []uint64{1, 2, 3, 4, 5},
+						FrameTypes: []libpf.FrameType{
+							libpf.KernelFrame,
+							libpf.KernelFrame,
+							libpf.KernelFrame,
+							libpf.KernelFrame,
+							libpf.KernelFrame,
+						},
+						MappingStarts: []libpf.Address{
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+						},
+						MappingEnds: []libpf.Address{
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+							libpf.Address(0),
+						},
+						MappingFileOffsets: []uint64{
+							0,
+							0,
+							0,
+							0,
+							0,
+						},
+						Timestamps: []uint64{1, 2, 3, 4, 5},
 					},
 				},
 			},


### PR DESCRIPTION
Drop installation of dependencies, that are not used and use `go.mod` as single source of truth for the installed Go version.