### PR TITLE
reporter/collector: fix reporting issue

### DIFF
--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -112,14 +112,12 @@ func (r *CollectorReporter) GetMetrics() Metrics {
 // reportProfile creates and sends out a profile.
 func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	traceEvents := r.traceEvents.WLock()
-	events := maps.Clone(*traceEvents)
-	originsMap := make(map[libpf.Origin]samples.KeyToEventMapping, 2)
-	clear(*traceEvents)
+	events := make(map[libpf.Origin]samples.KeyToEventMapping, 2)
 	for _, origin := range []libpf.Origin{support.TraceOriginSampling,
 		support.TraceOriginOffCPU} {
-		originsMap[origin] = make(samples.KeyToEventMapping)
+		events[origin] = maps.Clone((*traceEvents)[origin])
+		clear((*traceEvents)[origin])
 	}
-	*traceEvents = originsMap
 	r.traceEvents.WUnlock(&traceEvents)
 
 	profiles := r.pdata.Generate(events)

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -113,7 +113,13 @@ func (r *CollectorReporter) GetMetrics() Metrics {
 func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	traceEvents := r.traceEvents.WLock()
 	events := maps.Clone(*traceEvents)
+	originsMap := make(map[libpf.Origin]samples.KeyToEventMapping, 2)
 	clear(*traceEvents)
+	for _, origin := range []libpf.Origin{support.TraceOriginSampling,
+		support.TraceOriginOffCPU} {
+		originsMap[origin] = make(samples.KeyToEventMapping)
+	}
+	*traceEvents = originsMap
 	r.traceEvents.WUnlock(&traceEvents)
 
 	profiles := r.pdata.Generate(events)

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -169,14 +169,12 @@ func (r *OTLPReporter) Start(ctx context.Context) error {
 // reportOTLPProfile creates and sends out an OTLP profile.
 func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	traceEvents := r.traceEvents.WLock()
-	events := maps.Clone(*traceEvents)
-	originsMap := make(map[libpf.Origin]samples.KeyToEventMapping, 2)
-	clear(*traceEvents)
+	events := make(map[libpf.Origin]samples.KeyToEventMapping, 2)
 	for _, origin := range []libpf.Origin{support.TraceOriginSampling,
 		support.TraceOriginOffCPU} {
-		originsMap[origin] = make(samples.KeyToEventMapping)
+		events[origin] = maps.Clone((*traceEvents)[origin])
+		clear((*traceEvents)[origin])
 	}
-	*traceEvents = originsMap
 	r.traceEvents.WUnlock(&traceEvents)
 
 	profiles := r.pdata.Generate(events)


### PR DESCRIPTION
If the OTel collector reports profiles it clears all map entries. So to be able to report new events, the base structure needs to exist.

Thanks @rockdaboot for reporting.