### PR TITLE
Delayed processing for ProcessManager.pidToProcessInfo

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -293,33 +293,6 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 	return newTrace
 }
 
-// findMappingForTrace locates the mapping for a given host trace.
-func (pm *ProcessManager) findMappingForTrace(pid libpf.PID, fid host.FileID,
-	addr libpf.AddressOrLineno) (m Mapping, found bool) {
-	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-
-	procInfo, ok := pm.pidToProcessInfo[pid]
-	if !ok {
-		return Mapping{}, false
-	}
-
-	fidMappings, ok := procInfo.mappingsByFileID[fid]
-	if !ok {
-		return Mapping{}, false
-	}
-
-	for _, candidate := range fidMappings {
-		procSpaceVA := libpf.Address(uint64(addr) + candidate.Bias)
-		mappingEnd := candidate.Vaddr + libpf.Address(candidate.Length)
-		if procSpaceVA >= candidate.Vaddr && procSpaceVA <= mappingEnd {
-			return *candidate, true
-		}
-	}
-
-	return Mapping{}, false
-}
-
 func (pm *ProcessManager) MaybeNotifyAPMAgent(
 	rawTrace *host.Trace, umTraceHash libpf.TraceHash, count uint16) string {
 	pidInterp, ok := pm.interpreters[rawTrace.PID]

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -360,6 +360,9 @@ func (pm *ProcessManager) ProcessedUntil(traceCaptureKTime times.KTime) {
 		if pidExitKTime > traceCaptureKTime {
 			continue
 		}
+
+		delete(pm.pidToProcessInfo, pid)
+
 		for _, instance := range pm.interpreters[pid] {
 			if err := instance.Detach(pm.ebpf, pid); err != nil {
 				log.Errorf("Failed to handle interpreted process exit for PID %d: %v",

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -348,12 +348,12 @@ func (pm *ProcessManager) MaybeNotifyAPMAgent(
 	return serviceName
 }
 
-func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime times.KTime) {
+func (pm *ProcessManager) ProcessedUntil(traceCaptureKTime times.KTime) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
 	nowKTime := times.GetKTime()
-	log.Debugf("SymbolizationComplete captureKT: %v latency: %v ms",
+	log.Debugf("ProcessedUntil captureKT: %v latency: %v ms",
 		traceCaptureKTime, (nowKTime-traceCaptureKTime)/1e6)
 
 	for pid, pidExitKTime := range pm.exitEvents {

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -602,7 +602,7 @@ func TestProcExit(t *testing.T) {
 
 			populateManager(t, manager)
 
-			_ = manager.ProcessPIDExit(testcase.pid)
+			manager.ProcessPIDExit(testcase.pid)
 			assert.Equal(t, testcase.deletePidPageMappingCount,
 				ebpfMockup.deletePidPageMappingCount)
 			assert.Equal(t, testcase.deleteStackDeltaRangesCount,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -520,13 +520,13 @@ func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	pidExited := false
+	pidExitProcessed := false
 	info, pidExists := pm.pidToProcessInfo[pid]
 	if pidExists || (pm.interpreterTracerEnabled &&
 		len(pm.interpreters[pid]) > 0) {
 		// ProcessPIDExit may be called multiple times in short succession
 		// for the same PID, don't update exitKTime if we've previously recorded it.
-		if _, pidExited = pm.exitEvents[pid]; !pidExited {
+		if _, pidExitProcessed = pm.exitEvents[pid]; !pidExitProcessed {
 			pm.exitEvents[pid] = exitKTime
 		}
 	}
@@ -534,7 +534,7 @@ func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) {
 		log.Debugf("Skip process exit handling for unknown PID %d", pid)
 		return
 	}
-	if pidExited {
+	if pidExitProcessed {
 		log.Debugf("Skip duplicate process exit handling for PID %d", pid)
 		return
 	}

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -47,11 +47,11 @@ type TraceProcessor interface {
 	// the frame and send the associated metadata to the collection agent.
 	ConvertTrace(trace *host.Trace) *libpf.Trace
 
-	// SymbolizationComplete is called after a group of Trace has been symbolized.
+	// ProcessedUntil is called periodically after Traces are processed/symbolized.
 	// It gets the timestamp of when the Traces (if any) were captured. The timestamp
 	// is in essence an indicator that all Traces until that time have been now processed,
-	// and any events up to this time can be processed.
-	SymbolizationComplete(traceCaptureKTime times.KTime)
+	// and any events and cleanup actions up to this time can be processed.
+	ProcessedUntil(traceCaptureKTime times.KTime)
 }
 
 // traceHandler provides functions for handling new traces and trace count updates

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -40,7 +40,7 @@ func (f *fakeTraceProcessor) ConvertTrace(trace *host.Trace) *libpf.Trace {
 	return &newTrace
 }
 
-func (f *fakeTraceProcessor) SymbolizationComplete(times.KTime) {}
+func (f *fakeTraceProcessor) ProcessedUntil(times.KTime) {}
 
 func (f *fakeTraceProcessor) MaybeNotifyAPMAgent(*host.Trace, libpf.TraceHash, uint16) string {
 	return ""

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -190,9 +190,9 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 				traceOutChan <- trace
 			}
 			// After we've received and processed all trace events, call
-			// SymbolizationComplete if there is a pending oldKTime that we
+			// ProcessedUntil if there is a pending oldKTime that we
 			// haven't yet propagated to the rest of the agent.
-			// This introduces both an upper bound to SymbolizationComplete
+			// This introduces both an upper bound to ProcessedUntil
 			// call frequency (dictated by pollTicker) but also skips calls
 			// when none are needed (e.g. no trace events have been read).
 			//
@@ -206,7 +206,7 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 			// timestamps t0 < t1 < t2 < t3, this poll loop reads [t3 t1 t2]
 			// in a first iteration and [t0] in a second iteration. If we use
 			// the current iteration minKTime we'll call
-			// SymbolizationComplete(t1) first and t0 next, with t0 < t1.
+			// ProcessedUntil(t1) first and t0 next, with t0 < t1.
 			if oldKTime > 0 {
 				// Ensure that all previously sent trace events have been processed
 				traceOutChan <- nil
@@ -214,10 +214,10 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 				if minKTime > 0 && minKTime <= oldKTime {
 					// If minKTime is smaller than oldKTime, use it and reset it
 					// to avoid a repeat during next iteration.
-					t.TraceProcessor().SymbolizationComplete(minKTime)
+					t.TraceProcessor().ProcessedUntil(minKTime)
 					minKTime = 0
 				} else {
-					t.TraceProcessor().SymbolizationComplete(oldKTime)
+					t.TraceProcessor().ProcessedUntil(oldKTime)
 				}
 			}
 			oldKTime = minKTime


### PR DESCRIPTION
### Summary

- Renamed `SymbolizationComplete` to `ProcessedUntil` and moved to `processinfo.go`
- Dropped no longer needed "symbolize now" remnants
- Implemented delayed `ProcessManager.pidToProcessInfo` cleanup

Leverages #307 to ensure that process metadata is not discarded before all relevant trace events have been processed. 

Fixes #278.

You may find reviewing commit-by-commit to be simpler.