### PR TITLE
processmanager: simplify API and return early

### DIFF
--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -602,7 +602,7 @@ func TestProcExit(t *testing.T) {
 
 			populateManager(t, manager)
 
-			manager.ProcessPIDExit(testcase.pid)
+			manager.processPIDExit(testcase.pid)
 			assert.Equal(t, testcase.deletePidPageMappingCount,
 				ebpfMockup.deletePidPageMappingCount)
 			assert.Equal(t, testcase.deleteStackDeltaRangesCount,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -520,6 +520,10 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 	defer pm.mu.Unlock()
 
 	info, pidExists := pm.pidToProcessInfo[pid]
+	if !pidExists {
+		log.Debugf("Skip process exit handling for unknown PID %d", pid)
+		return
+	}
 	if pidExists || (pm.interpreterTracerEnabled &&
 		len(pm.interpreters[pid]) > 0) {
 		// ProcessPIDExit may be called multiple times in short succession
@@ -530,10 +534,6 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 			log.Debugf("Skip duplicate process exit handling for PID %d", pid)
 			return
 		}
-	}
-	if !pidExists {
-		log.Debugf("Skip process exit handling for unknown PID %d", pid)
-		return
 	}
 
 	// Delete all entries we have for this particular PID from pid_page_to_mapping_info.

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -524,8 +524,7 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 		log.Debugf("Skip process exit handling for unknown PID %d", pid)
 		return
 	}
-	if pidExists || (pm.interpreterTracerEnabled &&
-		len(pm.interpreters[pid]) > 0) {
+	if pm.interpreterTracerEnabled && len(pm.interpreters[pid]) > 0 {
 		// ProcessPIDExit may be called multiple times in short succession
 		// for the same PID, don't update exitKTime if we've previously recorded it.
 		if _, pidExitProcessed := pm.exitEvents[pid]; !pidExitProcessed {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -507,12 +507,11 @@ func (pm *ProcessManager) synchronizeMappings(pr process.Process,
 	return newProcess
 }
 
-// ProcessPIDExit informs the ProcessManager that a process exited and no longer will be scheduled.
+// processPIDExit informs the ProcessManager that a process exited and no longer will be scheduled.
 // exitKTime is stored for later processing in ProcessedUntil, when traces up to this time have been
 // processed. There can be a race condition if we can not clean up the references for this process
 // fast enough and this particular pid is reused again by the system.
-// NOTE: Exported only for tracer.
-func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) {
+func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 	exitKTime := times.GetKTime()
 	log.Debugf("- PID: %v", pid)
 	defer pm.ebpf.RemoveReportedPID(pid)
@@ -520,22 +519,20 @@ func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	pidExitProcessed := false
 	info, pidExists := pm.pidToProcessInfo[pid]
 	if pidExists || (pm.interpreterTracerEnabled &&
 		len(pm.interpreters[pid]) > 0) {
 		// ProcessPIDExit may be called multiple times in short succession
 		// for the same PID, don't update exitKTime if we've previously recorded it.
-		if _, pidExitProcessed = pm.exitEvents[pid]; !pidExitProcessed {
+		if _, pidExitProcessed := pm.exitEvents[pid]; !pidExitProcessed {
 			pm.exitEvents[pid] = exitKTime
+		} else {
+			log.Debugf("Skip duplicate process exit handling for PID %d", pid)
+			return
 		}
 	}
 	if !pidExists {
 		log.Debugf("Skip process exit handling for unknown PID %d", pid)
-		return
-	}
-	if pidExitProcessed {
-		log.Debugf("Skip duplicate process exit handling for PID %d", pid)
 		return
 	}
 
@@ -555,6 +552,8 @@ func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) {
 	}
 }
 
+// SynchronizeProcess triggers ProcessManager to update its internal information
+// about a process. This includes process exit information as well as changed memory mappings.
 func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	pid := pr.PID()
 	log.Debugf("= PID: %v", pid)
@@ -576,7 +575,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 
 		// All other errors imply that the process has exited.
 		// Clean up, and notify eBPF.
-		pm.ProcessPIDExit(pid)
+		pm.processPIDExit(pid)
 		if os.IsNotExist(err) {
 			// Since listing /proc and opening files in there later is inherently racy,
 			// we expect to lose the race sometimes and thus expect to hit os.IsNotExist.
@@ -602,7 +601,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		//    the process is changing: all mappings, comm, etc. If execve fails, we
 		//    reaped it early. If execve succeeds, we will get new synchronization
 		//    request soon, and handle it as a new process event.
-		pm.ProcessPIDExit(pid)
+		pm.processPIDExit(pid)
 		return
 	}
 
@@ -640,7 +639,7 @@ func (pm *ProcessManager) CleanupPIDs() {
 	pm.mu.RUnlock()
 
 	for _, pid := range deadPids {
-		pm.ProcessPIDExit(pid)
+		pm.processPIDExit(pid)
 	}
 
 	if len(deadPids) > 0 {


### PR DESCRIPTION
This change can be reviewed commit by commit.

`processmanager: make ProcessPIDExit private`
The recommended way to report new mappings or exited process SynchronizeProcess() should be used.

`processmanager: return early in processPIDExit()`
Return early from processPIDExit() if pm.pidToProcessInfo is not aware of a paritcular PID. This early return is possible, as processPIDExit() holds the global ProcessManager lock and entries in pm.pidToProcessInfo, pm.interpreters and pm.exitEvents are cleared in ProcessedUntil() while holding the lock.