### PR TITLE
rust: drop anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,6 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "symblib"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "base64",
  "cpp_demangle",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ debug-assertions = true
 opt-level = 1 # default of 0 is annoyingly slow
 
 [workspace.dependencies]
-anyhow = "1"
 argh = "0.1"
 base64 = "0.22.0"
 cpp_demangle = "0.4"

--- a/rust-crates/symblib/Cargo.toml
+++ b/rust-crates/symblib/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 base64.workspace = true
 cpp_demangle.workspace = true
 fallible-iterator.workspace = true


### PR DESCRIPTION
Avoid unused dependency warnings by removing those from the dependency list.