### PR TITLE
Use dummy support for any non-arm64 and non-amd64 archs

### DIFF
--- a/support/support_amd64.go
+++ b/support/support_amd64.go
@@ -1,4 +1,4 @@
-//go:build amd64 && !dummy
+//go:build amd64
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/support/support_arm64.go
+++ b/support/support_arm64.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !dummy
+//go:build arm64
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/support/support_others.go
+++ b/support/support_others.go
@@ -1,4 +1,4 @@
-//go:build dummy
+//go:build !arm64 && !amd64
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This is a follow-up to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/332
In any architecture other than ARM64 and AMD64, we need this dummy tracerData so the architecture can use `libpf` as a library.

Support for these architectures is required by OpenTelemetry Collector Contrib.
See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13069379268/job/36467659832?pr=37567