### PR TITLE
cargo: set license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "0.0.0"
 rust-version = "1.77"
+license = "Apache-2.0"
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Cargo tools use the license field to identify and recognize the correct license of the workspace.