### PR TITLE
drop host.TraceHash

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -12,11 +12,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/times"
 )
 
-// TraceHash is used for unique identifiers for traces, and is required to be 64-bits
-// due to the constraints imposed by the eBPF maps, unlike the larger TraceHash used
-// outside the host agent.
-type TraceHash uint64
-
 // FileID is used for unique identifiers for files, and is required to be 64-bits
 // due to the constraints imposed by the eBPF maps, unlike the larger FileID used
 // outside the host agent.
@@ -51,7 +46,7 @@ type Trace struct {
 	ProcessName      string
 	ExecutablePath   string
 	Frames           []Frame
-	Hash             TraceHash
+	Hash             libpf.TraceHash
 	KTime            times.KTime
 	PID              libpf.PID
 	TID              libpf.PID

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -337,7 +337,7 @@ func TestInterpreterConvertTrace(t *testing.T) {
 // trace for tests below.
 func getExpectedTrace(origTrace *host.Trace, linenos []libpf.AddressOrLineno) *libpf.Trace {
 	newTrace := &libpf.Trace{
-		Hash: libpf.NewTraceHash(uint64(origTrace.Hash), uint64(origTrace.Hash)),
+		Hash: origTrace.Hash,
 	}
 
 	for _, frame := range origTrace.Frames {

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -68,7 +68,7 @@ type traceHandler struct {
 	// bpfTraceCache stores mappings from BPF to user-mode hashes. This allows
 	// avoiding the overhead of re-doing user-mode symbolization of traces that
 	// we have recently seen already.
-	bpfTraceCache *lru.LRU[host.TraceHash, libpf.TraceHash]
+	bpfTraceCache *lru.LRU[libpf.TraceHash, libpf.TraceHash]
 
 	// umTraceCache is a LRU set that suppresses unnecessary resends of traces
 	// that we have recently reported to the collector already.
@@ -87,8 +87,8 @@ type traceHandler struct {
 // newTraceHandler creates a new traceHandler
 func newTraceHandler(rep reporter.TraceReporter, traceProcessor TraceProcessor,
 	intervals Times, cacheSize uint32) (*traceHandler, error) {
-	bpfTraceCache, err := lru.New[host.TraceHash, libpf.TraceHash](
-		cacheSize, func(k host.TraceHash) uint32 { return uint32(k) })
+	bpfTraceCache, err := lru.New[libpf.TraceHash, libpf.TraceHash](
+		cacheSize, func(k libpf.TraceHash) uint32 { return k.Hash32() })
 	if err != nil {
 		return nil, err
 	}

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -36,7 +36,7 @@ var _ tracehandler.TraceProcessor = (*fakeTraceProcessor)(nil)
 
 func (f *fakeTraceProcessor) ConvertTrace(trace *host.Trace) *libpf.Trace {
 	var newTrace libpf.Trace
-	newTrace.Hash = libpf.NewTraceHash(uint64(trace.Hash), uint64(trace.Hash))
+	newTrace.Hash = trace.Hash
 	return &newTrace
 }
 
@@ -101,23 +101,23 @@ func TestTraceHandler(t *testing.T) {
 
 		// simulates a single trace being received.
 		"single trace": {input: []arguments{
-			{trace: &host.Trace{Hash: host.TraceHash(0x1234)}},
+			{trace: &host.Trace{Hash: libpf.NewTraceHash(0x12, 0x34)}},
 		},
-			expectedTraces: []reportedTrace{{traceHash: libpf.NewTraceHash(0x1234, 0x1234)}},
+			expectedTraces: []reportedTrace{{traceHash: libpf.NewTraceHash(0x12, 0x34)}},
 			expectedCounts: []reportedCount{
-				{traceHash: libpf.NewTraceHash(0x1234, 0x1234), count: 1},
+				{traceHash: libpf.NewTraceHash(0x12, 0x34), count: 1},
 			},
 		},
 
 		// double trace simulates a case where the same trace is encountered in quick succession.
 		"double trace": {input: []arguments{
-			{trace: &host.Trace{Hash: host.TraceHash(4)}},
-			{trace: &host.Trace{Hash: host.TraceHash(4)}},
+			{trace: &host.Trace{Hash: libpf.NewTraceHash(0x56, 0x78)}},
+			{trace: &host.Trace{Hash: libpf.NewTraceHash(0x56, 0x78)}},
 		},
-			expectedTraces: []reportedTrace{{traceHash: libpf.NewTraceHash(4, 4)}},
+			expectedTraces: []reportedTrace{{traceHash: libpf.NewTraceHash(0x56, 0x78)}},
 			expectedCounts: []reportedCount{
-				{traceHash: libpf.NewTraceHash(4, 4), count: 1},
-				{traceHash: libpf.NewTraceHash(4, 4), count: 1},
+				{traceHash: libpf.NewTraceHash(0x56, 0x78), count: 1},
+				{traceHash: libpf.NewTraceHash(0x56, 0x78), count: 1},
 			},
 		},
 	}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1007,7 +1007,8 @@ func (t *Tracer) loadBpfTrace(raw []byte, cpu int) *host.Trace {
 	ptr.ktime = 0
 	ptr.origin = 0
 	ptr.offtime = 0
-	trace.Hash = host.TraceHash(xxh3.Hash128(raw).Lo)
+	tmpHash := xxh3.Hash128(raw)
+	trace.Hash = libpf.NewTraceHash(tmpHash.Hi, tmpHash.Lo)
 
 	userFrameOffs := 0
 	if ptr.kernel_stack_id >= 0 {


### PR DESCRIPTION
This is a follow up to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/340.

When working on https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/340 I realized we still differentiate between hashes on a host (64 bit) and global hashes (128 bit). With the rework on how traces and their counts are reported to user space, this differentiation is no longer needed.
Therefore we can use just one kind of hash, reduce the memory footprint of a map that converts these hashes and avoid additional computing for hashes.