### PR TITLE
processinfo: refactor process metadata

### DIFF
--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -89,8 +89,7 @@ func (pm *ProcessManager) updatePidInformation(pid libpf.PID, m *Mapping) (bool,
 			processName = string(name)
 		}
 		info = &processInfo{
-			name:             processName,
-			executable:       exePath,
+			meta:             ProcessMeta{Name: processName, Executable: exePath},
 			mappings:         make(map[libpf.Address]*Mapping),
 			mappingsByFileID: make(map[host.FileID]map[libpf.Address]*Mapping),
 			tsdInfo:          nil,
@@ -651,29 +650,14 @@ func (pm *ProcessManager) CleanupPIDs() {
 	}
 }
 
-// NameForPID returns the process name for given PID.
-// If the PID is not tracked it returns the empty string.
-func (pm *ProcessManager) NameForPID(pid libpf.PID) string {
+// MetaForPID returns the process metadata for given PID.
+func (pm *ProcessManager) MetaForPID(pid libpf.PID) ProcessMeta {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		return procInfo.name
+		return procInfo.meta
 	}
-	return ""
-}
-
-// ExePathForPID returns the full executable path for given PID.
-// If the PID is not tracked or belongs to a kernel worker,
-// it returns the empty string.
-func (pm *ProcessManager) ExePathForPID(pid libpf.PID) string {
-	var executable string
-
-	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		executable = procInfo.executable
-	}
-	return executable
+	return ProcessMeta{}
 }
 
 // findMappingForTrace locates the mapping for a given host trace.

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -135,13 +135,19 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 	}
 }
 
+// ProcessMeta contains metadata about a tracked process.
+type ProcessMeta struct {
+	// process name retrieved from /proc/PID/comm
+	Name string
+	// executable path retrieved from /proc/PID/exe
+	Executable string
+}
+
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
-	// process name retrieved from /proc/PID/comm
-	name string
-	// executable path retrieved from /proc/PID/exe
-	executable string
+	// process metadata, fixed for process lifetime (read-only)
+	meta ProcessMeta
 	// executable mappings keyed by start address.
 	mappings map[libpf.Address]*Mapping
 	// executable mappings keyed by host file ID.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -978,10 +978,11 @@ func (t *Tracer) loadBpfTrace(raw []byte, cpu int) *host.Trace {
 	}
 
 	pid := libpf.PID(ptr.pid)
+	procMeta := t.processManager.MetaForPID(pid)
 	trace := &host.Trace{
 		Comm:             C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
-		ExecutablePath:   t.processManager.ExePathForPID(pid),
-		ProcessName:      t.processManager.NameForPID(pid),
+		ExecutablePath:   procMeta.Executable,
+		ProcessName:      procMeta.Name,
 		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.apm_trace_id)),
 		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.apm_transaction_id)),
 		PID:              pid,


### PR DESCRIPTION
### Summary

Keep track of process metadata (read-only, captured when a process is first seen) in a separate struct to minimize locking operations.