### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ generate:
 	GOARCH=$(NATIVE_ARCH) go generate ./...
 	(cd support && ./generate.sh)
 
-ebpf:
+ebpf: generate
 	$(MAKE) $(EBPF_FLAGS) -C support/ebpf
 
 ebpf-profiler: generate ebpf


### PR DESCRIPTION
# Summary 

The ebpf build depends on `generate` target having executed. Previously, the two targets would run in parallel and could fail.