### PR TITLE
CI: skip environment setup

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -167,8 +167,6 @@ jobs:
     steps:
       - name: Clone code
         uses: actions/checkout@v4
-      - name: Set up environment
-        uses: ./.github/workflows/env
       - name: Install dependencies
         run: |
           case "${{ matrix.target_arch }}" in


### PR DESCRIPTION
When running the integration tests cross-compliation tooling is not needed. As a side effect, tests pass faster without installing the unneeded overhead.