### PR TITLE
doc: fix path of tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ The host agent code is tested with three test suites:
   tests. This works great for the user-land portion of the agent, but is unable
   to test any of the unwinding logic and BPF interaction.
 - **coredump test suite**\
-  The coredump test suite (`utils/coredump`) we compile the whole BPF unwinder
+  The coredump test suite (`tools/coredump`) we compile the whole BPF unwinder
   code into a user-mode executable, then use the information from a coredump to
   simulate a realistic environment to test the unwinder code in. The coredump
   suite essentially implements all required BPF helper functions in user-space,

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -3,7 +3,7 @@
 
 package processmanager
 
-// See also utils/coredump/coredump_test.go for core dump based testing.
+// See also tools/coredump/coredump_test.go for core dump based testing.
 
 import (
 	"context"

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -9,7 +9,7 @@ package processmanager // import "go.opentelemetry.io/ebpf-profiler/processmanag
 // these two components can be audited to be consistent.
 
 // The public functions in this file are restricted to be used from the
-// HA/tracer and utils/coredump modules only.
+// HA/tracer and tools/coredump modules only.
 
 import (
 	"errors"

--- a/support/ebpf/bpfdefs.h
+++ b/support/ebpf/bpfdefs.h
@@ -5,7 +5,7 @@
 #include "kernel.h"
 
 #if defined(TESTING_COREDUMP)
-  // utils/coredump uses CGO to build the eBPF code. Provide here the glue to
+  // tools/coredump uses CGO to build the eBPF code. Provide here the glue to
   // dispatch the BPF API to helpers implemented in ebpfhelpers.go.
   #define SEC(NAME)
 

--- a/support/ebpf/tracemgmt.h
+++ b/support/ebpf/tracemgmt.h
@@ -298,7 +298,7 @@ static inline __attribute__((__always_inline__)) ErrorCode _push_with_max_frames
   }
 
 #ifdef TESTING_COREDUMP
-  // utils/coredump uses CGO to build the eBPF code. This dispatches
+  // tools/coredump uses CGO to build the eBPF code. This dispatches
   // the frame information directly to helper implemented in ebpfhelpers.go.
   int __push_frame(u64, u64, u64, u8, u8);
   trace->stack_len++;


### PR DESCRIPTION
coredump used to be under a different path. Fix the path to avoid confusion.