### PR TITLE
processmanager: use a different cache timeout for entries with errors

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -42,6 +42,10 @@ const (
 
 	// TTL of entries in the LRU cache holding the executables' ELF information.
 	elfInfoCacheTTL = 6 * time.Hour
+
+	// Time to keep entries in the LRU cache before inspecting them again after
+	// the initial inspection returned an error.
+	elfInfoCacheRetry = 5 * time.Minute
 )
 
 var (

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -278,7 +278,7 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 		if !errors.Is(err, os.ErrNotExist) {
 			// Cache the other errors: not an ELF, ELF corrupt, etc.
 			// to reduce opening it again and again.
-			pm.elfInfoCache.Add(key, info)
+			pm.elfInfoCache.AddWithLifetime(key, info, elfInfoCacheRetry)
 		}
 		return info
 	}


### PR DESCRIPTION
To retry ELF inspection at some earlier point than the default elfInfoCacheTTL = 6 * time.Hour use a specific timeout elfInfoCacheRetry = 5 * time.Minute for these entries.