### PR TITLE
reporter: add custom gRPC dial options

### DIFF
--- a/reporter/config.go
+++ b/reporter/config.go
@@ -57,4 +57,8 @@ type Config struct {
 	// ExtraSampleAttrProd is an optional hook point for adding custom
 	// attributes to samples.
 	ExtraSampleAttrProd samples.SampleAttrProducer
+
+	// GRPCDialOptions allows passing additional gRPC dial options when establishing
+	// the connection to the collector. These options are appended after the default options.
+	GRPCDialOptions []grpc.DialOption
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -274,6 +274,8 @@ func setupGrpcConnection(parent context.Context, cfg *Config,
 			})))
 	}
 
+	opts = append(opts, cfg.GRPCDialOptions...)
+
 	ctx, cancel := context.WithTimeout(parent, cfg.GRPCConnectionTimeout)
 	defer cancel()
 	//nolint:staticcheck


### PR DESCRIPTION
Add support for custom gRPC dial options

This change allows users to provide additional gRPC dial options when establishing a connection to the collector. The options are appended after the default options that the reporter already sets.

This is useful for cases where users need to customize the gRPC connection behavior, such as:
- Adding custom interceptors
- Configuring custom transport credentials
- Setting custom keepalive parameters
- Adding custom headers

The change adds a new `GRPCDialOptions` field to the `Config` struct and applies these options when establishing the connection.