### PR TITLE
Stabilize CI / integration tests

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -147,9 +147,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          sudo apt-get update -y
           case "${{ matrix.target_arch }}" in
-            amd64) sudo apt-get update -y && sudo apt-get -y install qemu-system-x86;;
-            arm64) sudo apt-get update -y && sudo apt-get -y install qemu-system-arm;;
+            amd64) sudo apt-get -y install qemu-system-x86;;
+            arm64) sudo apt-get -y install qemu-system-arm;;
             *) echo >&2 "bug: bad arch selected"; exit 1;;
           esac
           go install github.com/florianl/bluebox@v0.0.1

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -148,8 +148,8 @@ jobs:
       - name: Install dependencies
         run: |
           case "${{ matrix.target_arch }}" in
-            amd64) sudo apt-get -y install qemu-system-x86;;
-            arm64) sudo apt-get -y install qemu-system-arm;;
+            amd64) sudo apt-get update -y && sudo apt-get -y install qemu-system-x86;;
+            arm64) sudo apt-get update -y && sudo apt-get -y install qemu-system-arm;;
             *) echo >&2 "bug: bad arch selected"; exit 1;;
           esac
           go install github.com/florianl/bluebox@v0.0.1


### PR DESCRIPTION
Updates the archives database as the Ubuntu image and public repositories might be out-of-sync.

Failures like `404  Not Found [IP: 52.252.75.106 80]` when installing packages for the integration tests can be mostly avoided. Same goes for missing packages.
