### PR TITLE
symblib: expose API for single point lookups

### DIFF
--- a/rust-crates/symblib-capi/c/symblib.h
+++ b/rust-crates/symblib-capi/c/symblib.h
@@ -138,6 +138,33 @@ extern SymblibStatus symblib_retpadextr_submit(
 // Frees a return pad extractor.
 extern void symblib_retpadextr_free(SymblibRetPadExtractor* extr);
 
+// Opaque handle to GoRuntimeInfo
+typedef struct SymblibGoRuntime SymblibGoRuntime;
+
+// Go function information
+typedef struct {
+    uint64_t start_addr;
+    SymblibString function_name;
+    SymblibString file_name;
+    uint32_t line_number;
+} SymblibGoFunc;
+
+// Create a new GoRuntime handler
+extern SymblibStatus symblib_goruntime_new(
+    const char* executable,
+    SymblibGoRuntime** runtime // out arg
+);
+
+// Lookup function by address
+extern SymblibStatus symblib_goruntime_lookup(
+    SymblibGoRuntime* runtime,
+    uint64_t addr,
+    SymblibGoFunc** func_info // out arg
+);
+
+// Free the GoRuntime handler
+extern void symblib_goruntime_free(SymblibGoRuntime* runtime);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rust-crates/symblib-capi/c/symblib.h
+++ b/rust-crates/symblib-capi/c/symblib.h
@@ -154,8 +154,8 @@ extern void symblib_goruntime_free(SymblibPointResolver* runtime);
 typedef struct SymblibResolvedSymbol {
     uint64_t start_addr;
     SymblibString function_name;
-    SymblibSlice file_names;
-    SymblibSlice line_numbers;
+    SymblibString file_name;
+    uint32_t line_number;
 } SymblibResolvedSymbol;
 
 // Enveloping struct that holds len number of symbols in data.

--- a/rust-crates/symblib-capi/c/symblib.h
+++ b/rust-crates/symblib-capi/c/symblib.h
@@ -141,16 +141,16 @@ extern void symblib_retpadextr_free(SymblibRetPadExtractor* extr);
 // Opaque handle to SymblibPointResolver.
 typedef struct SymblibPointResolver SymblibPointResolver;
 
-// Create a new SymblibPointResolver handler from a Go executable.
+// Creates a new SymblibPointResolver.
 extern SymblibStatus symblib_goruntime_new(
     const char* executable,
     SymblibPointResolver** runtime // out arg
 );
 
-// Frees a Go based SymblibPointResolver
+// Frees a SymblibPointResolver.
 extern void symblib_goruntime_free(SymblibPointResolver* runtime);
 
-// Hold information about a symbol and its origin.
+// Contains information about a symbol and its origin.
 typedef struct SymblibResolvedSymbol {
     uint64_t start_addr;
     SymblibString function_name;
@@ -158,7 +158,7 @@ typedef struct SymblibResolvedSymbol {
     uint32_t line_number;
 } SymblibResolvedSymbol;
 
-// Enveloping struct that holds len number of symbols in data.
+// Enveloping struct that contains len number of symbols in data.
 typedef struct SymblibSlice_SymblibResolvedSymbol {
     const SymblibResolvedSymbol* data;
     size_t len;

--- a/rust-crates/symblib-capi/c/symblib.h
+++ b/rust-crates/symblib-capi/c/symblib.h
@@ -138,32 +138,43 @@ extern SymblibStatus symblib_retpadextr_submit(
 // Frees a return pad extractor.
 extern void symblib_retpadextr_free(SymblibRetPadExtractor* extr);
 
-// Opaque handle to GoRuntimeInfo
-typedef struct SymblibGoRuntime SymblibGoRuntime;
+// Opaque handle to SymblibPointResolver.
+typedef struct SymblibPointResolver SymblibPointResolver;
 
-// Go function information
-typedef struct {
-    uint64_t start_addr;
-    SymblibString function_name;
-    SymblibString file_name;
-    uint32_t line_number;
-} SymblibGoFunc;
-
-// Create a new GoRuntime handler
+// Create a new SymblibPointResolver handler from a Go executable.
 extern SymblibStatus symblib_goruntime_new(
     const char* executable,
-    SymblibGoRuntime** runtime // out arg
+    SymblibPointResolver** runtime // out arg
 );
 
-// Lookup function by address
-extern SymblibStatus symblib_goruntime_lookup(
-    SymblibGoRuntime* runtime,
-    uint64_t addr,
-    SymblibGoFunc** func_info // out arg
+// Frees a Go based SymblibPointResolver
+extern void symblib_goruntime_free(SymblibPointResolver* runtime);
+
+// Hold information about a symbol and its origin.
+typedef struct SymblibResolvedSymbol {
+    uint64_t start_addr;
+    SymblibString function_name;
+    SymblibSlice file_names;
+    SymblibSlice line_numbers;
+} SymblibResolvedSymbol;
+
+// Enveloping struct that holds len number of symbols in data.
+typedef struct SymblibSlice_SymblibResolvedSymbol {
+    const SymblibResolvedSymbol* data;
+    size_t len;
+} SymblibSlice_SymblibResolvedSymbol;
+
+// Single point lookup for pc using SymblibPointResolver.
+SymblibStatus symblib_point_resolver_symbols_for_pc(
+    const SymblibPointResolver* resolver,
+    uint64_t pc,
+    SymblibSlice_SymblibResolvedSymbol** symbols // out arg
 );
 
-// Free the GoRuntime handler
-extern void symblib_goruntime_free(SymblibGoRuntime* runtime);
+// Frees a SymblibSlice_SymblibResolvedSymbol.
+void symblib_slice_symblibresolved_symbol_free(
+    SymblibSlice_SymblibResolvedSymbol* slice
+);
 
 #ifdef __cplusplus
 }

--- a/rust-crates/symblib-capi/src/gosym.rs
+++ b/rust-crates/symblib-capi/src/gosym.rs
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{FfiResult, StatusCode, SymblibString};
+use fallible_iterator::FallibleIterator;
+use std::ffi::{c_char, CStr};
+use std::path::Path;
+use symblib::{gosym::GoRuntimeInfo, objfile, VirtAddr};
+
+pub struct SymblibGoRuntime {
+    // Keep a reference to the backing executable
+    _obj: &'static objfile::File,
+    runtime: GoRuntimeInfo<'static>,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct SymblibGoFunc {
+    start_addr: u64,
+    function_name: SymblibString,
+    file_name: SymblibString,
+    line_number: u32,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn symblib_goruntime_new(
+    executable: *const c_char,
+    runtime: *mut *mut SymblibGoRuntime,
+) -> StatusCode {
+    match goruntime_new_impl(executable, runtime) {
+        Ok(()) => StatusCode::Ok,
+        Err(e) => e,
+    }
+}
+
+unsafe fn goruntime_new_impl(
+    executable: *const c_char,
+    runtime: *mut *mut SymblibGoRuntime,
+) -> FfiResult {
+    let executable = CStr::from_ptr(executable)
+        .to_str()
+        .map(Path::new)
+        .map_err(|_| StatusCode::BadUtf8)?;
+
+    let obj = Box::leak(Box::new(objfile::File::load(executable)?));
+    let obj_reader = obj.parse()?;
+    let go_runtime = GoRuntimeInfo::open(&obj_reader)?;
+
+    let runtime_handle = Box::new(SymblibGoRuntime {
+        runtime: go_runtime,
+        _obj: obj,
+    });
+    *runtime = Box::into_raw(runtime_handle);
+    Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn symblib_goruntime_lookup(
+    runtime: *mut SymblibGoRuntime,
+    addr: u64,
+    func_info: *mut *mut SymblibGoFunc,
+) -> StatusCode {
+    let runtime = &*runtime;
+    match runtime.runtime.find_func(VirtAddr::from(addr)) {
+        Ok(Some(func)) => {
+            let name = match func.name() {
+                Ok(n) => n,
+                Err(_) => return StatusCode::GosymMissingFuncName,
+            };
+
+            let mut file_name = "";
+            let mut line_number = 0;
+
+            // For file mapping
+            let mut file_iter = match func.file_mapping() {
+                Ok(iter) => iter,
+                Err(_) => return StatusCode::GosymBadFileMapping,
+            };
+            while let Ok(Some((range, file))) = file_iter.next() {
+                if range.contains(&VirtAddr::from(addr)) {
+                    file_name = file.unwrap_or("unknown");
+                    break;
+                }
+            }
+
+            // For line mapping
+            let mut line_iter = match func.line_mapping() {
+                Ok(iter) => iter,
+                Err(_) => return StatusCode::GosymBadLineMapping,
+            };
+            while let Ok(Some((range, line))) = line_iter.next() {
+                if range.contains(&VirtAddr::from(addr)) {
+                    line_number = line.unwrap_or(0);
+                    break;
+                }
+            }
+
+            let info = Box::new(SymblibGoFunc {
+                start_addr: func.start_addr(),
+                function_name: name.to_string().into(),
+                file_name: file_name.to_string().into(),
+                line_number: line_number,
+            });
+
+            *func_info = Box::into_raw(info);
+            StatusCode::Ok
+        }
+        Ok(None) => StatusCode::GosymMissingAddrMapping,
+        Err(_) => StatusCode::GosymBadAddrLookup,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn symblib_goruntime_free(runtime: *mut SymblibGoRuntime) {
+    if !runtime.is_null() {
+        drop(Box::from_raw(runtime));
+    }
+}

--- a/rust-crates/symblib-capi/src/gosym.rs
+++ b/rust-crates/symblib-capi/src/gosym.rs
@@ -3,13 +3,21 @@
 
 use crate::{FfiResult, StatusCode, SymblibPointResolver};
 use std::ffi::{c_char, CStr};
+use std::mem;
 use std::path::Path;
-use symblib::symbconv::PointResolver;
+use symblib::symbconv::{PointResolver, ResolvedSymbol, Result as SymconvResult};
 use symblib::{gosym::GoRuntimeInfo, objfile};
 
 pub struct SymblibGoRuntime {
-    #[allow(dead_code)]
+    #[allow(unused)]
+    obj: Box<objfile::File>,
     runtime: GoRuntimeInfo<'static>,
+}
+
+impl PointResolver for SymblibGoRuntime {
+    fn symbols_for_pc(&self, pc: symblib::VirtAddr) -> SymconvResult<Vec<ResolvedSymbol>> {
+        self.runtime.symbols_for_pc(pc)
+    }
 }
 
 #[no_mangle]
@@ -32,12 +40,20 @@ unsafe fn goruntime_new_impl(
         .map(Path::new)
         .map_err(|_| StatusCode::BadUtf8)?;
 
-    let obj = Box::leak(Box::new(objfile::File::load(executable)?));
+    let obj = Box::new(objfile::File::load(executable)?);
     let obj_reader = obj.parse()?;
     let go_runtime = GoRuntimeInfo::open(&obj_reader)?;
 
+    // Transmute away lifetime to allow for self-referential struct.
+    let go_runtime: GoRuntimeInfo<'static> = mem::transmute(go_runtime);
+
+    let resolver = SymblibGoRuntime {
+        obj,
+        runtime: go_runtime,
+    };
+
     let point_resolver = Box::new(SymblibPointResolver::new(
-        Box::new(go_runtime) as Box<dyn PointResolver + Send>
+        Box::new(resolver) as Box<dyn PointResolver + Send>
     ));
     *runtime = Box::into_raw(point_resolver);
     Ok(())

--- a/rust-crates/symblib-capi/src/gosym.rs
+++ b/rust-crates/symblib-capi/src/gosym.rs
@@ -1,31 +1,21 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{FfiResult, StatusCode, SymblibString};
-use fallible_iterator::FallibleIterator;
+use crate::{FfiResult, StatusCode, SymblibPointResolver};
 use std::ffi::{c_char, CStr};
 use std::path::Path;
-use symblib::{gosym::GoRuntimeInfo, objfile, VirtAddr};
+use symblib::symbconv::PointResolver;
+use symblib::{gosym::GoRuntimeInfo, objfile};
 
 pub struct SymblibGoRuntime {
-    // Keep a reference to the backing executable
-    _obj: &'static objfile::File,
+    #[allow(dead_code)]
     runtime: GoRuntimeInfo<'static>,
-}
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct SymblibGoFunc {
-    start_addr: u64,
-    function_name: SymblibString,
-    file_name: SymblibString,
-    line_number: u32,
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn symblib_goruntime_new(
     executable: *const c_char,
-    runtime: *mut *mut SymblibGoRuntime,
+    runtime: *mut *mut SymblibPointResolver,
 ) -> StatusCode {
     match goruntime_new_impl(executable, runtime) {
         Ok(()) => StatusCode::Ok,
@@ -35,7 +25,7 @@ pub unsafe extern "C" fn symblib_goruntime_new(
 
 unsafe fn goruntime_new_impl(
     executable: *const c_char,
-    runtime: *mut *mut SymblibGoRuntime,
+    runtime: *mut *mut SymblibPointResolver,
 ) -> FfiResult {
     let executable = CStr::from_ptr(executable)
         .to_str()
@@ -46,72 +36,15 @@ unsafe fn goruntime_new_impl(
     let obj_reader = obj.parse()?;
     let go_runtime = GoRuntimeInfo::open(&obj_reader)?;
 
-    let runtime_handle = Box::new(SymblibGoRuntime {
-        runtime: go_runtime,
-        _obj: obj,
-    });
-    *runtime = Box::into_raw(runtime_handle);
+    let point_resolver = Box::new(SymblibPointResolver::new(
+        Box::new(go_runtime) as Box<dyn PointResolver + Send>
+    ));
+    *runtime = Box::into_raw(point_resolver);
     Ok(())
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn symblib_goruntime_lookup(
-    runtime: *mut SymblibGoRuntime,
-    addr: u64,
-    func_info: *mut *mut SymblibGoFunc,
-) -> StatusCode {
-    let runtime = &*runtime;
-    match runtime.runtime.find_func(VirtAddr::from(addr)) {
-        Ok(Some(func)) => {
-            let name = match func.name() {
-                Ok(n) => n,
-                Err(_) => return StatusCode::GosymMissingFuncName,
-            };
-
-            let mut file_name = "";
-            let mut line_number = 0;
-
-            // For file mapping
-            let mut file_iter = match func.file_mapping() {
-                Ok(iter) => iter,
-                Err(_) => return StatusCode::GosymBadFileMapping,
-            };
-            while let Ok(Some((range, file))) = file_iter.next() {
-                if range.contains(&VirtAddr::from(addr)) {
-                    file_name = file.unwrap_or("unknown");
-                    break;
-                }
-            }
-
-            // For line mapping
-            let mut line_iter = match func.line_mapping() {
-                Ok(iter) => iter,
-                Err(_) => return StatusCode::GosymBadLineMapping,
-            };
-            while let Ok(Some((range, line))) = line_iter.next() {
-                if range.contains(&VirtAddr::from(addr)) {
-                    line_number = line.unwrap_or(0);
-                    break;
-                }
-            }
-
-            let info = Box::new(SymblibGoFunc {
-                start_addr: func.start_addr(),
-                function_name: name.to_string().into(),
-                file_name: file_name.to_string().into(),
-                line_number: line_number,
-            });
-
-            *func_info = Box::into_raw(info);
-            StatusCode::Ok
-        }
-        Ok(None) => StatusCode::GosymMissingAddrMapping,
-        Err(_) => StatusCode::GosymBadAddrLookup,
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn symblib_goruntime_free(runtime: *mut SymblibGoRuntime) {
+pub unsafe extern "C" fn symblib_goruntime_free(runtime: *mut SymblibPointResolver) {
     if !runtime.is_null() {
         drop(Box::from_raw(runtime));
     }

--- a/rust-crates/symblib-capi/src/lib.rs
+++ b/rust-crates/symblib-capi/src/lib.rs
@@ -5,12 +5,14 @@
 
 mod ffislice;
 mod ffistr;
+mod gosym;
 mod rangeextr;
 mod retpadextr;
 mod status;
 
 pub use ffislice::*;
 pub use ffistr::*;
+pub use gosym::*;
 pub use rangeextr::*;
 pub use retpadextr::*;
 pub use status::*;

--- a/rust-crates/symblib-capi/src/lib.rs
+++ b/rust-crates/symblib-capi/src/lib.rs
@@ -6,6 +6,7 @@
 mod ffislice;
 mod ffistr;
 mod gosym;
+mod pointresolver;
 mod rangeextr;
 mod retpadextr;
 mod status;
@@ -13,6 +14,7 @@ mod status;
 pub use ffislice::*;
 pub use ffistr::*;
 pub use gosym::*;
+pub use pointresolver::*;
 pub use rangeextr::*;
 pub use retpadextr::*;
 pub use status::*;

--- a/rust-crates/symblib-capi/src/pointresolver.rs
+++ b/rust-crates/symblib-capi/src/pointresolver.rs
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{StatusCode, SymblibSlice, SymblibString};
+use symblib::symbconv;
+use symblib::symbconv::PointResolver;
+use symblib::VirtAddr;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct SymblibResolvedSymbol {
+    pub start_addr: VirtAddr,
+    pub function_name: SymblibString,
+    pub file_names: SymblibSlice<SymblibString>,
+    pub line_numbers: SymblibSlice<u32>,
+}
+
+impl From<symbconv::ResolvedSymbol> for SymblibResolvedSymbol {
+    fn from(sym: symbconv::ResolvedSymbol) -> Self {
+        let file_names: Vec<SymblibString> = sym
+            .file_names
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        let line_numbers: Vec<u32> = sym.line_numbers.unwrap_or_default();
+
+        Self {
+            start_addr: sym.start_addr,
+            function_name: sym.function_name.into(),
+            file_names: file_names.into(),
+            line_numbers: line_numbers.into(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct SymblibPointResolver {
+    inner: Box<dyn PointResolver + Send>,
+}
+
+impl SymblibPointResolver {
+    pub fn new(resolver: Box<dyn PointResolver + Send>) -> Self {
+        Self { inner: resolver }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn symblib_point_resolver_symbols_for_pc(
+    resolver: &SymblibPointResolver,
+    pc: VirtAddr,
+    out_symbols: *mut *mut SymblibSlice<SymblibResolvedSymbol>,
+) -> StatusCode {
+    let symbols: Vec<_> = match resolver.inner.symbols_for_pc(pc) {
+        Ok(syms) => syms.into_iter().map(Into::into).collect(),
+        Err(e) => return StatusCode::from(e),
+    };
+
+    unsafe {
+        *out_symbols = Box::into_raw(Box::new(symbols.into()));
+    }
+    StatusCode::Ok
+}
+
+#[no_mangle]
+pub extern "C" fn symblib_slice_symblibresolved_symbol_free(
+    slice: *mut SymblibSlice<SymblibResolvedSymbol>,
+) {
+    if !slice.is_null() {
+        unsafe {
+            drop(Box::from_raw(slice));
+        }
+    }
+}

--- a/rust-crates/symblib-capi/src/pointresolver.rs
+++ b/rust-crates/symblib-capi/src/pointresolver.rs
@@ -11,26 +11,17 @@ use symblib::VirtAddr;
 pub struct SymblibResolvedSymbol {
     pub start_addr: VirtAddr,
     pub function_name: SymblibString,
-    pub file_names: SymblibSlice<SymblibString>,
-    pub line_numbers: SymblibSlice<u32>,
+    pub file_name: SymblibString, // may be empty
+    pub line_number: u32,         // 0 = unknown
 }
 
 impl From<symbconv::ResolvedSymbol> for SymblibResolvedSymbol {
     fn from(sym: symbconv::ResolvedSymbol) -> Self {
-        let file_names: Vec<SymblibString> = sym
-            .file_names
-            .unwrap_or_default()
-            .into_iter()
-            .map(Into::into)
-            .collect();
-
-        let line_numbers: Vec<u32> = sym.line_numbers.unwrap_or_default();
-
         Self {
             start_addr: sym.start_addr,
             function_name: sym.function_name.into(),
-            file_names: file_names.into(),
-            line_numbers: line_numbers.into(),
+            file_name: sym.file_name.unwrap_or("".to_string()).into(),
+            line_number: sym.line_number.unwrap_or(0),
         }
     }
 }

--- a/rust-crates/symblib-capi/src/status.rs
+++ b/rust-crates/symblib-capi/src/status.rs
@@ -43,20 +43,8 @@ pub enum StatusCode {
     #[error("The channel was already closed in a previous call")]
     AlreadyClosed = 8,
 
-    #[error("Functionname is not available")]
-    GosymMissingFuncName = 9,
-
-    #[error("File mapping error")]
-    GosymBadFileMapping = 10,
-
-    #[error("Line mapping error")]
-    GosymBadLineMapping = 11,
-
-    #[error("Address lookup error")]
-    GosymBadAddrLookup = 12,
-
-    #[error("No mapping found for address")]
-    GosymMissingAddrMapping = 13,
+    #[error("Point resolver error")]
+    PointResolver = 9,
 }
 
 impl From<StatusCode> for FfiResult {

--- a/rust-crates/symblib-capi/src/status.rs
+++ b/rust-crates/symblib-capi/src/status.rs
@@ -4,7 +4,7 @@
 //! Defines FFI error codes and their conversion from Rust error types.
 
 use std::io;
-use symblib::{dwarf, objfile, retpads, symbconv};
+use symblib::{dwarf, gosym, objfile, retpads, symbconv};
 
 pub type FfiResult<T = ()> = Result<T, StatusCode>;
 
@@ -42,6 +42,21 @@ pub enum StatusCode {
 
     #[error("The channel was already closed in a previous call")]
     AlreadyClosed = 8,
+
+    #[error("Functionname is not available")]
+    GosymMissingFuncName = 9,
+
+    #[error("File mapping error")]
+    GosymBadFileMapping = 10,
+
+    #[error("Line mapping error")]
+    GosymBadLineMapping = 11,
+
+    #[error("Address lookup error")]
+    GosymBadAddrLookup = 12,
+
+    #[error("No mapping found for address")]
+    GosymMissingAddrMapping = 13,
 }
 
 impl From<StatusCode> for FfiResult {
@@ -115,5 +130,11 @@ impl From<std::str::Utf8Error> for StatusCode {
 impl From<retpads::Error> for StatusCode {
     fn from(_: retpads::Error) -> Self {
         Self::Retpad
+    }
+}
+
+impl From<gosym::Error> for StatusCode {
+    fn from(_: gosym::Error) -> Self {
+        StatusCode::Symbconv
     }
 }

--- a/rust-crates/symblib/src/gosym/mod.rs
+++ b/rust-crates/symblib/src/gosym/mod.rs
@@ -17,7 +17,7 @@ mod errors;
 pub use errors::*;
 mod raw;
 
-use crate::{objfile, VirtAddr};
+use crate::{objfile, symbconv, VirtAddr};
 use fallible_iterator::FallibleIterator;
 use std::ops::Range;
 
@@ -538,5 +538,57 @@ fn range_rel2abs(base: VirtAddr, rng: Range<raw::TextStartOffset>) -> Range<Virt
     Range {
         start: base.wrapping_add(rng.start.0),
         end: base.wrapping_add(rng.end.0),
+    }
+}
+
+impl symbconv::PointResolver for GoRuntimeInfo<'_> {
+    fn symbols_for_pc(&self, pc: VirtAddr) -> symbconv::Result<Vec<symbconv::ResolvedSymbol>> {
+        let mut symbols = Vec::new();
+
+        match self.find_func(pc) {
+            Ok(Some(func)) => {
+                let mut source_files = Vec::new();
+                let mut line_numbers = Vec::new();
+
+                // For file mappings
+                let mut file_iter = func
+                    .file_mapping()
+                    .map_err(|e| symbconv::Error::Go(symbconv::go::Error::Gosym(e)))?;
+                while let Ok(Some((range, file))) = file_iter.next() {
+                    if range.contains(&VirtAddr::from(pc)) {
+                        source_files.push(file.unwrap_or("<unknown>").into());
+                    }
+                }
+
+                // For line mappings
+                let mut line_iter = func
+                    .line_mapping()
+                    .map_err(|e| symbconv::Error::Go(symbconv::go::Error::Gosym(e)))?;
+                while let Ok(Some((range, line))) = line_iter.next() {
+                    if range.contains(&VirtAddr::from(pc)) {
+                        line_numbers.push(line.unwrap_or(0));
+                    }
+                }
+
+                symbols.push(symbconv::ResolvedSymbol {
+                    start_addr: func.start_addr(),
+                    function_name: func.name().ok().map(|s| s.to_string()),
+                    file_names: if !source_files.is_empty() {
+                        Some(source_files)
+                    } else {
+                        None
+                    },
+                    line_numbers: if !line_numbers.is_empty() {
+                        Some(line_numbers)
+                    } else {
+                        None
+                    },
+                });
+            }
+            Ok(None) => {}
+            Err(e) => return Err(symbconv::Error::Go(symbconv::go::Error::Gosym(e))),
+        }
+
+        Ok(symbols)
     }
 }

--- a/rust-crates/symblib/src/gosym/mod.rs
+++ b/rust-crates/symblib/src/gosym/mod.rs
@@ -542,6 +542,7 @@ fn range_rel2abs(base: VirtAddr, rng: Range<raw::TextStartOffset>) -> Range<Virt
 }
 
 impl symbconv::PointResolver for GoRuntimeInfo<'_> {
+    /// NOTE: this is currently doesn't support inline functions
     fn symbols_for_pc(&self, pc: VirtAddr) -> symbconv::Result<Vec<symbconv::ResolvedSymbol>> {
         let func = match self.find_func(pc) {
             Ok(Some(func)) => func,

--- a/rust-crates/symblib/src/symbconv/mod.rs
+++ b/rust-crates/symblib/src/symbconv/mod.rs
@@ -3,7 +3,7 @@
 
 //! Extract symbol info and convert it to [`symbfile`] format.
 
-use crate::{objfile, symbfile, AnyError};
+use crate::{objfile, symbfile, AnyError, VirtAddr};
 use std::io;
 
 /// Result type shorthand.
@@ -77,6 +77,27 @@ pub trait RangeExtractor {
         out.finalize()?;
         Ok(stats)
     }
+}
+
+/// Hold information about a symbol and its origin.
+pub struct ResolvedSymbol {
+    /// Start address of a symbol
+    pub start_addr: VirtAddr,
+    /// Function name associated with an address.
+    pub function_name: Option<String>,
+    /// File names that hold this function or any inlined function.
+    pub file_names: Option<Vec<String>>,
+    /// Line numbers associcated with this virtual address.
+    pub line_numbers: Option<Vec<u32>>,
+}
+
+/// Common interface to tesolve symbols for a specific program counter address.
+pub trait PointResolver {
+    /// Returns all symbols that match the given program counter address.
+    ///
+    /// The returned vector contains all resolved symbols at the given address,
+    /// which can include both the direct function and any inline frames
+    fn symbols_for_pc(&self, pc: VirtAddr) -> Result<Vec<ResolvedSymbol>>;
 }
 
 fn _assert_obj_safe(_: &dyn RangeExtractor) {}

--- a/rust-crates/symblib/src/symbconv/mod.rs
+++ b/rust-crates/symblib/src/symbconv/mod.rs
@@ -85,10 +85,10 @@ pub struct ResolvedSymbol {
     pub start_addr: VirtAddr,
     /// Function name associated with an address.
     pub function_name: Option<String>,
-    /// File names that hold this function or any inlined function.
-    pub file_names: Option<Vec<String>>,
-    /// Line numbers associcated with this virtual address.
-    pub line_numbers: Option<Vec<u32>>,
+    /// File name that hold this function.
+    pub file_name: Option<String>,
+    /// Line number associcated with this virtual address.
+    pub line_number: Option<u32>,
 }
 
 /// Common interface to tesolve symbols for a specific program counter address.


### PR DESCRIPTION
Implement a trait with the API for Go executables that got introduced with https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/346 and expose this trait as C API.

<details>
<summary> Go programm that uses this Rust API via the C FFI </summary>

```
	executablePath := C.CString("/.../...")
	defer C.free(unsafe.Pointer(executablePath))
	addr := uint64(0xc0ffee)

	var goRuntime *C.SymblibPointResolver

	status := C.symblib_goruntime_new(executablePath, &goRuntime)
	if status != C.SYMBLIB_OK {
		fmt.Fprintf(os.Stderr, "Failed to create SymblibGoRuntime: %d\n", status)
		return
	}
	defer C.symblib_goruntime_free(goRuntime)

	var symbols *C.SymblibSlice_SymblibResolvedSymbol
	defer C.symblib_slice_symblibresolved_symbol_free(symbols)

	status = C.symblib_point_resolver_symbols_for_pc(goRuntime, C.uint64_t(addr), &symbols)
	if status != C.SYMBLIB_OK {
		fmt.Fprintf(os.Stderr, "Failed to get information for 0x%x: %d\n",
			addr, status)
		return
	}

	// Access resolved symbols
	symbolsSlice := unsafe.Slice((*C.SymblibResolvedSymbol)(unsafe.Pointer(symbols.data)), symbols.len)
	for _, sym := range symbolsSlice {
		fmt.Printf("%s\n\t%s@%d\n",
			C.GoString(sym.function_name),
			C.GoString(sym.file_name),
			uint32(sym.line_number),
		)

	}
```

</details>