### PR TITLE
Makefile: add cargo clean to target clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ clean:
 	@rm -f support/*.test
 	@chmod -Rf u+w go/ || true
 	@rm -rf go .cache
+	@cargo clean
 
 generate:
 	GOARCH=$(NATIVE_ARCH) go generate ./...


### PR DESCRIPTION
Proper clean up helps to not getting lost with cached elements and getting lost in debugging ...