### PR TITLE
chore: remove unused controller.Config fields

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -32,11 +32,7 @@ type Config struct {
 	Tracers                string
 	VerboseMode            bool
 	Version                bool
-	// HostName is the name of the host.
-	HostName string
-	// IPAddress is the IP address of the host that sends data to CollAgentAddr.
-	IPAddress       string
-	OffCPUThreshold uint
+	OffCPUThreshold        uint
 
 	Reporter reporter.Reporter
 

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func mainWithExitCode() exitCode {
 		log.Error(err)
 		return exitFailure
 	}
-	cfg.HostName, cfg.IPAddress = hostname, sourceIP
 
 	rep, err := reporter.NewOTLP(&reporter.Config{
 		CollAgentAddr:            cfg.CollAgentAddr,


### PR DESCRIPTION
Remove `HostName` `IPAddress` fields. They seem to be used only in the reporter