### PR TITLE
processmanager: Add DeletePidPageMappingInfoBatch fallback

### DIFF
--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -749,7 +749,13 @@ func (impl *ebpfMapsImpl) UpdatePidPageMappingInfo(pid libpf.PID, prefix lpm.Pre
 func (impl *ebpfMapsImpl) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (int,
 	error) {
 	if impl.hasLPMTrieBatchOperations {
-		return impl.DeletePidPageMappingInfoBatch(pid, prefixes)
+		deleted, err := impl.DeletePidPageMappingInfoBatch(pid, prefixes)
+		if err != nil {
+			// BatchDelete may return early and not run to completion. If that happens,
+			// fall back to a single Delete pass to avoid leaking map entries.
+			deleted2, _ := impl.DeletePidPageMappingInfoSingle(pid, prefixes)
+			return (deleted + deleted2), err
+		}
 	}
 	return impl.DeletePidPageMappingInfoSingle(pid, prefixes)
 }


### PR DESCRIPTION
### Summary

Added a fallback to ensure cleanup of `pid_page_to_mapping_info` if `BatchDelete` operation fails.

Also see: #329