### PR TITLE
ci: exclude some workflows from running on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze Go (${{ matrix.target_arch }})
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository == 'open-telemetry/opentelemetry-ebpf-profiler' }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: github.repository == 'open-telemetry/opentelemetry-ebpf-profiler'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Some CI workflows require secrets from the main upstream repository and can't succeed on forks. Prevent them from running on forks.