### PR TITLE
processmanager/ebpf: return on success

### DIFF
--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -756,6 +756,7 @@ func (impl *ebpfMapsImpl) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm
 			deleted2, _ := impl.DeletePidPageMappingInfoSingle(pid, prefixes)
 			return (deleted + deleted2), err
 		}
+		return deleted, nil
 	}
 	return impl.DeletePidPageMappingInfoSingle(pid, prefixes)
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/390 introduced a bug by just adding a return if DeletePidPageMappingInfoBatch() fails. In the case where no error is returned by DeletePidPageMappingInfoBatch() the function continues with `return impl.DeletePidPageMappingInfoSingle(pid, prefixes)` and fails, as prefixes just got removed.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/392