### PR TITLE
ci: also disable FOSSA on forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   fossa:
     runs-on: ubuntu-latest
+    if: github.repository == 'open-telemetry/opentelemetry-ebpf-profiler'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
This also requires an API key that is only available on the upstream repo and doesn't work on forks.

I missed this one during https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/395 -- sorry for the noise!