### PR TITLE
Don't exit if parsing of /proc/PID/maps fails

### DIFF
--- a/libpf/convenience_test.go
+++ b/libpf/convenience_test.go
@@ -11,42 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHexTo(t *testing.T) {
-	tests := map[string]struct {
-		result uint64
-	}{
-		"0":      {result: 0},
-		"FFFFFF": {result: 16777215},
-		"42":     {result: 66},
-	}
-
-	for name, testcase := range tests {
-		name := name
-		testcase := testcase
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, testcase.result, util.HexToUint64(name))
-		})
-	}
-}
-
-func TestDecTo(t *testing.T) {
-	tests := map[string]struct {
-		result uint64
-	}{
-		"0":   {result: 0},
-		"123": {result: 123},
-		"42":  {result: 42},
-	}
-
-	for name, testcase := range tests {
-		name := name
-		testcase := testcase
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, testcase.result, util.DecToUint64(name))
-		})
-	}
-}
-
 func TestIsValidString(t *testing.T) {
 	tests := map[string]struct {
 		input    []byte

--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -638,6 +638,9 @@ const (
 	// Number of times a trace event read failed (trace_events)
 	IDTraceEventReadError = 274
 
+	// Number of format errors seen during parsing /proc/<PID>/maps
+	IDErrProcFormat = 275
+
 	// max number of ID values, keep this as *last entry*
-	IDMax = 275
+	IDMax = 276
 )

--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -638,8 +638,8 @@ const (
 	// Number of times a trace event read failed (trace_events)
 	IDTraceEventReadError = 274
 
-	// Number of format errors seen during parsing /proc/<PID>/maps
-	IDErrProcFormat = 275
+	// Number of parsing errors seen during processing /proc/<PID>/maps
+	IDErrProcParse = 275
 
 	// max number of ID values, keep this as *last entry*
 	IDMax = 276

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -1978,5 +1978,12 @@
     "name": "TraceEventReadError",
     "field": "agent.errors.trace_event_read_error",
     "id": 274
+  },
+  {
+    "description": "Number of format errors seen during parsing /proc/<PID>/maps",
+    "type": "counter",
+    "name": "ErrProcFormat",
+    "field": "agent.errors.proc_format",
+    "id": 275
   }
 ]

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -1980,10 +1980,10 @@
     "id": 274
   },
   {
-    "description": "Number of format errors seen during parsing /proc/<PID>/maps",
+    "description": "Number of parsing errors seen during processing /proc/<PID>/maps",
     "type": "counter",
-    "name": "ErrProcFormat",
-    "field": "agent.errors.proc_format",
+    "name": "ErrProcParse",
+    "field": "agent.errors.proc_parse",
     "id": 275
   }
 ]

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -258,8 +258,8 @@ func (cd *CoredumpProcess) GetMachineData() MachineData {
 }
 
 // GetMappings implements the Process interface
-func (cd *CoredumpProcess) GetMappings() ([]Mapping, error) {
-	return cd.mappings, nil
+func (cd *CoredumpProcess) GetMappings() ([]Mapping, uint32, error) {
+	return cd.mappings, 0, nil
 }
 
 // GetThreadInfo implements the Process interface

--- a/process/process.go
+++ b/process/process.go
@@ -129,7 +129,7 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 		}
 		inode, err := strconv.ParseUint(fields[4], 10, 64)
 		if err != nil {
-			logrus.Errorf("inode: failed to convert %s to uint64: %v", fields[4], err)
+			logrus.Debugf("inode: failed to convert %s to uint64: %v", fields[4], err)
 			continue
 		}
 
@@ -139,12 +139,12 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 		}
 		major, err := strconv.ParseUint(devs[0], 16, 64)
 		if err != nil {
-			logrus.Errorf("major device: failed to convert %s to uint64: %v", devs[0], err)
+			logrus.Debugf("major device: failed to convert %s to uint64: %v", devs[0], err)
 			continue
 		}
 		minor, err := strconv.ParseUint(devs[1], 16, 64)
 		if err != nil {
-			logrus.Errorf("minor device: failed to convert %s to uint64: %v", devs[0], err)
+			logrus.Debugf("minor device: failed to convert %s to uint64: %v", devs[0], err)
 			continue
 		}
 		device := major<<8 + minor
@@ -167,19 +167,19 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 
 		vaddr, err := strconv.ParseUint(addrs[0], 16, 64)
 		if err != nil {
-			logrus.Errorf("vaddr: failed to convert %s to uint64: %v", addrs[0], err)
+			logrus.Debugf("vaddr: failed to convert %s to uint64: %v", addrs[0], err)
 			continue
 		}
 		vend, err := strconv.ParseUint(addrs[1], 16, 64)
 		if err != nil {
-			logrus.Errorf("vend: failed to convert %s to uint64: %v", addrs[1], err)
+			logrus.Debugf("vend: failed to convert %s to uint64: %v", addrs[1], err)
 			continue
 		}
 		length := vend - vaddr
 
 		fileOffset, err := strconv.ParseUint(fields[2], 16, 64)
 		if err != nil {
-			logrus.Errorf("fileOffset: failed to convert %s to uint64: %v", fields[2], err)
+			logrus.Debugf("fileOffset: failed to convert %s to uint64: %v", fields[2], err)
 			continue
 		}
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -22,11 +22,16 @@ var testMappings = `55fe82710000-55fe8273c000 r--p 00000000 fd:01 1068432       
 55fe82836000-55fe8283d000 r--p 00125000 fd:01 1068432                    /tmp/usr_bin_seahorse
 55fe8283d000-55fe8283e000 rw-p 0012c000 fd:01 1068432                    /tmp/usr_bin_seahorse
 7f63c8c3e000-7f63c8de0000 r-xp 00085000 08:01 1048922                    /tmp/usr_lib_x86_64-linux-gnu_libcrypto.so.1.1
-7f63c8ebf000-7f63c8fef000 r-xp 0001c000 1fd:01 1075944                   /tmp/usr_lib_x86_64-linux-gnu_libopensc.so.6.0.0`
+7f63c8ebf000-7f63c8fef000 r-xp 0001c000 1fd:01 1075944                   /tmp/usr_lib_x86_64-linux-gnu_libopensc.so.6.0.0
+7f63c8eef000-7f63c8fdf000 r-xp 0001c000 1fd:01
+7f63c8eef000-7f63c8fdf000 r-xp 0001c000 1fd.01 1075944
+7f63c8eef000-7f63c8fdf000 r- 0001c000 1fd:01 1075944
+7f63c8eef000 r-xp 0001c000 1fd:01 1075944`
 
 func TestParseMappings(t *testing.T) {
-	mappings, err := parseMappings(strings.NewReader(testMappings))
+	mappings, numFormatErrors, err := parseMappings(strings.NewReader(testMappings))
 	require.NoError(t, err)
+	require.Equal(t, uint32(4), numFormatErrors)
 	assert.NotNil(t, mappings)
 
 	expected := []Mapping{
@@ -101,7 +106,8 @@ func TestNewPIDOfSelf(t *testing.T) {
 	pr := New(libpf.PID(os.Getpid()))
 	assert.NotNil(t, pr)
 
-	mappings, err := pr.GetMappings()
+	mappings, numFormatErrors, err := pr.GetMappings()
 	require.NoError(t, err)
+	require.Equal(t, uint32(0), numFormatErrors)
 	assert.NotEmpty(t, mappings)
 }

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -29,9 +29,9 @@ var testMappings = `55fe82710000-55fe8273c000 r--p 00000000 fd:01 1068432       
 7f63c8eef000 r-xp 0001c000 1fd:01 1075944`
 
 func TestParseMappings(t *testing.T) {
-	mappings, numFormatErrors, err := parseMappings(strings.NewReader(testMappings))
+	mappings, numParseErrors, err := parseMappings(strings.NewReader(testMappings))
 	require.NoError(t, err)
-	require.Equal(t, uint32(4), numFormatErrors)
+	require.Equal(t, uint32(4), numParseErrors)
 	assert.NotNil(t, mappings)
 
 	expected := []Mapping{
@@ -106,8 +106,8 @@ func TestNewPIDOfSelf(t *testing.T) {
 	pr := New(libpf.PID(os.Getpid()))
 	assert.NotNil(t, pr)
 
-	mappings, numFormatErrors, err := pr.GetMappings()
+	mappings, numParseErrors, err := pr.GetMappings()
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), numFormatErrors)
+	require.Equal(t, uint32(0), numParseErrors)
 	assert.NotEmpty(t, mappings)
 }

--- a/process/types.go
+++ b/process/types.go
@@ -101,7 +101,7 @@ type Process interface {
 	GetMachineData() MachineData
 
 	// GetMappings reads and parses process memory mappings
-	GetMappings() ([]Mapping, error)
+	GetMappings() ([]Mapping, uint32, error)
 
 	// GetThreads reads the process thread states
 	GetThreads() ([]ThreadInfo, error)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -174,6 +174,8 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 			metrics.MetricValue(pm.mappingStats.maxProcParseUsec.Swap(0))
 		summary[metrics.IDTotalProcParseUsec] =
 			metrics.MetricValue(pm.mappingStats.totalProcParseUsec.Swap(0))
+		summary[metrics.IDErrProcFormat] =
+			metrics.MetricValue(pm.mappingStats.numProcFormatErrors.Swap(0))
 
 		mapsMetrics := pm.ebpf.CollectMetrics()
 		for _, metric := range mapsMetrics {

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -174,8 +174,8 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 			metrics.MetricValue(pm.mappingStats.maxProcParseUsec.Swap(0))
 		summary[metrics.IDTotalProcParseUsec] =
 			metrics.MetricValue(pm.mappingStats.totalProcParseUsec.Swap(0))
-		summary[metrics.IDErrProcFormat] =
-			metrics.MetricValue(pm.mappingStats.numProcFormatErrors.Swap(0))
+		summary[metrics.IDErrProcParse] =
+			metrics.MetricValue(pm.mappingStats.numProcParseErrors.Swap(0))
 
 		mapsMetrics := pm.ebpf.CollectMetrics()
 		for _, metric := range mapsMetrics {

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -48,8 +48,8 @@ func (d *dummyProcess) GetMachineData() process.MachineData {
 	return process.MachineData{}
 }
 
-func (d *dummyProcess) GetMappings() ([]process.Mapping, error) {
-	return nil, errors.New("not implemented")
+func (d *dummyProcess) GetMappings() ([]process.Mapping, uint32, error) {
+	return nil, 0, errors.New("not implemented")
 }
 
 func (d *dummyProcess) GetThreads() ([]process.ThreadInfo, error) {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -600,8 +600,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
-	mappings, err := pr.GetMappings()
+	mappings, numFormatErrors, err := pr.GetMappings()
 	elapsed := time.Since(start)
+	pm.mappingStats.numProcFormatErrors.Add(numFormatErrors)
 
 	if err != nil {
 		if os.IsPermission(err) {
@@ -622,7 +623,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			pm.mappingStats.errProcNotExist.Add(1)
 		} else if e, ok := err.(*os.PathError); ok && e.Err == syscall.ESRCH {
 			// If the process exits while reading its /proc/$PID/maps, the kernel will
-			// return ESRCH. Handle it as if the process did not exists.
+			// return ESRCH. Handle it as if the process did not exist.
 			pm.mappingStats.errProcESRCH.Add(1)
 		}
 		return

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -600,9 +600,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
-	mappings, numFormatErrors, err := pr.GetMappings()
+	mappings, numParseErrors, err := pr.GetMappings()
 	elapsed := time.Since(start)
-	pm.mappingStats.numProcFormatErrors.Add(numFormatErrors)
+	pm.mappingStats.numProcParseErrors.Add(numParseErrors)
 
 	if err != nil {
 		if os.IsPermission(err) {

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -72,12 +72,13 @@ type ProcessManager struct {
 
 	// mappingStats are statistics for parsing process mappings
 	mappingStats struct {
-		errProcNotExist    atomic.Uint32
-		errProcESRCH       atomic.Uint32
-		errProcPerm        atomic.Uint32
-		numProcAttempts    atomic.Uint32
-		maxProcParseUsec   atomic.Uint32
-		totalProcParseUsec atomic.Uint32
+		errProcNotExist     atomic.Uint32
+		errProcESRCH        atomic.Uint32
+		errProcPerm         atomic.Uint32
+		numProcAttempts     atomic.Uint32
+		maxProcParseUsec    atomic.Uint32
+		totalProcParseUsec  atomic.Uint32
+		numProcFormatErrors atomic.Uint32
 	}
 
 	// elfInfoCache provides a cache to quickly retrieve the ELF info and fileID for a particular

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -72,13 +72,13 @@ type ProcessManager struct {
 
 	// mappingStats are statistics for parsing process mappings
 	mappingStats struct {
-		errProcNotExist     atomic.Uint32
-		errProcESRCH        atomic.Uint32
-		errProcPerm         atomic.Uint32
-		numProcAttempts     atomic.Uint32
-		maxProcParseUsec    atomic.Uint32
-		totalProcParseUsec  atomic.Uint32
-		numProcFormatErrors atomic.Uint32
+		errProcNotExist    atomic.Uint32
+		errProcESRCH       atomic.Uint32
+		errProcPerm        atomic.Uint32
+		numProcAttempts    atomic.Uint32
+		maxProcParseUsec   atomic.Uint32
+		totalProcParseUsec atomic.Uint32
+		numProcParseErrors atomic.Uint32
 	}
 
 	// elfInfoCache provides a cache to quickly retrieve the ELF info and fileID for a particular

--- a/util/util.go
+++ b/util/util.go
@@ -5,35 +5,12 @@ package util // import "go.opentelemetry.io/ebpf-profiler/util"
 
 import (
 	"math/bits"
-	"strconv"
 	"sync/atomic"
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/sirupsen/logrus"
-
 	"go.opentelemetry.io/ebpf-profiler/libpf/hash"
 )
-
-// HexToUint64 is a convenience function to extract a hex string to a uint64 and
-// not worry about errors. Essentially a "mustConvertHexToUint64".
-func HexToUint64(str string) uint64 {
-	v, err := strconv.ParseUint(str, 16, 64)
-	if err != nil {
-		logrus.Fatalf("Failure to hex-convert %s to uint64: %v", str, err)
-	}
-	return v
-}
-
-// DecToUint64 is a convenience function to extract a decimal string to a uint64
-// and not worry about errors. Essentially a "mustConvertDecToUint64".
-func DecToUint64(str string) uint64 {
-	v, err := strconv.ParseUint(str, 10, 64)
-	if err != nil {
-		logrus.Fatalf("Failure to dec-convert %s to uint64: %v", str, err)
-	}
-	return v
-}
 
 // IsValidString checks if string is UTF-8-encoded and only contains expected characters.
 func IsValidString(s string) bool {


### PR DESCRIPTION
Fixes #366

I believe this is a remnant from old days.
The agent should not exit if there is a parsing error. Instead, log an error and continue with the next line of the maps file.

**Scope**
- treat parsing errors gracefully
- be more consistent with other parsing code and do not `exit()`
- remove unnecessarily exported functions `util.HexToUint64()` and `util.DecToUint64()`
- the formerly exported functions did not document the exiting behavior

**Not in scope**
- dealing with breaking changes of the maps format (assumption is that this won't happen as it will break many different workflows / tools)
