### PR TITLE
Remove linter 'exportloopref'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,8 +91,6 @@ linters:
     - wastedassign
     - wsl
     - wrapcheck
-    # the following linters are deprecated
-    - exportloopref
     # we don't want to change code to Go 1.22+ yet
     - intrange
     - copyloopvar


### PR DESCRIPTION
Because the linter complained:
```
WARN [lintersdb] The linter "exportloopref" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
```