### PR TITLE
process: Deduplicate paths in parseMappings()

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -93,6 +93,8 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 		}
 		bufPool.Put(scanBuf)
 	}()
+
+	lastPath := ""
 	scanner.Buffer(*scanBuf, 8192)
 	for scanner.Scan() {
 		var fields [6]string
@@ -146,7 +148,14 @@ func parseMappings(mapsFile io.Reader) ([]Mapping, error) {
 			}
 		} else {
 			path = trimMappingPath(path)
-			path = strings.Clone(path)
+			if path == lastPath {
+				// Take advantage of the fact that mappings are sorted by path
+				// and avoid allocating the same string multiple times.
+				path = lastPath
+			} else {
+				path = strings.Clone(path)
+				lastPath = path
+			}
 		}
 
 		vaddr := util.HexToUint64(addrs[0])


### PR DESCRIPTION
Reduce number of allocations significantly in `parseMappings()`. It also has some positive effects on CPU usage.

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/ebpf-profiler/process
cpu: 12th Gen Intel(R) Core(TM) i7-12800H
                 │   old.txt   │              new.txt               │
                 │   sec/op    │   sec/op     vs base               │
ParseMappings-20   90.92µ ± 5%   85.19µ ± 2%  -6.31% (p=0.000 n=10)

                 │   old.txt    │               new.txt                │
                 │     B/op     │     B/op      vs base                │
ParseMappings-20   97.82Ki ± 0%   80.92Ki ± 0%  -17.27% (p=0.000 n=10)

                 │   old.txt   │              new.txt               │
                 │  allocs/op  │ allocs/op   vs base                │
ParseMappings-20   438.00 ± 0%   95.00 ± 0%  -78.31% (p=0.000 n=10)
```

The mappings are from a locally running Firefox. The benchmark code is:
```
func BenchmarkParseMappings(b *testing.B) {
	for i := 0; i < b.N; i++ {
		mappings, err := parseMappings(strings.NewReader(firefoxMappings))
		if err != nil {
			b.Fatal(err)
		}
		if len(mappings) == 0 {
			b.Fatal("expected non-empty mappings")
		}
	}
}
```

Just for reproducibility:
<details close>
<summary>Firefox mappings</summary>

```Go
var firefoxMappings = `55b90916b000-55b909192000 r--p 00000000 fd:01 63180418                   /usr/lib/firefox/firefox
55b909192000-55b90920c000 r-xp 00026000 fd:01 63180418                   /usr/lib/firefox/firefox
55b90920c000-55b90920f000 r--p 0009f000 fd:01 63180418                   /usr/lib/firefox/firefox
55b90920f000-55b909210000 rw-p 000a1000 fd:01 63180418                   /usr/lib/firefox/firefox
55b909210000-55b909212000 rw-p 00000000 00:00 0 
7f61fae00000-7f61fae02000 rw-p 00000000 00:00 0 
7f61fae02000-7f61fae03000 ---p 00000000 00:00 0 
7f61fae03000-7f61faeff000 rw-p 00000000 00:00 0 
7f61faeff000-7f61faf00000 ---p 00000000 00:00 0 
7f61faf4b000-7f61faf4c000 ---p 00000000 00:00 0 
7f61faf4c000-7f61faf8c000 rw-p 00000000 00:00 0 
7f61faf8c000-7f61faf8d000 ---p 00000000 00:00 0 
7f61faf8d000-7f61fafcd000 rw-p 00000000 00:00 0 
7f61fafcd000-7f61fafdb000 r--p 00000000 fd:01 63180427                   /usr/lib/firefox/libipcclientcerts.so
7f61fafdb000-7f61fb02a000 r-xp 0000d000 fd:01 63180427                   /usr/lib/firefox/libipcclientcerts.so
7f61fb02a000-7f61fb02d000 r--p 0005b000 fd:01 63180427                   /usr/lib/firefox/libipcclientcerts.so
7f61fb02d000-7f61fb02e000 rw-p 0005d000 fd:01 63180427                   /usr/lib/firefox/libipcclientcerts.so
7f61fb02e000-7f61fb032000 r--p 00000000 fd:01 56766108                   /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so
7f61fb032000-7f61fb0eb000 r-xp 00004000 fd:01 56766108                   /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so
7f61fb0eb000-7f61fb11a000 r--p 000bd000 fd:01 56766108                   /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so
7f61fb11a000-7f61fb11c000 r--p 000ec000 fd:01 56766108                   /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so
7f61fb11c000-7f61fb11d000 rw-p 000ee000 fd:01 56766108                   /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so
7f61fb11d000-7f61fb121000 rw-p 00000000 00:00 0 
7f61fb121000-7f61fb148000 r--p 00000000 fd:01 56763797                   /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f61fb148000-7f61fb258000 r-xp 00027000 fd:01 56763797                   /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f61fb258000-7f61fb296000 r--p 00137000 fd:01 56763797                   /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f61fb296000-7f61fb29c000 r--p 00175000 fd:01 56763797                   /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f61fb29c000-7f61fb2a1000 rw-p 0017b000 fd:01 56763797                   /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f61fb2a1000-7f61fb2a7000 r--p 00000000 fd:01 56766363                   /usr/lib/x86_64-linux-gnu/libsoftokn3.so
7f61fb2a7000-7f61fb2e4000 r-xp 00006000 fd:01 56766363                   /usr/lib/x86_64-linux-gnu/libsoftokn3.so
7f61fb2e4000-7f61fb2fc000 r--p 00043000 fd:01 56766363                   /usr/lib/x86_64-linux-gnu/libsoftokn3.so
7f61fb2fc000-7f61fb2fd000 r--p 0005b000 fd:01 56766363                   /usr/lib/x86_64-linux-gnu/libsoftokn3.so
7f61fb2fd000-7f61fb2fe000 rw-p 0005c000 fd:01 56766363                   /usr/lib/x86_64-linux-gnu/libsoftokn3.so
7f61fb2fe000-7f61fb302000 rw-p 00000000 00:00 0 
7f61fb302000-7f61fb303000 ---p 00000000 00:00 0 
7f61fb303000-7f61fb3ff000 rw-p 00000000 00:00 0 
7f61fb3ff000-7f61fb400000 ---p 00000000 00:00 0 
7f61fb400000-7f61fb407000 r--p 00000000 fd:01 56756176                   /usr/lib/x86_64-linux-gnu/libvpx.so.9.1.0
7f61fb407000-7f61fb718000 r-xp 00007000 fd:01 56756176                   /usr/lib/x86_64-linux-gnu/libvpx.so.9.1.0
7f61fb718000-7f61fb769000 r--p 00318000 fd:01 56756176                   /usr/lib/x86_64-linux-gnu/libvpx.so.9.1.0
7f61fb769000-7f61fb76c000 r--p 00369000 fd:01 56756176                   /usr/lib/x86_64-linux-gnu/libvpx.so.9.1.0
7f61fb76c000-7f61fb76d000 rw-p 0036c000 fd:01 56756176                   /usr/lib/x86_64-linux-gnu/libvpx.so.9.1.0
7f61fb76d000-7f61fb774000 rw-p 00000000 00:00 0 
7f61fb78f000-7f61fb790000 ---p 00000000 00:00 0 
7f61fb790000-7f61fb7d0000 rw-p 00000000 00:00 0 
7f61fb7d0000-7f61fb7d1000 ---p 00000000 00:00 0 
7f61fb7d1000-7f61fb811000 rw-p 00000000 00:00 0 
7f61fb811000-7f61fb853000 r--s 00000000 00:01 16399                      /memfd:mozilla-ipc (deleted)
7f61fb853000-7f61fb854000 ---p 00000000 00:00 0 
7f61fb854000-7f61fb894000 rw-p 00000000 00:00 0 
7f61fb894000-7f61fb8a2000 r--p 00000000 fd:01 56764741                   /usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1
7f61fb8a2000-7f61fb8d4000 r-xp 0000e000 fd:01 56764741                   /usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1
7f61fb8d4000-7f61fb8e7000 r--p 00040000 fd:01 56764741                   /usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1
7f61fb8e7000-7f61fb8e9000 r--p 00053000 fd:01 56764741                   /usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1
7f61fb8e9000-7f61fb8ea000 rw-p 00055000 fd:01 56764741                   /usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.1
7f61fb8ea000-7f61fb8f8000 r--p 00000000 fd:01 56766364                   /usr/lib/x86_64-linux-gnu/libssl3.so
7f61fb8f8000-7f61fb93a000 r-xp 0000e000 fd:01 56766364                   /usr/lib/x86_64-linux-gnu/libssl3.so
7f61fb93a000-7f61fb94f000 r--p 00050000 fd:01 56766364                   /usr/lib/x86_64-linux-gnu/libssl3.so
7f61fb94f000-7f61fb953000 r--p 00065000 fd:01 56766364                   /usr/lib/x86_64-linux-gnu/libssl3.so
7f61fb953000-7f61fb954000 rw-p 00069000 fd:01 56766364                   /usr/lib/x86_64-linux-gnu/libssl3.so
7f61fb954000-7f61fb955000 rw-p 00000000 00:00 0 
7f61fb955000-7f61fb95f000 r--p 00000000 fd:01 56766361                   /usr/lib/x86_64-linux-gnu/libsmime3.so
7f61fb95f000-7f61fb97c000 r-xp 0000a000 fd:01 56766361                   /usr/lib/x86_64-linux-gnu/libsmime3.so
7f61fb97c000-7f61fb984000 r--p 00027000 fd:01 56766361                   /usr/lib/x86_64-linux-gnu/libsmime3.so
7f61fb984000-7f61fb988000 r--p 0002f000 fd:01 56766361                   /usr/lib/x86_64-linux-gnu/libsmime3.so
7f61fb988000-7f61fb989000 rw-p 00033000 fd:01 56766361                   /usr/lib/x86_64-linux-gnu/libsmime3.so
7f61fb989000-7f61fb9a5000 r--p 00000000 fd:01 56766109                   /usr/lib/x86_64-linux-gnu/libnss3.so
7f61fb9a5000-7f61fbaa0000 r-xp 0001c000 fd:01 56766109                   /usr/lib/x86_64-linux-gnu/libnss3.so
7f61fbaa0000-7f61fbae1000 r--p 00117000 fd:01 56766109                   /usr/lib/x86_64-linux-gnu/libnss3.so
7f61fbae1000-7f61fbae8000 r--p 00158000 fd:01 56766109                   /usr/lib/x86_64-linux-gnu/libnss3.so
7f61fbae8000-7f61fbae9000 rw-p 0015f000 fd:01 56766109                   /usr/lib/x86_64-linux-gnu/libnss3.so
7f61fbae9000-7f61fbaeb000 rw-p 00000000 00:00 0 
7f61fbaeb000-7f61fbb1b000 r--p 00000000 fd:01 56755565                   /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f61fbb1b000-7f61fbbba000 r-xp 00030000 fd:01 56755565                   /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f61fbbba000-7f61fbbf7000 r--p 000cf000 fd:01 56755565                   /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f61fbbf7000-7f61fbbff000 r--p 0010c000 fd:01 56755565                   /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f61fbbff000-7f61fbc00000 rw-p 00114000 fd:01 56755565                   /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f61fbc00000-7f61fe7b3000 r--p 00000000 fd:01 63180439                   /usr/lib/firefox/libxul.so
7f61fe7b3000-7f6204c3b000 r-xp 02bb2000 fd:01 63180439                   /usr/lib/firefox/libxul.so
7f6204c3b000-7f6205112000 r--p 09039000 fd:01 63180439                   /usr/lib/firefox/libxul.so
7f6205112000-7f62051aa000 rw-p 0950f000 fd:01 63180439                   /usr/lib/firefox/libxul.so
7f62051aa000-7f6205257000 rw-p 00000000 00:00 0 
7f620527c000-7f6205289000 r--p 00000000 fd:01 56766360                   /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f6205289000-7f620529b000 r-xp 0000d000 fd:01 56766360                   /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f620529b000-7f62052a8000 r--p 0001f000 fd:01 56766360                   /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f62052a8000-7f62052af000 r--p 0002c000 fd:01 56766360                   /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f62052af000-7f62052b0000 rw-p 00033000 fd:01 56766360                   /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f62052c6000-7f62052d2000 rw-p 00000000 00:00 0 
7f62052d2000-7f62052d5000 r--p 00000000 fd:01 56755779                   /usr/lib/x86_64-linux-gnu/libcap.so.2.66
7f62052d5000-7f62052da000 r-xp 00003000 fd:01 56755779                   /usr/lib/x86_64-linux-gnu/libcap.so.2.66
7f62052da000-7f62052dc000 r--p 00008000 fd:01 56755779                   /usr/lib/x86_64-linux-gnu/libcap.so.2.66
7f62052dc000-7f62052dd000 r--p 0000a000 fd:01 56755779                   /usr/lib/x86_64-linux-gnu/libcap.so.2.66
7f62052dd000-7f62052de000 rw-p 0000b000 fd:01 56755779                   /usr/lib/x86_64-linux-gnu/libcap.so.2.66
7f62052de000-7f62052df000 r--p 00000000 fd:01 56758033                   /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0
7f62052df000-7f62052e0000 r-xp 00001000 fd:01 56758033                   /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0
7f62052e0000-7f62052ff000 r--p 00002000 fd:01 56758033                   /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0
7f62052ff000-7f6205300000 r--p 00021000 fd:01 56758033                   /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0
7f6205300000-7f6205301000 rw-p 00022000 fd:01 56758033                   /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0
7f6205301000-7f620531d000 r--p 00000000 fd:01 56763774                   /usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0
7f620531d000-7f62053cc000 r-xp 0001c000 fd:01 56763774                   /usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0
7f62053cc000-7f6205407000 r--p 000cb000 fd:01 56763774                   /usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0
7f6205407000-7f6205414000 r--p 00105000 fd:01 56763774                   /usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0
7f6205414000-7f6205415000 rw-p 00112000 fd:01 56763774                   /usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0
7f6205415000-7f6205416000 rw-p 00000000 00:00 0 
7f6205416000-7f6205418000 r--p 00000000 fd:01 56758505                   /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f6205418000-7f620541a000 r-xp 00002000 fd:01 56758505                   /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f620541a000-7f620541c000 r--p 00004000 fd:01 56758505                   /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f620541c000-7f620541d000 r--p 00005000 fd:01 56758505                   /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f620541d000-7f620541e000 rw-p 00006000 fd:01 56758505                   /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f620541e000-7f620541f000 r--p 00000000 fd:01 56758412                   /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f620541f000-7f6205420000 r-xp 00001000 fd:01 56758412                   /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f6205420000-7f6205421000 r--p 00002000 fd:01 56758412                   /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f6205421000-7f6205422000 r--p 00002000 fd:01 56758412                   /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f6205422000-7f6205423000 rw-p 00003000 fd:01 56758412                   /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f6205423000-7f6205424000 r--p 00000000 fd:01 56764113                   /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0
7f6205424000-7f620542c000 r-xp 00001000 fd:01 56764113                   /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0
7f620542c000-7f620542f000 r--p 00009000 fd:01 56764113                   /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0
7f620542f000-7f6205430000 r--p 0000b000 fd:01 56764113                   /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0
7f6205430000-7f6205431000 rw-p 0000c000 fd:01 56764113                   /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0
7f6205431000-7f6205433000 r--p 00000000 fd:01 56754219                   /usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4
7f6205433000-7f6205440000 r-xp 00002000 fd:01 56754219                   /usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4
7f6205440000-7f6205442000 r--p 0000f000 fd:01 56754219                   /usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4
7f6205442000-7f6205443000 r--p 00010000 fd:01 56754219                   /usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4
7f6205443000-7f6205444000 rw-p 00011000 fd:01 56754219                   /usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4
7f6205444000-7f6205446000 r--p 00000000 fd:01 56786448                   /usr/lib/x86_64-linux-gnu/libdatrie.so.1.4.0
7f6205446000-7f620544a000 r-xp 00002000 fd:01 56786448                   /usr/lib/x86_64-linux-gnu/libdatrie.so.1.4.0
7f620544a000-7f620544c000 r--p 00006000 fd:01 56786448                   /usr/lib/x86_64-linux-gnu/libdatrie.so.1.4.0
7f620544c000-7f620544d000 r--p 00007000 fd:01 56786448                   /usr/lib/x86_64-linux-gnu/libdatrie.so.1.4.0
7f620544d000-7f620544e000 rw-p 00008000 fd:01 56786448                   /usr/lib/x86_64-linux-gnu/libdatrie.so.1.4.0
7f620544e000-7f6205458000 r--p 00000000 fd:01 56755667                   /usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f6205458000-7f6205494000 r-xp 0000a000 fd:01 56755667                   /usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f6205494000-7f62054a7000 r--p 00046000 fd:01 56755667                   /usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f62054a7000-7f62054ad000 r--p 00059000 fd:01 56755667                   /usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f62054ad000-7f62054ae000 rw-p 0005f000 fd:01 56755667                   /usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f62054ae000-7f62054bc000 r--p 00000000 fd:01 56755806                   /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3
7f62054bc000-7f62054ed000 r-xp 0000e000 fd:01 56755806                   /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3
7f62054ed000-7f6205502000 r--p 0003f000 fd:01 56755806                   /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3
7f6205502000-7f6205504000 r--p 00053000 fd:01 56755806                   /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3
7f6205504000-7f6205505000 rw-p 00055000 fd:01 56755806                   /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3
7f6205505000-7f6205516000 r--p 00000000 fd:01 56763174                   /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f6205516000-7f620552e000 r-xp 00011000 fd:01 56763174                   /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f620552e000-7f620553c000 r--p 00029000 fd:01 56763174                   /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f620553c000-7f6205540000 r--p 00036000 fd:01 56763174                   /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f6205540000-7f6205541000 rw-p 0003a000 fd:01 56763174                   /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f6205541000-7f6205545000 r--p 00000000 fd:01 56757433                   /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
7f6205545000-7f6205594000 r-xp 00004000 fd:01 56757433                   /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
7f6205594000-7f62055d6000 r--p 00053000 fd:01 56757433                   /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
7f62055d6000-7f62055d7000 r--p 00095000 fd:01 56757433                   /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
7f62055d7000-7f62055d8000 rw-p 00096000 fd:01 56757433                   /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
7f62055d8000-7f62055dc000 r--p 00000000 fd:01 56754304                   /usr/lib/x86_64-linux-gnu/libexpat.so.1.10.0
7f62055dc000-7f62055f8000 r-xp 00004000 fd:01 56754304                   /usr/lib/x86_64-linux-gnu/libexpat.so.1.10.0
7f62055f8000-7f6205600000 r--p 00020000 fd:01 56754304                   /usr/lib/x86_64-linux-gnu/libexpat.so.1.10.0
7f6205600000-7f6205602000 r--p 00028000 fd:01 56754304                   /usr/lib/x86_64-linux-gnu/libexpat.so.1.10.0
7f6205602000-7f6205603000 rw-p 0002a000 fd:01 56754304                   /usr/lib/x86_64-linux-gnu/libexpat.so.1.10.0
7f6205603000-7f620560e000 r--p 00000000 fd:01 56759633                   /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.44.0
7f620560e000-7f6205695000 r-xp 0000b000 fd:01 56759633                   /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.44.0
7f6205695000-7f62056a7000 r--p 00092000 fd:01 56759633                   /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.44.0
7f62056a7000-7f62056af000 r--p 000a4000 fd:01 56759633                   /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.44.0
7f62056af000-7f62056b0000 rw-p 000ac000 fd:01 56759633                   /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.44.0
7f62056b0000-7f62056b1000 r--p 00000000 fd:01 56755461                   /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f62056b1000-7f62056b2000 r-xp 00001000 fd:01 56755461                   /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f62056b2000-7f62056b3000 r--p 00002000 fd:01 56755461                   /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f62056b3000-7f62056b4000 r--p 00002000 fd:01 56755461                   /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f62056b4000-7f62056b5000 rw-p 00003000 fd:01 56755461                   /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f62056b5000-7f62056ba000 r--p 00000000 fd:01 56760888                   /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f62056ba000-7f62056c0000 r-xp 00005000 fd:01 56760888                   /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f62056c0000-7f62056c2000 r--p 0000b000 fd:01 56760888                   /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f62056c2000-7f62056c3000 r--p 0000d000 fd:01 56760888                   /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f62056c3000-7f62056c4000 rw-p 0000e000 fd:01 56760888                   /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f62056c4000-7f62056d0000 r--p 00000000 fd:01 56754381                   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f62056d0000-7f62056e4000 r-xp 0000c000 fd:01 56754381                   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f62056e4000-7f62056ed000 r--p 00020000 fd:01 56754381                   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f62056ed000-7f62056ee000 r--p 00028000 fd:01 56754381                   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f62056ee000-7f62056ef000 rw-p 00029000 fd:01 56754381                   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f62056ef000-7f62056f1000 r--p 00000000 fd:01 56756225                   /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f62056f1000-7f62056f8000 r-xp 00002000 fd:01 56756225                   /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f62056f8000-7f62056fa000 r--p 00009000 fd:01 56756225                   /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f62056fa000-7f62056fb000 r--p 0000a000 fd:01 56756225                   /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f62056fb000-7f62056fc000 rw-p 0000b000 fd:01 56756225                   /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f62056fc000-7f6205702000 r--p 00000000 fd:01 56758438                   /usr/lib/x86_64-linux-gnu/libpng16.so.16.47.0
7f6205702000-7f6205727000 r-xp 00006000 fd:01 56758438                   /usr/lib/x86_64-linux-gnu/libpng16.so.16.47.0
7f6205727000-7f6205732000 r--p 0002b000 fd:01 56758438                   /usr/lib/x86_64-linux-gnu/libpng16.so.16.47.0
7f6205732000-7f6205733000 r--p 00036000 fd:01 56758438                   /usr/lib/x86_64-linux-gnu/libpng16.so.16.47.0
7f6205733000-7f6205734000 rw-p 00037000 fd:01 56758438                   /usr/lib/x86_64-linux-gnu/libpng16.so.16.47.0
7f6205734000-7f6205737000 r--p 00000000 fd:01 56762972                   /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
7f6205737000-7f6205756000 r-xp 00003000 fd:01 56762972                   /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
7f6205756000-7f620575b000 r--p 00022000 fd:01 56762972                   /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
7f620575b000-7f620575d000 r--p 00026000 fd:01 56762972                   /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
7f620575d000-7f620575e000 rw-p 00028000 fd:01 56762972                   /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
7f620575e000-7f620576c000 r--p 00000000 fd:01 56754608                   /usr/lib/x86_64-linux-gnu/libfreetype.so.6.20.2
7f620576c000-7f62057fa000 r-xp 0000e000 fd:01 56754608                   /usr/lib/x86_64-linux-gnu/libfreetype.so.6.20.2
7f62057fa000-7f6205825000 r--p 0009c000 fd:01 56754608                   /usr/lib/x86_64-linux-gnu/libfreetype.so.6.20.2
7f6205825000-7f620582d000 r--p 000c6000 fd:01 56754608                   /usr/lib/x86_64-linux-gnu/libfreetype.so.6.20.2
7f620582d000-7f620582e000 rw-p 000ce000 fd:01 56754608                   /usr/lib/x86_64-linux-gnu/libfreetype.so.6.20.2
7f620582e000-7f6205830000 r--p 00000000 fd:01 56769421                   /usr/lib/x86_64-linux-gnu/libthai.so.0.3.1
7f6205830000-7f6205834000 r-xp 00002000 fd:01 56769421                   /usr/lib/x86_64-linux-gnu/libthai.so.0.3.1
7f6205834000-7f6205837000 r--p 00006000 fd:01 56769421                   /usr/lib/x86_64-linux-gnu/libthai.so.0.3.1
7f6205837000-7f6205838000 r--p 00008000 fd:01 56769421                   /usr/lib/x86_64-linux-gnu/libthai.so.0.3.1
7f6205838000-7f6205839000 rw-p 00009000 fd:01 56769421                   /usr/lib/x86_64-linux-gnu/libthai.so.0.3.1
7f6205839000-7f6205840000 r--p 00000000 fd:01 56757996                   /usr/lib/x86_64-linux-gnu/libselinux.so.1
7f6205840000-7f6205860000 r-xp 00007000 fd:01 56757996                   /usr/lib/x86_64-linux-gnu/libselinux.so.1
7f6205860000-7f6205869000 r--p 00027000 fd:01 56757996                   /usr/lib/x86_64-linux-gnu/libselinux.so.1
7f6205869000-7f620586a000 r--p 0002f000 fd:01 56757996                   /usr/lib/x86_64-linux-gnu/libselinux.so.1
7f620586a000-7f620586b000 rw-p 00030000 fd:01 56757996                   /usr/lib/x86_64-linux-gnu/libselinux.so.1
7f620586b000-7f620586d000 rw-p 00000000 00:00 0 
7f620586d000-7f6205879000 r--p 00000000 fd:01 56758262                   /usr/lib/x86_64-linux-gnu/libmount.so.1.1.0
7f6205879000-7f62058c6000 r-xp 0000c000 fd:01 56758262                   /usr/lib/x86_64-linux-gnu/libmount.so.1.1.0
7f62058c6000-7f62058de000 r--p 00059000 fd:01 56758262                   /usr/lib/x86_64-linux-gnu/libmount.so.1.1.0
7f62058de000-7f62058e1000 r--p 00070000 fd:01 56758262                   /usr/lib/x86_64-linux-gnu/libmount.so.1.1.0
7f62058e1000-7f62058e2000 rw-p 00073000 fd:01 56758262                   /usr/lib/x86_64-linux-gnu/libmount.so.1.1.0
7f62058e2000-7f62058e5000 r--p 00000000 fd:01 56756577                   /usr/lib/x86_64-linux-gnu/libz.so.1.3.1
7f62058e5000-7f62058f9000 r-xp 00003000 fd:01 56756577                   /usr/lib/x86_64-linux-gnu/libz.so.1.3.1
7f62058f9000-7f6205900000 r--p 00017000 fd:01 56756577                   /usr/lib/x86_64-linux-gnu/libz.so.1.3.1
7f6205900000-7f6205901000 r--p 0001d000 fd:01 56756577                   /usr/lib/x86_64-linux-gnu/libz.so.1.3.1
7f6205901000-7f6205902000 rw-p 0001e000 fd:01 56756577                   /usr/lib/x86_64-linux-gnu/libz.so.1.3.1
7f6205902000-7f6205904000 r--p 00000000 fd:01 56755279                   /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
7f6205904000-7f620590b000 r-xp 00002000 fd:01 56755279                   /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
7f620590b000-7f620590d000 r--p 00009000 fd:01 56755279                   /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
7f620590d000-7f620590e000 r--p 0000a000 fd:01 56755279                   /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
7f620590e000-7f620590f000 rw-p 0000b000 fd:01 56755279                   /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
7f620590f000-7f6205912000 r--p 00000000 fd:01 56754213                   /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0
7f6205912000-7f620598d000 r-xp 00003000 fd:01 56754213                   /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0
7f620598d000-7f62059bc000 r--p 0007e000 fd:01 56754213                   /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0
7f62059bc000-7f62059bd000 r--p 000ac000 fd:01 56754213                   /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0
7f62059bd000-7f62059be000 rw-p 000ad000 fd:01 56754213                   /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0
7f62059be000-7f62059c0000 r--p 00000000 fd:01 56756206                   /usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0
7f62059c0000-7f62059c3000 r-xp 00002000 fd:01 56756206                   /usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0
7f62059c3000-7f62059c5000 r--p 00005000 fd:01 56756206                   /usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0
7f62059c5000-7f62059c6000 r--p 00006000 fd:01 56756206                   /usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0
7f62059c6000-7f62059c7000 rw-p 00007000 fd:01 56756206                   /usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0
7f62059c7000-7f62059c8000 rw-p 00000000 00:00 0 
7f62059c8000-7f62059c9000 r--p 00000000 fd:01 56759431                   /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f62059c9000-7f62059ca000 r-xp 00001000 fd:01 56759431                   /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f62059ca000-7f62059cb000 r--p 00002000 fd:01 56759431                   /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f62059cb000-7f62059cc000 r--p 00002000 fd:01 56759431                   /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f62059cc000-7f62059cd000 rw-p 00003000 fd:01 56759431                   /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f62059cd000-7f62059cf000 r--p 00000000 fd:01 56763712                   /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f62059cf000-7f62059d6000 r-xp 00002000 fd:01 56763712                   /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f62059d6000-7f62059d8000 r--p 00009000 fd:01 56763712                   /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f62059d8000-7f62059d9000 r--p 0000a000 fd:01 56763712                   /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f62059d9000-7f62059da000 rw-p 0000b000 fd:01 56763712                   /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f62059da000-7f62059dd000 r--p 00000000 fd:01 56757791                   /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f62059dd000-7f62059e3000 r-xp 00003000 fd:01 56757791                   /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f62059e3000-7f62059e5000 r--p 00009000 fd:01 56757791                   /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f62059e5000-7f62059e6000 r--p 0000a000 fd:01 56757791                   /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f62059e6000-7f62059e7000 rw-p 0000b000 fd:01 56757791                   /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f62059e7000-7f62059eb000 r--p 00000000 fd:01 56755348                   /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f62059eb000-7f62059f6000 r-xp 00004000 fd:01 56755348                   /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f62059f6000-7f62059fa000 r--p 0000f000 fd:01 56755348                   /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f62059fa000-7f62059fb000 r--p 00012000 fd:01 56755348                   /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f62059fb000-7f62059fc000 rw-p 00013000 fd:01 56755348                   /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f62059fc000-7f62059fe000 r--p 00000000 fd:01 56755982                   /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.23.1
7f62059fe000-7f6205a00000 r-xp 00002000 fd:01 56755982                   /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.23.1
7f6205a00000-7f6205a01000 r--p 00004000 fd:01 56755982                   /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.23.1
7f6205a01000-7f6205a02000 r--p 00004000 fd:01 56755982                   /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.23.1
7f6205a02000-7f6205a06000 rw-p 00005000 fd:01 56755982                   /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.23.1
7f6205a06000-7f6205a0c000 r--p 00000000 fd:01 56756571                   /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.23.1
7f6205a0c000-7f6205a13000 r-xp 00006000 fd:01 56756571                   /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.23.1
7f6205a13000-7f6205a16000 r--p 0000d000 fd:01 56756571                   /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.23.1
7f6205a16000-7f6205a18000 r--p 00010000 fd:01 56756571                   /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.23.1
7f6205a18000-7f6205a19000 rw-p 00012000 fd:01 56756571                   /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.23.1
7f6205a19000-7f6205a1e000 r--p 00000000 fd:01 56773489                   /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
7f6205a1e000-7f6205a3d000 r-xp 00005000 fd:01 56773489                   /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
7f6205a3d000-7f6205a61000 r--p 00024000 fd:01 56773489                   /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
7f6205a61000-7f6205a63000 r--p 00047000 fd:01 56773489                   /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
7f6205a63000-7f6205a64000 rw-p 00049000 fd:01 56773489                   /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
7f6205a64000-7f6205a70000 r--p 00000000 fd:01 56758877                   /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f6205a70000-7f6205a89000 r-xp 0000c000 fd:01 56758877                   /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f6205a89000-7f6205a9e000 r--p 00025000 fd:01 56758877                   /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f6205a9e000-7f6205aa0000 r--p 00039000 fd:01 56758877                   /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f6205aa0000-7f6205aa2000 rw-p 0003b000 fd:01 56758877                   /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f6205aa2000-7f6205abe000 r--p 00000000 fd:01 56757409                   /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
7f6205abe000-7f6205b4e000 r-xp 0001c000 fd:01 56757409                   /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
7f6205b4e000-7f6205be4000 r--p 000ac000 fd:01 56757409                   /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
7f6205be4000-7f6205be5000 r--p 00142000 fd:01 56757409                   /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
7f6205be5000-7f6205bea000 rw-p 00143000 fd:01 56757409                   /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
7f6205bea000-7f6205c49000 r--p 00000000 fd:01 56754485                   /usr/lib/x86_64-linux-gnu/libepoxy.so.0.0.0
7f6205c49000-7f6205cae000 r-xp 0005f000 fd:01 56754485                   /usr/lib/x86_64-linux-gnu/libepoxy.so.0.0.0
7f6205cae000-7f6205d0b000 r--p 000c4000 fd:01 56754485                   /usr/lib/x86_64-linux-gnu/libepoxy.so.0.0.0
7f6205d0b000-7f6205d13000 r--p 00121000 fd:01 56754485                   /usr/lib/x86_64-linux-gnu/libepoxy.so.0.0.0
7f6205d13000-7f6205d1a000 rw-p 00129000 fd:01 56754485                   /usr/lib/x86_64-linux-gnu/libepoxy.so.0.0.0
7f6205d1a000-7f6205d2e000 r--p 00000000 fd:01 56759659                   /usr/lib/x86_64-linux-gnu/libcairo.so.2.11802.2
7f6205d2e000-7f6205e1a000 r-xp 00014000 fd:01 56759659                   /usr/lib/x86_64-linux-gnu/libcairo.so.2.11802.2
7f6205e1a000-7f6205e5c000 r--p 00100000 fd:01 56759659                   /usr/lib/x86_64-linux-gnu/libcairo.so.2.11802.2
7f6205e5c000-7f6205e60000 r--p 00142000 fd:01 56759659                   /usr/lib/x86_64-linux-gnu/libcairo.so.2.11802.2
7f6205e60000-7f6205e62000 rw-p 00146000 fd:01 56759659                   /usr/lib/x86_64-linux-gnu/libcairo.so.2.11802.2
7f6205e62000-7f6205e63000 rw-p 00000000 00:00 0 
7f6205e63000-7f6205e70000 r--p 00000000 fd:01 56754501                   /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.61020.0
7f6205e70000-7f6205f62000 r-xp 0000d000 fd:01 56754501                   /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.61020.0
7f6205f62000-7f6205fa1000 r--p 000ff000 fd:01 56754501                   /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.61020.0
7f6205fa1000-7f6205fa3000 r--p 0013d000 fd:01 56754501                   /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.61020.0
7f6205fa3000-7f6205fa4000 rw-p 0013f000 fd:01 56754501                   /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.61020.0
7f6205fa4000-7f6205fe2000 r--p 00000000 fd:01 56754843                   /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8304.0
7f6205fe2000-7f6206100000 r-xp 0003e000 fd:01 56754843                   /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8304.0
7f6206100000-7f620618e000 r--p 0015c000 fd:01 56754843                   /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8304.0
7f620618e000-7f6206198000 r--p 001ea000 fd:01 56754843                   /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8304.0
7f6206198000-7f6206199000 rw-p 001f4000 fd:01 56754843                   /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8304.0
7f6206199000-7f620619b000 rw-p 00000000 00:00 0 
7f620619b000-7f62061b9000 r--p 00000000 fd:01 56755540                   /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8304.0
7f62061b9000-7f620625a000 r-xp 0001e000 fd:01 56755540                   /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8304.0
7f620625a000-7f62062ef000 r--p 000bf000 fd:01 56755540                   /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8304.0
7f62062ef000-7f62062f0000 r--p 00154000 fd:01 56755540                   /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8304.0
7f62062f0000-7f62062f1000 rw-p 00155000 fd:01 56755540                   /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8304.0
7f62062f1000-7f62062f2000 rw-p 00000000 00:00 0 
7f62062f2000-7f6206320000 r--p 00000000 fd:01 56763917                   /usr/lib/x86_64-linux-gnu/libgdk-3.so.0.2416.32
7f6206320000-7f62063a6000 r-xp 0002e000 fd:01 56763917                   /usr/lib/x86_64-linux-gnu/libgdk-3.so.0.2416.32
7f62063a6000-7f62063f4000 r--p 000b4000 fd:01 56763917                   /usr/lib/x86_64-linux-gnu/libgdk-3.so.0.2416.32
7f62063f4000-7f62063fe000 r--p 00102000 fd:01 56763917                   /usr/lib/x86_64-linux-gnu/libgdk-3.so.0.2416.32
7f62063fe000-7f6206400000 rw-p 0010c000 fd:01 56763917                   /usr/lib/x86_64-linux-gnu/libgdk-3.so.0.2416.32
7f6206400000-7f620648d000 r--p 00000000 fd:01 56763918                   /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2416.32
7f620648d000-7f620681e000 r-xp 0008d000 fd:01 56763918                   /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2416.32
7f620681e000-7f6206be2000 r--p 0041e000 fd:01 56763918                   /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2416.32
7f6206be2000-7f6206bf5000 r--p 007e1000 fd:01 56763918                   /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2416.32
7f6206bf5000-7f6206bf8000 rw-p 007f4000 fd:01 56763918                   /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2416.32
7f6206bf8000-7f6206bfd000 rw-p 00000000 00:00 0 
7f6206c01000-7f6206c02000 r--p 00000000 fd:01 56757955                   /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f6206c02000-7f6206c03000 r-xp 00001000 fd:01 56757955                   /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f6206c03000-7f6206c04000 r--p 00002000 fd:01 56757955                   /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f6206c04000-7f6206c05000 r--p 00002000 fd:01 56757955                   /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f6206c05000-7f6206c06000 rw-p 00003000 fd:01 56757955                   /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f6206c06000-7f6206c0d000 r--p 00000000 fd:01 56757431                   /usr/lib/x86_64-linux-gnu/libcloudproviders.so.0.3.6
7f6206c0d000-7f6206c17000 r-xp 00007000 fd:01 56757431                   /usr/lib/x86_64-linux-gnu/libcloudproviders.so.0.3.6
7f6206c17000-7f6206c1c000 r--p 00011000 fd:01 56757431                   /usr/lib/x86_64-linux-gnu/libcloudproviders.so.0.3.6
7f6206c1c000-7f6206c1d000 r--p 00016000 fd:01 56757431                   /usr/lib/x86_64-linux-gnu/libcloudproviders.so.0.3.6
7f6206c1d000-7f6206c1e000 rw-p 00017000 fd:01 56757431                   /usr/lib/x86_64-linux-gnu/libcloudproviders.so.0.3.6
7f6206c1e000-7f6206c21000 r--p 00000000 fd:01 56762745                   /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f6206c21000-7f6206c2d000 r-xp 00003000 fd:01 56762745                   /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f6206c2d000-7f6206c30000 r--p 0000f000 fd:01 56762745                   /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f6206c30000-7f6206c31000 r--p 00011000 fd:01 56762745                   /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f6206c31000-7f6206c32000 rw-p 00012000 fd:01 56762745                   /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f6206c32000-7f6206c3d000 r--p 00000000 fd:01 56759189                   /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.25511.1
7f6206c3d000-7f6206c4c000 r-xp 0000b000 fd:01 56759189                   /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.25511.1
7f6206c4c000-7f6206c58000 r--p 0001a000 fd:01 56759189                   /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.25511.1
7f6206c58000-7f6206c5b000 r--p 00025000 fd:01 56759189                   /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.25511.1
7f6206c5b000-7f6206c5c000 rw-p 00028000 fd:01 56759189                   /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.25511.1
7f6206c5c000-7f6206c64000 r--p 00000000 fd:01 56755115                   /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.1
7f6206c64000-7f6206c8e000 r-xp 00008000 fd:01 56755115                   /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.1
7f6206c8e000-7f6206ca7000 r--p 00032000 fd:01 56755115                   /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.1
7f6206ca7000-7f6206ca9000 r--p 0004b000 fd:01 56755115                   /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.1
7f6206ca9000-7f6206caa000 rw-p 0004d000 fd:01 56755115                   /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.1
7f6206caa000-7f6206cdf000 r--p 00000000 fd:01 63180436                   /usr/lib/firefox/libmozsqlite3.so
7f6206cdf000-7f6206df8000 r-xp 00034000 fd:01 63180436                   /usr/lib/firefox/libmozsqlite3.so
7f6206df8000-7f6206dfb000 r--p 0014c000 fd:01 63180436                   /usr/lib/firefox/libmozsqlite3.so
7f6206dfb000-7f6206e00000 rw-p 0014e000 fd:01 63180436                   /usr/lib/firefox/libmozsqlite3.so
7f6206e00000-7f6206f78000 r--p 00000000 fd:01 63180425                   /usr/lib/firefox/libgkcodecs.so
7f6206f78000-7f62074cc000 r-xp 00177000 fd:01 63180425                   /usr/lib/firefox/libgkcodecs.so
7f62074cc000-7f62074f5000 r--p 006ca000 fd:01 63180425                   /usr/lib/firefox/libgkcodecs.so
7f62074f5000-7f62074fb000 rw-p 006f2000 fd:01 63180425                   /usr/lib/firefox/libgkcodecs.so
7f62074fb000-7f6207547000 rw-p 00000000 00:00 0 
7f6207548000-7f6207549000 r--p 00000000 fd:01 56758344                   /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f6207549000-7f620754a000 r-xp 00001000 fd:01 56758344                   /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f620754a000-7f620754b000 r--p 00002000 fd:01 56758344                   /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f620754b000-7f620754c000 r--p 00002000 fd:01 56758344                   /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f620754c000-7f620754d000 rw-p 00003000 fd:01 56758344                   /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f620754d000-7f620754f000 r--p 00000000 fd:01 56758572                   /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f620754f000-7f6207552000 r-xp 00002000 fd:01 56758572                   /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f6207552000-7f6207553000 r--p 00005000 fd:01 56758572                   /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f6207553000-7f6207554000 r--p 00005000 fd:01 56758572                   /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f6207554000-7f6207555000 rw-p 00006000 fd:01 56758572                   /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f6207555000-7f620755d000 r--p 00000000 fd:01 56757766                   /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.4200.12
7f620755d000-7f6207577000 r-xp 00008000 fd:01 56757766                   /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.4200.12
7f6207577000-7f6207581000 r--p 00022000 fd:01 56757766                   /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.4200.12
7f6207581000-7f6207582000 r--p 0002c000 fd:01 56757766                   /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.4200.12
7f6207582000-7f6207583000 rw-p 0002d000 fd:01 56757766                   /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.4200.12
7f6207583000-7f6207587000 r--p 00000000 fd:01 56757559                   /usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2.11802.2
7f6207587000-7f6207589000 r-xp 00004000 fd:01 56757559                   /usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2.11802.2
7f6207589000-7f620758b000 r--p 00006000 fd:01 56757559                   /usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2.11802.2
7f620758b000-7f620758d000 r--p 00008000 fd:01 56757559                   /usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2.11802.2
7f620758d000-7f620758e000 rw-p 0000a000 fd:01 56757559                   /usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2.11802.2
7f620758e000-7f62075a1000 r--p 00000000 fd:01 56762563                   /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5600.1
7f62075a1000-7f62075de000 r-xp 00013000 fd:01 56762563                   /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5600.1
7f62075de000-7f62075fa000 r--p 00050000 fd:01 56762563                   /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5600.1
7f62075fa000-7f62075fe000 r--p 0006b000 fd:01 56762563                   /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5600.1
7f62075fe000-7f62075ff000 rw-p 0006f000 fd:01 56762563                   /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5600.1
7f62075ff000-7f6207600000 ---p 00000000 00:00 0 
7f6207600000-7f6207e00000 rw-p 00000000 00:00 0 
7f6207e00000-7f6208100000 ---p 00000000 00:00 0 
7f6208100000-7f6208102000 rw-p 00000000 00:00 0 
7f6208102000-7f6208103000 ---p 00000000 00:00 0 
7f6208103000-7f62081ff000 rw-p 00000000 00:00 0 
7f62081ff000-7f6208200000 ---p 00000000 00:00 0 
7f6208200000-7f6208201000 rw-p 00000000 00:00 0 
7f6208201000-7f6208300000 ---p 00000000 00:00 0 
7f6208300000-7f6208302000 r--p 00000000 fd:01 56756886                   /usr/lib/x86_64-linux-gnu/libfribidi.so.0.4.0
7f6208302000-7f6208306000 r-xp 00002000 fd:01 56756886                   /usr/lib/x86_64-linux-gnu/libfribidi.so.0.4.0
7f6208306000-7f620831d000 r--p 00006000 fd:01 56756886                   /usr/lib/x86_64-linux-gnu/libfribidi.so.0.4.0
7f620831d000-7f620831e000 r--p 0001c000 fd:01 56756886                   /usr/lib/x86_64-linux-gnu/libfribidi.so.0.4.0
7f620831e000-7f620831f000 rw-p 0001d000 fd:01 56756886                   /usr/lib/x86_64-linux-gnu/libfribidi.so.0.4.0
7f620831f000-7f6208327000 r--p 00000000 fd:01 56756310                   /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5600.1
7f6208327000-7f6208335000 r-xp 00008000 fd:01 56756310                   /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5600.1
7f6208335000-7f620833a000 r--p 00016000 fd:01 56756310                   /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5600.1
7f620833a000-7f620833b000 r--p 0001b000 fd:01 56756310                   /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5600.1
7f620833b000-7f620833c000 rw-p 0001c000 fd:01 56756310                   /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5600.1
7f620833c000-7f620834c000 r--p 00000000 fd:01 56758125                   /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8304.0
7f620834c000-7f6208381000 r-xp 00010000 fd:01 56758125                   /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8304.0
7f6208381000-7f620839b000 r--p 00045000 fd:01 56758125                   /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8304.0
7f620839b000-7f620839e000 r--p 0005f000 fd:01 56758125                   /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8304.0
7f620839e000-7f620839f000 rw-p 00062000 fd:01 56758125                   /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8304.0
7f620839f000-7f62083a8000 r--p 00000000 fd:01 63180428                   /usr/lib/firefox/liblgpllibs.so
7f62083a8000-7f62083c4000 r-xp 00008000 fd:01 63180428                   /usr/lib/firefox/liblgpllibs.so
7f62083c4000-7f62083c6000 r--p 00023000 fd:01 63180428                   /usr/lib/firefox/liblgpllibs.so
7f62083c6000-7f62083c7000 rw-p 00024000 fd:01 63180428                   /usr/lib/firefox/liblgpllibs.so
7f62083c7000-7f62083d3000 r--p 00000000 fd:01 56756936                   /usr/lib/x86_64-linux-gnu/libnspr4.so
7f62083d3000-7f62083f6000 r-xp 0000c000 fd:01 56756936                   /usr/lib/x86_64-linux-gnu/libnspr4.so
7f62083f6000-7f6208404000 r--p 0002f000 fd:01 56756936                   /usr/lib/x86_64-linux-gnu/libnspr4.so
7f6208404000-7f6208406000 r--p 0003c000 fd:01 56756936                   /usr/lib/x86_64-linux-gnu/libnspr4.so
7f6208406000-7f6208407000 rw-p 0003e000 fd:01 56756936                   /usr/lib/x86_64-linux-gnu/libnspr4.so
7f6208407000-7f620840a000 rw-p 00000000 00:00 0 
7f620840a000-7f6208432000 r--p 00000000 fd:01 56766599                   /usr/lib/x86_64-linux-gnu/libc.so.6
7f6208432000-7f6208597000 r-xp 00028000 fd:01 56766599                   /usr/lib/x86_64-linux-gnu/libc.so.6
7f6208597000-7f62085ed000 r--p 0018d000 fd:01 56766599                   /usr/lib/x86_64-linux-gnu/libc.so.6
7f62085ed000-7f62085f1000 r--p 001e2000 fd:01 56766599                   /usr/lib/x86_64-linux-gnu/libc.so.6
7f62085f1000-7f62085f3000 rw-p 001e6000 fd:01 56766599                   /usr/lib/x86_64-linux-gnu/libc.so.6
7f62085f3000-7f6208600000 rw-p 00000000 00:00 0 
7f6208600000-7f620869d000 r--p 00000000 fd:01 56755581                   /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
7f620869d000-7f62087c6000 r-xp 0009d000 fd:01 56755581                   /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
7f62087c6000-7f6208854000 r--p 001c6000 fd:01 56755581                   /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
7f6208854000-7f620885f000 r--p 00254000 fd:01 56755581                   /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
7f620885f000-7f6208862000 rw-p 0025f000 fd:01 56755581                   /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
7f6208862000-7f6208866000 rw-p 00000000 00:00 0 
7f6208869000-7f6208871000 rw-p 00000000 00:00 0 
7f6208871000-7f6208872000 r--p 00000000 fd:01 56758427                   /usr/lib/x86_64-linux-gnu/libplds4.so
7f6208872000-7f6208873000 r-xp 00001000 fd:01 56758427                   /usr/lib/x86_64-linux-gnu/libplds4.so
7f6208873000-7f6208874000 r--p 00002000 fd:01 56758427                   /usr/lib/x86_64-linux-gnu/libplds4.so
7f6208874000-7f6208875000 r--p 00002000 fd:01 56758427                   /usr/lib/x86_64-linux-gnu/libplds4.so
7f6208875000-7f6208876000 rw-p 00003000 fd:01 56758427                   /usr/lib/x86_64-linux-gnu/libplds4.so
7f6208876000-7f6208877000 r--p 00000000 fd:01 56758365                   /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f6208877000-7f6208878000 r-xp 00001000 fd:01 56758365                   /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f6208878000-7f6208879000 r--p 00002000 fd:01 56758365                   /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f6208879000-7f620887a000 r--p 00002000 fd:01 56758365                   /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f620887a000-7f620887b000 rw-p 00003000 fd:01 56758365                   /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f620887b000-7f620887d000 r--p 00000000 fd:01 56756944                   /usr/lib/x86_64-linux-gnu/libplc4.so
7f620887d000-7f620887f000 r-xp 00002000 fd:01 56756944                   /usr/lib/x86_64-linux-gnu/libplc4.so
7f620887f000-7f6208880000 r--p 00004000 fd:01 56756944                   /usr/lib/x86_64-linux-gnu/libplc4.so
7f6208880000-7f6208881000 r--p 00004000 fd:01 56756944                   /usr/lib/x86_64-linux-gnu/libplc4.so
7f6208881000-7f6208882000 rw-p 00005000 fd:01 56756944                   /usr/lib/x86_64-linux-gnu/libplc4.so
7f6208882000-7f6208884000 r--p 00000000 fd:01 63180437                   /usr/lib/firefox/libmozwayland.so
7f6208884000-7f6208886000 r-xp 00001000 fd:01 63180437                   /usr/lib/firefox/libmozwayland.so
7f6208886000-7f6208887000 r--p 00002000 fd:01 63180437                   /usr/lib/firefox/libmozwayland.so
7f6208887000-7f6208888000 rw-p 00002000 fd:01 63180437                   /usr/lib/firefox/libmozwayland.so
7f6208888000-7f620888e000 rw-p 00000000 00:00 0 
7f620888e000-7f6208892000 r--p 00000000 fd:01 56755123                   /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f6208892000-7f62088b5000 r-xp 00004000 fd:01 56755123                   /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f62088b5000-7f62088b9000 r--p 00027000 fd:01 56755123                   /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f62088b9000-7f62088ba000 r--p 0002b000 fd:01 56755123                   /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f62088ba000-7f62088bb000 rw-p 0002c000 fd:01 56755123                   /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f62088bb000-7f62088cb000 r--p 00000000 fd:01 56766604                   /usr/lib/x86_64-linux-gnu/libm.so.6
7f62088cb000-7f6208945000 r-xp 00010000 fd:01 56766604                   /usr/lib/x86_64-linux-gnu/libm.so.6
7f6208945000-7f620899f000 r--p 0008a000 fd:01 56766604                   /usr/lib/x86_64-linux-gnu/libm.so.6
7f620899f000-7f62089a0000 r--p 000e4000 fd:01 56766604                   /usr/lib/x86_64-linux-gnu/libm.so.6
7f62089a0000-7f62089a1000 rw-p 000e5000 fd:01 56766604                   /usr/lib/x86_64-linux-gnu/libm.so.6
7f62089a2000-7f62089a3000 r--p 00000000 fd:01 56756579                   /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.23.1
7f62089a3000-7f62089a4000 r-xp 00001000 fd:01 56756579                   /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.23.1
7f62089a4000-7f62089a5000 r--p 00002000 fd:01 56756579                   /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.23.1
7f62089a5000-7f62089a6000 r--p 00002000 fd:01 56756579                   /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.23.1
7f62089a6000-7f62089a7000 rw-p 00003000 fd:01 56756579                   /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.23.1
7f62089a7000-7f62089ac000 r--p 00000000 fd:01 56754403                   /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5600.1
7f62089ac000-7f62089b3000 r-xp 00005000 fd:01 56754403                   /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5600.1
7f62089b3000-7f62089b6000 r--p 0000c000 fd:01 56754403                   /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5600.1
7f62089b6000-7f62089b7000 r--p 0000e000 fd:01 56754403                   /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5600.1
7f62089b7000-7f62089b8000 rw-p 0000f000 fd:01 56754403                   /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5600.1
7f62089b8000-7f62089ba000 r--p 00000000 fd:01 56757212                   /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.8304.0
7f62089ba000-7f62089bc000 r-xp 00002000 fd:01 56757212                   /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.8304.0
7f62089bc000-7f62089bd000 r--p 00004000 fd:01 56757212                   /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.8304.0
7f62089bd000-7f62089be000 r--p 00004000 fd:01 56757212                   /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.8304.0
7f62089be000-7f62089bf000 rw-p 00005000 fd:01 56757212                   /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.8304.0
7f62089bf000-7f62089c0000 r--p 00000000 fd:01 63180433                   /usr/lib/firefox/libmozgtk.so
7f62089c0000-7f62089c1000 r-xp 00000000 fd:01 63180433                   /usr/lib/firefox/libmozgtk.so
7f62089c1000-7f62089c2000 r--p 00000000 fd:01 63180433                   /usr/lib/firefox/libmozgtk.so
7f62089c2000-7f62089c3000 rw-p 00000000 fd:01 63180433                   /usr/lib/firefox/libmozgtk.so
7f62089c3000-7f62089cf000 r--p 00000000 fd:01 63180434                   /usr/lib/firefox/libmozsandbox.so
7f62089cf000-7f62089f0000 r-xp 0000b000 fd:01 63180434                   /usr/lib/firefox/libmozsandbox.so
7f62089f0000-7f62089f2000 r--p 0002b000 fd:01 63180434                   /usr/lib/firefox/libmozsandbox.so
7f62089f2000-7f62089f3000 rw-p 0002c000 fd:01 63180434                   /usr/lib/firefox/libmozsandbox.so
7f62089f3000-7f62089f5000 rw-p 00000000 00:00 0 
7f62089f5000-7f62089f9000 r--p 00000000 00:00 0                          [vvar]
7f62089f9000-7f62089fb000 r-xp 00000000 00:00 0                          [vdso]
7f62089fb000-7f62089fc000 r--p 00000000 fd:01 56766596                   /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f62089fc000-7f6208a23000 r-xp 00001000 fd:01 56766596                   /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f6208a23000-7f6208a2e000 r--p 00028000 fd:01 56766596                   /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f6208a2e000-7f6208a30000 r--p 00033000 fd:01 56766596                   /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f6208a30000-7f6208a32000 rw-p 00035000 fd:01 56766596                   /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7ffd43769000-7ffd43789000 rw-p 00000000 00:00 0                          [stack]
7ffd43789000-7ffd4378a000 rw-p 00000000 00:00 0`
```
</details>