### PR TITLE
reporter.ExecutableMetadataArgs: simplify fields

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -622,17 +622,11 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			info.simpleName, info.guid)
 
 		if !symbolReporter.ExecutableKnown(info.fileID) {
-			open := func() (process.ReadAtCloser, error) {
-				return pr.OpenMappingFile(m)
-			}
 			symbolReporter.ExecutableMetadata(
 				&reporter.ExecutableMetadataArgs{
-					FileID:            info.fileID,
-					FileName:          path.Base(m.Path),
-					GnuBuildID:        info.guid,
-					DebuglinkFileName: "",
-					Interp:            libpf.Dotnet,
-					Open:              open,
+					FileID:     info.fileID,
+					FileName:   path.Base(m.Path),
+					GnuBuildID: info.guid,
 				},
 			)
 		}

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -341,17 +341,10 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	}
 
 	gnuBuildID, _ := ef.GetBuildID()
-	mapping2 := *mapping // copy to avoid races if callee saves the closure
-	open := func() (process.ReadAtCloser, error) {
-		return pr.OpenMappingFile(&mapping2)
-	}
 	pm.reporter.ExecutableMetadata(&reporter.ExecutableMetadataArgs{
-		FileID:            fileID,
-		FileName:          baseName,
-		GnuBuildID:        gnuBuildID,
-		DebuglinkFileName: ef.DebuglinkFileName(elfRef.FileName(), elfRef),
-		Interp:            libpf.Native,
-		Open:              open,
+		FileID:     fileID,
+		FileName:   baseName,
+		GnuBuildID: gnuBuildID,
 	})
 	return info
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 )
 
@@ -48,9 +47,6 @@ type TraceReporter interface {
 	SupportsReportTraceEvent() bool
 }
 
-// ExecutableOpener is a function that attempts to open an executable.
-type ExecutableOpener = func() (process.ReadAtCloser, error)
-
 // ExecutableMetadataArgs collects metadata about a discovered
 // executable, for reporting to a SymbolReporter via the ExecutableMetadata function.
 type ExecutableMetadataArgs struct {
@@ -60,15 +56,6 @@ type ExecutableMetadataArgs struct {
 	FileName string
 	// GnuBuildID is the GNU build ID from .note.gnu.build-id, if any.
 	GnuBuildID string
-	// DebuglinkFileName is the path to the matching debug file
-	// from the .gnu.debuglink, if any. The caller should
-	// verify that the file in question matches the GnuBuildID of this executable..
-	DebuglinkFileName string
-	// Interp is the discovered interpreter type of this executable, if any.
-	Interp libpf.InterpreterType
-	// Open is a function that can be used to open the executable for reading,
-	// or nil for interpreters that don't support this.
-	Open ExecutableOpener
 }
 
 // FrameMetadataArgs collects metadata about a single frame in a trace, for

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -213,11 +213,9 @@ func processKernelModulesMetadata(rep reporter.SymbolReporter, kernelModules *li
 
 		result[nameStr] = fileID
 		rep.ExecutableMetadata(&reporter.ExecutableMetadataArgs{
-			FileID:            fileID,
-			FileName:          nameStr,
-			GnuBuildID:        buildID,
-			DebuglinkFileName: "",
-			Interp:            libpf.Kernel,
+			FileID:     fileID,
+			FileName:   nameStr,
+			GnuBuildID: buildID,
 		})
 	})
 


### PR DESCRIPTION
As part of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/384 dropping unused struct fields.