### PR TITLE
reporter: Add basic auth flag to pass on authentication

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -45,6 +45,7 @@ var (
 		"Default is %d corresponding to 4GB of executable address space, max is %d.",
 		defaultArgMapScaleFactor, controller.MaxArgMapScaleFactor)
 	disableTLSHelp             = "Disable encryption for data in transit."
+	basicAuthHelp             = "Use basic auth for reporter. Specify as user:password."
 	bpfVerifierLogLevelHelp    = "Log level of the eBPF verifier output (0,1,2). Default is 0."
 	versionHelp                = "Show version."
 	probabilisticThresholdHelp = fmt.Sprintf("If set to a value between 1 and %d will enable "+
@@ -87,6 +88,8 @@ func parseArgs() (*controller.Config, error) {
 	fs.BoolVar(&args.Copyright, "copyright", false, copyrightHelp)
 
 	fs.BoolVar(&args.DisableTLS, "disable-tls", false, disableTLSHelp)
+
+	fs.StringVar(&args.BasicAuth, "basic-auth", "", basicAuthHelp)
 
 	fs.UintVar(&args.MapScaleFactor, "map-scale-factor",
 		defaultArgMapScaleFactor, mapScaleFactorHelp)

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -45,7 +45,7 @@ var (
 		"Default is %d corresponding to 4GB of executable address space, max is %d.",
 		defaultArgMapScaleFactor, controller.MaxArgMapScaleFactor)
 	disableTLSHelp             = "Disable encryption for data in transit."
-	basicAuthHelp             = "Use basic auth for reporter. Specify as user:password."
+	basicAuthHelp              = "Use basic auth for reporter. Specify as user:password."
 	bpfVerifierLogLevelHelp    = "Log level of the eBPF verifier output (0,1,2). Default is 0."
 	versionHelp                = "Show version."
 	probabilisticThresholdHelp = fmt.Sprintf("If set to a value between 1 and %d will enable "+

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	CollAgentAddr          string
 	Copyright              bool
 	DisableTLS             bool
+	BasicAuth              string
 	MapScaleFactor         uint
 	MonitorInterval        time.Duration
 	ClockSyncInterval      time.Duration

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ func mainWithExitCode() exitCode {
 	rep, err := reporter.NewOTLP(&reporter.Config{
 		CollAgentAddr:            cfg.CollAgentAddr,
 		DisableTLS:               cfg.DisableTLS,
+		BasicAuth:                cfg.BasicAuth,
 		MaxRPCMsgSize:            32 << 20, // 32 MiB
 		MaxGRPCRetries:           5,
 		GRPCOperationTimeout:     intervals.GRPCOperationTimeout(),

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -26,6 +26,8 @@ type Config struct {
 
 	// Disable secure communication with Collection Agent.
 	DisableTLS bool
+	// Enable basic auth.
+	BasicAuth string
 	// ExecutablesCacheElements defines item capacity of the executables cache.
 	ExecutablesCacheElements uint32
 	// FramesCacheElements defines the item capacity of the frames cache.

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -244,11 +244,11 @@ func newHeaderAuth(key, value string) headerAuth {
 	}
 }
 
-func (m headerAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (m headerAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
 	return m, nil
 }
 
-func (_ headerAuth) RequireTransportSecurity() bool {
+func (headerAuth) RequireTransportSecurity() bool {
 	return true
 }
 


### PR DESCRIPTION
This allows to add a basic auth header to the GRPC connection. Can be useful for sending profiles directly to a public endpoint.
