### PR TITLE
symblib: Add test case for go binaries symbconv

### DIFF
--- a/rust-crates/symblib/src/gosym/raw/regions.rs
+++ b/rust-crates/symblib/src/gosym/raw/regions.rs
@@ -153,12 +153,12 @@ impl<'obj> FuncTable<'obj> {
 mod tests {
     use super::*;
     use crate::gosym::GoRuntimeInfo;
-    use crate::tests::testdata;
+    use crate::tests::go_testdata;
 
     #[test]
     fn test_func_by_addr() -> Result<()> {
-        for test_file in ["go-1.20.14", "go-1.22.12", "go-1.24.0"] {
-            let obj = objfile::File::load(&testdata(test_file))?;
+        for test_file in go_testdata() {
+            let obj = objfile::File::load(&test_file)?;
             let obj = obj.parse()?;
 
             let runtime_info = GoRuntimeInfo::open(&obj)?;

--- a/rust-crates/symblib/src/lib.rs
+++ b/rust-crates/symblib/src/lib.rs
@@ -64,4 +64,13 @@ mod tests {
             .join("testdata")
             .join(name)
     }
+
+    // Get go testdata binaries
+    pub fn go_testdata() -> Vec<PathBuf> {
+        vec![
+            testdata("go-1.20.14"),
+            testdata("go-1.22.12"),
+            testdata("go-1.24.0"),
+        ]
+    }
 }


### PR DESCRIPTION
Noticed Gosym(BadLineNumber) in the go-1.24.0 binary. So I have added handling in symbconv and a test.

```
WARN: bad line number of function (go:textfipsstart)
WARN: bad line number of function (go:textfipsend)
```
