### PR TITLE
Fix accidentally swapped reporter and monitor interval

### DIFF
--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -22,8 +22,8 @@ type Controller struct {
 
 func NewController(cfg *controller.Config,
 	nextConsumer xconsumer.Profiles) (*Controller, error) {
-	intervals := times.New(cfg.MonitorInterval,
-		cfg.ReporterInterval, cfg.ProbabilisticInterval)
+	intervals := times.New(cfg.ReporterInterval,
+		cfg.MonitorInterval, cfg.ProbabilisticInterval)
 
 	rep, err := reporter.NewCollector(&reporter.Config{
 		MaxRPCMsgSize:            32 << 20, // 32 MiB

--- a/main.go
+++ b/main.go
@@ -99,8 +99,8 @@ func mainWithExitCode() exitCode {
 		}()
 	}
 
-	intervals := times.New(cfg.MonitorInterval,
-		cfg.ReporterInterval, cfg.ProbabilisticInterval)
+	intervals := times.New(cfg.ReporterInterval,
+		cfg.MonitorInterval, cfg.ProbabilisticInterval)
 
 	kernelVersion, err := helpers.GetKernelVersion()
 	if err != nil {


### PR DESCRIPTION
`times.New` signature is:

```
func New(reportInterval, monitorInterval,
  probabilisticInterval time.Duration) *Times
```

The argument order in `main.go` was swapped, this commit fixes that.

Default for both is 5s, but if you pass args to override the defaults, this would result in incorrect behavior.