### PR TITLE
Add Process.ExtractAsFile interface

### DIFF
--- a/interpreter/loaderinfo.go
+++ b/interpreter/loaderinfo.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
@@ -67,4 +68,14 @@ func (i *LoaderInfo) FileName() string {
 // Gaps returns the gaps for the executable of this LoaderInfo.
 func (i *LoaderInfo) Gaps() []util.Range {
 	return i.gaps
+}
+
+// ExtractAsFile returns a filename referring to the ELF executable. Extracting it from
+// a backing archive if needed.
+func (i *LoaderInfo) ExtractAsFile() (string, error) {
+	if pr, ok := i.elfRef.ELFOpener.(process.Process); ok {
+		return pr.ExtractAsFile(i.FileName())
+	}
+	return "", fmt.Errorf("unable to open main executable '%v' due to wrong interface type",
+		i.FileName())
 }

--- a/interpreter/loaderinfo.go
+++ b/interpreter/loaderinfo.go
@@ -70,8 +70,8 @@ func (i *LoaderInfo) Gaps() []util.Range {
 	return i.gaps
 }
 
-// ExtractAsFile returns a filename referring to the ELF executable. Extracting it from
-// a backing archive if needed.
+// ExtractAsFile returns a filename referring to the ELF executable, extracting
+// it from a backing archive if needed.
 func (i *LoaderInfo) ExtractAsFile() (string, error) {
 	if pr, ok := i.elfRef.ELFOpener.(process.Process); ok {
 		return pr.ExtractAsFile(i.FileName())

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -312,6 +312,12 @@ func (cd *CoredumpProcess) OpenELF(path string) (*pfelf.File, error) {
 	return nil, fmt.Errorf("ELF file `%s` not found", path)
 }
 
+// ExtractAsFile implements the Process interface
+func (cd *CoredumpProcess) ExtractAsFile(_ string) (string, error) {
+	// No filesystem level backing file in coredumps
+	return "", errors.New("coredump does not support opening backing file")
+}
+
 // getFile returns (creating if needed) a matching CoredumpFile for given file name
 func (cd *CoredumpProcess) getFile(name string) *CoredumpFile {
 	if cf, ok := cd.files[name]; ok {

--- a/process/process.go
+++ b/process/process.go
@@ -332,3 +332,7 @@ func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
 	// Fall back to opening the file using the process specific root
 	return pfelf.Open(fmt.Sprintf("/proc/%v/root/%s", sp.pid, file))
 }
+
+func (sp *systemProcess) ExtractAsFile(file string) (string, error) {
+	return fmt.Sprintf("/proc/%v/root/%s", sp.pid, file), nil
+}

--- a/process/types.go
+++ b/process/types.go
@@ -119,6 +119,13 @@ type Process interface {
 	// CalculateMappingFileID calculates FileID of the backing file
 	CalculateMappingFileID(*Mapping) (libpf.FileID, error)
 
+	// ExtractAsFile returns a filename suitable for opening the given file from
+	// the target process namespace. A last resort method to access the file if
+	// the ReaderAt interface from OpenMappingFile is not usable.
+	// The returned filename may refer to /proc, or be a temporarily extracted
+	// file from the backing archive.
+	ExtractAsFile(string) (string, error)
+
 	io.Closer
 
 	pfelf.ELFOpener

--- a/process/types.go
+++ b/process/types.go
@@ -120,10 +120,10 @@ type Process interface {
 	CalculateMappingFileID(*Mapping) (libpf.FileID, error)
 
 	// ExtractAsFile returns a filename suitable for opening the given file from
-	// the target process namespace. A last resort method to access the file if
-	// the ReaderAt interface from OpenMappingFile is not usable.
-	// The returned filename may refer to /proc, or be a temporarily extracted
-	// file from the backing archive.
+	// the target process namespace. This is a last resort method to access the file
+	// when the ReaderAt interface from OpenMappingFile is not sufficient. The returned
+	// filename may refer to /proc or be a temporarily file, and it must not be modified
+	// or deleted.
 	ExtractAsFile(string) (string, error)
 
 	io.Closer

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -76,6 +76,10 @@ func (d *dummyProcess) OpenELF(name string) (*pfelf.File, error) {
 	return pfelf.Open(name)
 }
 
+func (d *dummyProcess) ExtractAsFile(name string) (string, error) {
+	return name, nil
+}
+
 func (d *dummyProcess) Close() error {
 	return nil
 }

--- a/tools/coredump/new.go
+++ b/tools/coredump/new.go
@@ -106,6 +106,16 @@ func (tc *trackedCoredump) OpenELF(fileName string) (*pfelf.File, error) {
 	return tc.CoredumpProcess.OpenELF(fileName)
 }
 
+func (tc *trackedCoredump) ExtractAsFile(fileName string) (string, error) {
+	prefixedFileName := tc.prefix + fileName
+	if _, err := os.Stat(prefixedFileName); err != nil {
+		tc.warnMissing(fileName)
+		return "", err
+	}
+	tc.seen[fileName] = libpf.Void{}
+	return prefixedFileName, nil
+}
+
 func newNewCmd(store *modulestore.Store) *ffcli.Command {
 	args := &newCmd{store: store}
 

--- a/tools/coredump/storecoredump.go
+++ b/tools/coredump/storecoredump.go
@@ -64,12 +64,12 @@ func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 func (scd *StoreCoredump) ExtractAsFile(file string) (string, error) {
 	info, ok := scd.modules[file]
 	if !ok {
-		return "", fmt.Errorf("failed to open file `%s`: %w", file, os.ErrNotExist)
+		return "", os.ErrNotExist
 	}
 
 	f, err := os.CreateTemp("", "ebpf-profiler-coredump.*")
 	if err != nil {
-		return "", fmt.Errorf("failed to extract file `%s`: %w", file, os.ErrNotExist)
+		return "", err
 	}
 	tmpFile := f.Name()
 	f.Close()


### PR DESCRIPTION
For live processes a direct filename to /proc is returned, and for coredump cases a temporary file is created with the data extracted.

This is a last resort method to access the contets and mainly suitable if the is inspected via 3rd party module/library which does not support Go ReaderAt interface.

prerequisite for #408