### PR TITLE
Bump minimal supported kernel version from 4.19 to 5.4

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -138,7 +138,6 @@ jobs:
           # https://github.com/cilium/ci-kernels/pkgs/container/ci-kernels/versions?filters%5Bversion_type%5D=tagged
 
           # AMD64
-          - { target_arch: amd64, kernel: 4.19.314 }
           - { target_arch: amd64, kernel: 5.4.276 }
           - { target_arch: amd64, kernel: 5.10.217 }
           - { target_arch: amd64, kernel: 5.15.159 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ slack channel for discussions and questions.
 
 ## Pre-requisites
 
-- Linux (4.19+ for x86-64, 5.5+ for ARM64) with eBPF enabled (the profiler currently only runs on Linux)
+- Linux (5.4+ for x86-64, 5.5+ for ARM64) with eBPF enabled (the profiler currently only runs on Linux)
 - Go as specified in [go.mod](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/go.mod)
 - docker
 - Rust as specified in [Cargo.toml](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/Cargo.toml)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The resulting binary will be named <ebpf-profiler> in the current directory.
 ## Other OSes
 Since the profiler is Linux-only, macOS and Windows users need to set up a Linux VM to build and run the agent. Ensure the appropriate architecture is specified if using cross-compilation. Use the same make targets as above after the Linux environment is configured in the VM.
 
+## Supported Linux kernel version
+
+[7ddc23ea](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/commit/7ddc23ea135a2e00fffc17850ab90534e9b63108) is the last commit with support for 4.19. Changes after this commit may require a minimal Linux kernel version of 5.4.
+
 ## Alternative Build (Without Docker)
 You can build the agent without Docker by directly installing the dependencies listed in the Dockerfile. Once dependencies are set up, simply run:
 ```sh

--- a/support/README.md
+++ b/support/README.md
@@ -4,11 +4,10 @@ translation.
 
 ## Testing eBPF code on different kernel version
 Via the following commands, you can run the eBPF loading tests on kernel version
-4.9.198, 4.19.81 or 5.4.5 respectively.
+5.4.276 or 6.12.16 respectively.
 ```
-$ ./run-tests.sh 4.9.198
-$ ./run-tests.sh 4.19.81
-$ ./run-tests.sh 5.4.5
+$ ./run-tests.sh 5.4.276
+$ ./run-tests.sh 6.12.16
 ```
 The script loads the provided eBPF code into the kernel in a virtual environment so that it does not affect your local environment.
 
@@ -24,7 +23,7 @@ The tests are built on top of the following dependencies. Make sure you have the
  ## Test a Custom Kernel Image
  By default `run-tests.sh` takes only the kernel version as argument. The script looks for the kernel image with the specified version in `ci-kernels`. As an alternative one can provide a directory to look for this kernel image via `KERN_DIR`.
  ```
- $ KERN_DIR=my-other-kernels/ ./run-tests.sh 5.4.31
+ $ KERN_DIR=my-other-kernels/ ./run-tests.sh 5.4.276
  ```
 
  ## Manually Debugging a Custom Kernel Image
@@ -41,7 +40,7 @@ $ git clone -q https://git.kernel.org/pub/scm/utils/kernel/virtme/virtme.git "${
 ```
 3. Start the virtual environment for debugging with gdb:
 ```
-$ ${tmp_virtme}/virtme-run --kimg  ci-kernels/linux-5.4.31.bz \
+$ ${tmp_virtme}/virtme-run --kimg  ci-kernels/linux-5.4.276.bz \
     --memory 4096M \
     --pwd \
     --script-sh "mount -t bpf bpf /sys/fs/bpf ; ./support.test -test.v" \
@@ -54,9 +53,9 @@ $ gdb
 # Attach gdb to the running qemu process in the same directory:
 (gdb) target remote localhost:1234
 # Load source code:
-(gdb) directory ./ci-kernels/_build/linux-5.4.31
+(gdb) directory ./ci-kernels/_build/linux-5.4.276
 # Load symbols for debugging:
-(gdb) sym ./ci-kernels/_build/linux-5.4.31/vmlinux
+(gdb) sym ./ci-kernels/_build/linux-5.4.276/vmlinux
 # Set breakpoint at entry of eBPF verifier:
 (gdb) break do_check
 Breakpoint 1 at 0xffffffff81184460: file kernel/bpf/verifier.c, line 4105.


### PR DESCRIPTION
While the Linux kernel LTS support for 4.19 was dropped for some time the oldest supported Linux kernel LTS version is currently 5.4. Update references to use the currently oldest supported Linux kernel LTS version.

Proposed change based on the discussion in https://cloud-native.slack.com/archives/C03J794L0BV/p1744317888826789 - FYI @gnurizen @umanwizard 