### PR TITLE
Add host_arch and artifact_filename in resource information

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"maps"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -201,6 +202,8 @@ func (r *OTLPReporter) setResource(rp pprofile.ResourceProfiles) {
 	attrs.PutStr(string(semconv.HostNameKey), r.hostName)
 	attrs.PutStr(string(semconv.ServiceVersionKey), r.version)
 	attrs.PutStr("os.kernel", r.kernelVersion)
+	attrs.PutStr(string(semconv.HostArchKey), runtime.GOARCH)
+	attrs.PutStr(string(semconv.ArtifactFilenameKey), "opentelmetry-eBPF-profiler")
 }
 
 // waitGrpcEndpoint waits until the gRPC connection is established.


### PR DESCRIPTION
What:
In ResouceProfiles, add following attributes:
- Host arhtitecture
- Artifact filename/ profiler name : opentelemetry-eBPF-profiler


Why:
Help identify the origin of profile in order to generate usage/adaptivity reports.
- In an environment where opentelemetry-eBPF-profiler is being used on multiple hosts, having data about the host architecture/platform is useful.
- In a observability platform supporting multiple profilers, there is a need to identify the origin of profiles(i.e. which profiler generated the specific profile).