### PR TITLE
nativeunwind/stackdeltatypes: move cgo definition

### DIFF
--- a/nativeunwind/elfunwindinfo/elfehframe.go
+++ b/nativeunwind/elfunwindinfo/elfehframe.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/hash"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
 const (
@@ -856,7 +857,7 @@ func (regs *vmRegs) getUnwindInfo(allowGenericRegisters bool) sdtypes.UnwindInfo
 	default:
 		panic(fmt.Sprintf("architecture %d is not supported", regs.arch))
 	}
-	if !allowGenericRegisters && info.Opcode == sdtypes.UnwindOpcodeBaseReg {
+	if !allowGenericRegisters && info.Opcode == support.UnwindOpcodeBaseReg {
 		return sdtypes.UnwindInfoInvalid
 	}
 	return info

--- a/nativeunwind/elfunwindinfo/elfehframe_aarch64.go
+++ b/nativeunwind/elfunwindinfo/elfehframe_aarch64.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
 //nolint:deadcode,varcheck
@@ -117,10 +118,10 @@ func (regs *vmRegs) getUnwindInfoARM() sdtypes.UnwindInfo {
 	// are used for CFA.
 	switch regs.cfa.reg {
 	case armRegFP:
-		info.Opcode = sdtypes.UnwindOpcodeBaseFP
+		info.Opcode = support.UnwindOpcodeBaseFP
 		info.Param = int32(regs.cfa.off)
 	case armRegSP:
-		info.Opcode = sdtypes.UnwindOpcodeBaseSP
+		info.Opcode = support.UnwindOpcodeBaseSP
 		info.Param = int32(regs.cfa.off)
 	}
 
@@ -139,7 +140,7 @@ func (regs *vmRegs) getUnwindInfoARM() sdtypes.UnwindInfo {
 		// thus, the assumption - use UnwindOpcodeBaseLR to instruct native stack
 		// unwinder to load RA from link register
 		// This is either prolog or epilog sequence, read RA from link register.
-		info.FPOpcode = sdtypes.UnwindOpcodeBaseLR
+		info.FPOpcode = support.UnwindOpcodeBaseLR
 		info.FPParam = 0
 	case regCFA:
 		if regs.cfa.off != 0 {

--- a/nativeunwind/elfunwindinfo/elfehframe_test.go
+++ b/nativeunwind/elfunwindinfo/elfehframe_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,18 +49,18 @@ func genDelta(opcode uint8, cfa, rbp int32) sdtypes.UnwindInfo {
 		Param:  cfa,
 	}
 	if rbp != 0 {
-		res.FPOpcode = sdtypes.UnwindOpcodeBaseCFA
+		res.FPOpcode = support.UnwindOpcodeBaseCFA
 		res.FPParam = -rbp
 	}
 	return res
 }
 
 func deltaRSP(cfa, rbp int32) sdtypes.UnwindInfo {
-	return genDelta(sdtypes.UnwindOpcodeBaseSP, cfa, rbp)
+	return genDelta(support.UnwindOpcodeBaseSP, cfa, rbp)
 }
 
 func deltaRBP(cfa, rbp int32) sdtypes.UnwindInfo {
-	return genDelta(sdtypes.UnwindOpcodeBaseFP, cfa, rbp)
+	return genDelta(support.UnwindOpcodeBaseFP, cfa, rbp)
 }
 
 func TestEhFrame(t *testing.T) {

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -16,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
 // Go runtime functions for which we should not attempt to unwind further
@@ -625,11 +626,11 @@ func parseX86pclntabFunc(deltas *sdtypes.StackDeltaArray, fun *pclntabFunc, data
 	hints := sdtypes.UnwindHintKeep
 	for ok := true; ok; ok = p.step() {
 		info := sdtypes.UnwindInfo{
-			Opcode: sdtypes.UnwindOpcodeBaseSP,
+			Opcode: support.UnwindOpcodeBaseSP,
 			Param:  p.val + 8,
 		}
 		if s == strategyDeltasWithFrame && info.Param >= 16 {
-			info.FPOpcode = sdtypes.UnwindOpcodeBaseCFA
+			info.FPOpcode = support.UnwindOpcodeBaseCFA
 			info.FPParam = -16
 		}
 		deltas.Add(sdtypes.StackDelta{
@@ -664,12 +665,12 @@ func parseArm64pclntabFunc(deltas *sdtypes.StackDeltaArray, fun *pclntabFunc,
 			// Regular basic block in the function body: unwind via SP.
 			info = sdtypes.UnwindInfo{
 				// Unwind via SP offset.
-				Opcode: sdtypes.UnwindOpcodeBaseSP,
+				Opcode: support.UnwindOpcodeBaseSP,
 				Param:  p.val,
 			}
 			if s == strategyDeltasWithFrame {
 				// On ARM64, the previous LR value is stored to top-of-stack.
-				info.FPOpcode = sdtypes.UnwindOpcodeBaseSP
+				info.FPOpcode = support.UnwindOpcodeBaseSP
 				info.FPParam = 0
 			}
 		}

--- a/processmanager/execinfomanager/manager.go
+++ b/processmanager/execinfomanager/manager.go
@@ -450,7 +450,7 @@ func (state *executableInfoManagerState) loadDeltas(
 // Zero means no merging happened. Only small differences for address and the CFA delta
 // are considered, in order to limit the amount of unique combinations generated.
 func calculateMergeOpcode(delta, nextDelta sdtypes.StackDelta) uint8 {
-	if delta.Info.Opcode == sdtypes.UnwindOpcodeCommand {
+	if delta.Info.Opcode == support.UnwindOpcodeCommand {
 		return 0
 	}
 	addrDiff := nextDelta.Address - delta.Address
@@ -478,7 +478,7 @@ func calculateMergeOpcode(delta, nextDelta sdtypes.StackDelta) uint8 {
 func (state *executableInfoManagerState) getUnwindInfoIndex(
 	info sdtypes.UnwindInfo,
 ) (uint16, error) {
-	if info.Opcode == sdtypes.UnwindOpcodeCommand {
+	if info.Opcode == support.UnwindOpcodeCommand {
 		return uint16(info.Param) | support.DeltaCommandFlag, nil
 	}
 

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -27,6 +27,7 @@ import (
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpf"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/support"
 	tracertypes "go.opentelemetry.io/ebpf-profiler/tracer/types"
 	"go.opentelemetry.io/ebpf-profiler/traceutil"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -102,7 +103,7 @@ func (d *dummyStackDeltaProvider) GetIntervalStructuresForFile(_ host.FileID,
 		data := int32(8 * r.IntN(42))
 		result.Deltas.Add(sdtypes.StackDelta{
 			Address: uint64(addr),
-			Info:    sdtypes.UnwindInfo{Opcode: sdtypes.UnwindOpcodeBaseSP, Param: data},
+			Info:    sdtypes.UnwindInfo{Opcode: support.UnwindOpcodeBaseSP, Param: data},
 		})
 	}
 	return nil

--- a/processmanager/synthdeltas.go
+++ b/processmanager/synthdeltas.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
 // regFP is the arm64 frame-pointer register (x29) number
@@ -99,9 +100,9 @@ func createVDSOSyntheticRecordArm64(ef *pfelf.File) sdtypes.IntervalData {
 					sdtypes.StackDelta{
 						Address: addr + frameStart,
 						Info: sdtypes.UnwindInfo{
-							Opcode:   sdtypes.UnwindOpcodeBaseFP,
+							Opcode:   support.UnwindOpcodeBaseFP,
 							Param:    int32(frameSize),
-							FPOpcode: sdtypes.UnwindOpcodeBaseFP,
+							FPOpcode: support.UnwindOpcodeBaseFP,
 							FPParam:  8,
 						},
 					},

--- a/processmanager/synthdeltas_test.go
+++ b/processmanager/synthdeltas_test.go
@@ -8,15 +8,16 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/support"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestVDSOArm64(t *testing.T) {
 	frameSize16 := sdtypes.UnwindInfo{
-		Opcode:   sdtypes.UnwindOpcodeBaseFP,
+		Opcode:   support.UnwindOpcodeBaseFP,
 		Param:    16,
-		FPOpcode: sdtypes.UnwindOpcodeBaseFP,
+		FPOpcode: support.UnwindOpcodeBaseFP,
 		FPParam:  8,
 	}
 

--- a/support/types.go
+++ b/support/types.go
@@ -128,3 +128,22 @@ const (
 	sizeof_PHPProcInfo    = 0x18
 	sizeof_RubyProcInfo   = 0x20
 )
+
+const (
+	UnwindOpcodeCommand   uint8 = 0x0
+	UnwindOpcodeBaseCFA   uint8 = 0x1
+	UnwindOpcodeBaseSP    uint8 = 0x2
+	UnwindOpcodeBaseFP    uint8 = 0x3
+	UnwindOpcodeBaseLR    uint8 = 0x4
+	UnwindOpcodeBaseReg   uint8 = 0x5
+	UnwindOpcodeFlagDeref uint8 = 0x80
+
+	UnwindCommandInvalid      int32 = 0x0
+	UnwindCommandStop         int32 = 0x1
+	UnwindCommandPLT          int32 = 0x2
+	UnwindCommandSignal       int32 = 0x3
+	UnwindCommandFramePointer int32 = 0x4
+
+	UnwindDerefMask       int32 = 0x7
+	UnwindDerefMultiplier int32 = 0x8
+)

--- a/support/types_def.go
+++ b/support/types_def.go
@@ -8,6 +8,7 @@ package support // import "go.opentelemetry.io/ebpf-profiler/support"
 /*
 #include "./ebpf/types.h"
 #include "./ebpf/frametypes.h"
+#include "./ebpf/stackdeltatypes.h"
 */
 import "C"
 
@@ -105,4 +106,26 @@ const (
 	sizeof_DotnetProcInfo = C.sizeof_DotnetProcInfo
 	sizeof_PHPProcInfo    = C.sizeof_PHPProcInfo
 	sizeof_RubyProcInfo   = C.sizeof_RubyProcInfo
+)
+
+const (
+	// UnwindOpcodes from the C header file
+	UnwindOpcodeCommand   uint8 = C.UNWIND_OPCODE_COMMAND
+	UnwindOpcodeBaseCFA   uint8 = C.UNWIND_OPCODE_BASE_CFA
+	UnwindOpcodeBaseSP    uint8 = C.UNWIND_OPCODE_BASE_SP
+	UnwindOpcodeBaseFP    uint8 = C.UNWIND_OPCODE_BASE_FP
+	UnwindOpcodeBaseLR    uint8 = C.UNWIND_OPCODE_BASE_LR
+	UnwindOpcodeBaseReg   uint8 = C.UNWIND_OPCODE_BASE_REG
+	UnwindOpcodeFlagDeref uint8 = C.UNWIND_OPCODEF_DEREF
+
+	// UnwindCommands from the C header file
+	UnwindCommandInvalid      int32 = C.UNWIND_COMMAND_INVALID
+	UnwindCommandStop         int32 = C.UNWIND_COMMAND_STOP
+	UnwindCommandPLT          int32 = C.UNWIND_COMMAND_PLT
+	UnwindCommandSignal       int32 = C.UNWIND_COMMAND_SIGNAL
+	UnwindCommandFramePointer int32 = C.UNWIND_COMMAND_FRAME_POINTER
+
+	// UnwindDeref handling from the C header file
+	UnwindDerefMask       int32 = C.UNWIND_DEREF_MASK
+	UnwindDerefMultiplier int32 = C.UNWIND_DEREF_MULTIPLIER
 )

--- a/tools/stackdeltas/stackdeltas.go
+++ b/tools/stackdeltas/stackdeltas.go
@@ -33,32 +33,32 @@ type stats struct {
 
 func getOpcode(opcode uint8, param int32) string {
 	str := ""
-	switch opcode &^ sdtypes.UnwindOpcodeFlagDeref {
-	case sdtypes.UnwindOpcodeCommand:
+	switch opcode &^ support.UnwindOpcodeFlagDeref {
+	case support.UnwindOpcodeCommand:
 		switch param {
-		case sdtypes.UnwindCommandInvalid:
+		case support.UnwindCommandInvalid:
 			return "invalid"
-		case sdtypes.UnwindCommandStop:
+		case support.UnwindCommandStop:
 			return "stop"
-		case sdtypes.UnwindCommandPLT:
+		case support.UnwindCommandPLT:
 			return "plt"
-		case sdtypes.UnwindCommandSignal:
+		case support.UnwindCommandSignal:
 			return "signal"
-		case sdtypes.UnwindCommandFramePointer:
+		case support.UnwindCommandFramePointer:
 			return "framepointer"
 		default:
 			return "?"
 		}
-	case sdtypes.UnwindOpcodeBaseCFA:
+	case support.UnwindOpcodeBaseCFA:
 		str = "cfa"
-	case sdtypes.UnwindOpcodeBaseFP:
+	case support.UnwindOpcodeBaseFP:
 		str = "fp"
-	case sdtypes.UnwindOpcodeBaseSP:
+	case support.UnwindOpcodeBaseSP:
 		str = "sp"
 	default:
 		return "?"
 	}
-	if opcode&sdtypes.UnwindOpcodeFlagDeref != 0 {
+	if opcode&support.UnwindOpcodeFlagDeref != 0 {
 		preDeref, postDeref := sdtypes.UnpackDerefParam(param)
 		if postDeref != 0 {
 			str = fmt.Sprintf("*(%s%+x)%+x", str, preDeref, postDeref)


### PR DESCRIPTION
Reduce the spread of CGO across the code base and move definitions to support package.

Follow up to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/422#discussion_r2036799445