### PR TITLE
reporter: replace inner regular map with LRU

### DIFF
--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -166,12 +166,12 @@ func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
 			}
 		}
 
-		(*frameMap).AddWithLifetime(addressOrLine, samples.SourceInfo{
+		(*frameMap).Add(addressOrLine, samples.SourceInfo{
 			LineNumber:     args.SourceLine,
 			FilePath:       sourceFile,
 			FunctionOffset: args.FunctionOffset,
 			FunctionName:   args.FunctionName,
-		}, pdata.FrameMapLifetime)
+		})
 
 		return
 	}
@@ -184,12 +184,12 @@ func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
 	}
 	frameMap.SetLifetime(pdata.FrameMapLifetime)
 
-	frameMap.AddWithLifetime(addressOrLine, samples.SourceInfo{
+	frameMap.Add(addressOrLine, samples.SourceInfo{
 		LineNumber:     args.SourceLine,
 		FilePath:       args.SourceFile,
 		FunctionOffset: args.FunctionOffset,
 		FunctionName:   args.FunctionName,
-	}, pdata.FrameMapLifetime)
+	})
 
 	mu := xsync.NewRWMutex(frameMap)
 	b.pdata.Frames.Add(fileID, &mu)

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -78,7 +78,7 @@ func (b *baseReporter) FrameKnown(frameID libpf.FrameID) bool {
 		pdata.FramesCacheLifetime); exists {
 		frameMap := frameMapLock.RLock()
 		defer frameMapLock.RUnlock(&frameMap)
-		_, known = (*frameMap)[frameID.AddressOrLine()]
+		_, known = (*frameMap).GetAndRefresh(frameID.AddressOrLine(), pdata.FrameMapLifetime)
 	}
 	return known
 }
@@ -160,27 +160,37 @@ func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
 		if sourceFile == "" {
 			// The new SourceFile may be empty, and we don't want to overwrite
 			// an existing filePath with it.
-			if s, exists := (*frameMap)[addressOrLine]; exists {
-				sourceFile = s.FilePath
+			if source, exists := (*frameMap).GetAndRefresh(addressOrLine,
+				pdata.FrameMapLifetime); exists {
+				sourceFile = source.FilePath
 			}
 		}
 
-		(*frameMap)[addressOrLine] = samples.SourceInfo{
+		(*frameMap).AddWithLifetime(addressOrLine, samples.SourceInfo{
 			LineNumber:     args.SourceLine,
 			FilePath:       sourceFile,
 			FunctionOffset: args.FunctionOffset,
 			FunctionName:   args.FunctionName,
-		}
+		}, pdata.FrameMapLifetime)
+
 		return
 	}
 
-	v := make(map[libpf.AddressOrLineno]samples.SourceInfo)
-	v[addressOrLine] = samples.SourceInfo{
+	frameMap, err := lru.New[libpf.AddressOrLineno, samples.SourceInfo](1024,
+		func(k libpf.AddressOrLineno) uint32 { return uint32(k) })
+	if err != nil {
+		log.Errorf("Failed to create inner frameMap for %x: %v", fileID, err)
+		return
+	}
+	frameMap.SetLifetime(pdata.FrameMapLifetime)
+
+	frameMap.AddWithLifetime(addressOrLine, samples.SourceInfo{
 		LineNumber:     args.SourceLine,
 		FilePath:       args.SourceFile,
 		FunctionOffset: args.FunctionOffset,
 		FunctionName:   args.FunctionName,
-	}
-	mu := xsync.NewRWMutex(v)
+	}, pdata.FrameMapLifetime)
+
+	mu := xsync.NewRWMutex(frameMap)
 	b.pdata.Frames.Add(fileID, &mu)
 }

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -24,6 +24,7 @@ import (
 const (
 	ExecutableCacheLifetime = 1 * time.Hour
 	FramesCacheLifetime     = 1 * time.Hour
+	FrameMapLifetime        = 1 * time.Hour
 )
 
 // Generate generates a pdata request out of internal profiles data, to be
@@ -180,7 +181,7 @@ func (p *Pdata) setProfile(
 						"UNREPORTED", frameKind.String()))
 				} else {
 					fileIDInfo := fileIDInfoLock.RLock()
-					if si, exists := (*fileIDInfo)[traceInfo.Linenos[i]]; exists {
+					if si, exists := (*fileIDInfo).Get(traceInfo.Linenos[i]); exists {
 						line.SetLine(int64(si.LineNumber))
 
 						line.SetFunctionIndex(createFunctionEntry(funcMap,

--- a/reporter/internal/pdata/pdata.go
+++ b/reporter/internal/pdata/pdata.go
@@ -23,7 +23,7 @@ type Pdata struct {
 	// Frames maps frame information to its source location.
 	Frames *lru.SyncedLRU[
 		libpf.FileID,
-		*xsync.RWMutex[map[libpf.AddressOrLineno]samples.SourceInfo],
+		*xsync.RWMutex[*lru.LRU[libpf.AddressOrLineno, samples.SourceInfo]],
 	]
 
 	// ExtraSampleAttrProd is an optional hook point for adding custom
@@ -41,7 +41,7 @@ func New(samplesPerSecond int, executablesCacheElements, framesCacheElements uin
 	executables.SetLifetime(ExecutableCacheLifetime) // Allow GC to clean stale items.
 
 	frames, err := lru.NewSynced[libpf.FileID,
-		*xsync.RWMutex[map[libpf.AddressOrLineno]samples.SourceInfo]](
+		*xsync.RWMutex[*lru.LRU[libpf.AddressOrLineno, samples.SourceInfo]]](
 		framesCacheElements, libpf.FileID.Hash32)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/248 the possibile unlimited growth of the inner map `map[libpf.AddressOrLineno]sourceInfo` of the `frames` cache, was identified as potential issue. Replace this regular map with a LRU to limit its size.