### PR TITLE
Fix build with gcc 15

### DIFF
--- a/support/ebpf/kernel.h
+++ b/support/ebpf/kernel.h
@@ -47,11 +47,13 @@ _Static_assert(sizeof(uintptr_t) == 8, "bad uintptr_t size");
 _Static_assert(sizeof(size_t) == 8, "bad size_t size");
 
 // Define bool type (emulates stdbool.h).
-typedef _Bool bool;
-#ifndef __bool_true_false_are_defined
-  #define true                          1
-  #define false                         0
-  #define __bool_true_false_are_defined 1
+#if __STDC_VERSION__ < 202311L
+  typedef _Bool bool;
+  #ifndef __bool_true_false_are_defined
+    #define true                          1
+    #define false                         0
+    #define __bool_true_false_are_defined 1
+  #endif
 #endif
 
 // Go defines `NULL` in `cgo-builtin-prolog`, so we have to check whether

--- a/support/ebpf/kernel.h
+++ b/support/ebpf/kernel.h
@@ -48,7 +48,7 @@ _Static_assert(sizeof(size_t) == 8, "bad size_t size");
 
 // Define bool type (emulates stdbool.h).
 #if __STDC_VERSION__ < 202311L
-  typedef _Bool bool;
+typedef _Bool bool;
   #ifndef __bool_true_false_are_defined
     #define true                          1
     #define false                         0


### PR DESCRIPTION
gcc 15 defaults to c23, in which bool, true and false are keywords.