### PR TITLE
reporter: fix race condition in `FrameKnown`

### DIFF
--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -76,8 +76,8 @@ func (b *baseReporter) FrameKnown(frameID libpf.FrameID) bool {
 	known := false
 	if frameMapLock, exists := b.pdata.Frames.GetAndRefresh(frameID.FileID(),
 		pdata.FramesCacheLifetime); exists {
-		frameMap := frameMapLock.RLock()
-		defer frameMapLock.RUnlock(&frameMap)
+		frameMap := frameMapLock.WLock()
+		defer frameMapLock.WUnlock(&frameMap)
 		_, known = (*frameMap).GetAndRefresh(frameID.AddressOrLine(), pdata.FrameMapLifetime)
 	}
 	return known


### PR DESCRIPTION
4377c7485ec426eb1210098593e6175d2d53bcd8 switched the inner value of `pdata.Frames` to be a LRU, instead of a map. It uses `GetAndRefresh` in `FrameKnown` to update the lifetime of an element, if it exists.

`GetAndRefresh` is a write operation, but the lock that is taken around this operation was not updated in the commit, thus we still only hold a read lock here, leading to potential data races.

This commit changes the code to take a write lock instead, so only one Goroutine can refresh the key at a time.