### PR TITLE
Add the thread ID attribute to the sample

### DIFF
--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -116,6 +116,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		ApmServiceName: meta.APMServiceName,
 		ContainerID:    containerID,
 		Pid:            int64(meta.PID),
+		Tid:            int64(meta.TID),
 		ExtraMeta:      extraMeta,
 	}
 

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -223,6 +223,8 @@ func (p *Pdata) setProfile(
 			semconv.ServiceNameKey, traceKey.ApmServiceName)
 		attrMgr.AppendInt(sample.AttributeIndices(),
 			semconv.ProcessPIDKey, traceKey.Pid)
+		attrMgr.AppendInt(sample.AttributeIndices(),
+			semconv.ThreadIDKey, traceKey.Tid)
 
 		for key, value := range traceInfo.EnvVars {
 			attrMgr.AppendOptionalString(

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -42,6 +42,7 @@ type TraceAndMetaKey struct {
 	// containerID is annotated based on PID information
 	ContainerID string
 	Pid         int64
+	Tid         int64
 	// Process name is retrieved from /proc/PID/comm
 	ProcessName string
 	// Executable path is retrieved from /proc/PID/exe


### PR DESCRIPTION
As mentioned in the title, this commit primarily aims to add the thread ID attribute to the sent samples. Previously, samples only had the thread name attribute, which couldn't differentiate between samples with same thread names or indicate thread load balancing.