### PR TITLE
CI: group renovate update PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,13 +6,24 @@
   ],
   "packageRules": [
     {
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "groupName": "Go dependencies",
+      "matchManagers": ["gomod"],
       "schedule": ["before 8am every weekday"]
     },
     {
-      "matchUpdateTypes": ["minor", "major"],
-      "schedule": ["before 8am on Monday"]
+      "groupName": "Dockerfile dependencies",
+      "matchManagers": ["dockerfile"],
+      "schedule": ["before 8am every weekday"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "schedule": ["before 8am every weekday"]
+    },
+    {
+      "groupName": "Other dependencies",
+      "matchManagers": ["!gomod", "!dockerfile", "!github-actions"],
+      "schedule": ["before 8am every weekday"]
     }
   ],
   "labels": [


### PR DESCRIPTION
Instead of opening a PR for every dependency (like #476, #477, #478 and others), group dependency update PRs from renovate by their type.