### PR TITLE
CI: fix renovate negated matchManagers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,8 +11,8 @@
       "schedule": ["before 8am every weekday"]
     },
     {
-      "groupName": "Dockerfile dependencies",
-      "matchManagers": ["dockerfile"],
+      "groupName": "Docker related dependencies",
+      "matchManagers": ["buildpacks", "devcontainer", "docker-compose", "dockerfile"],
       "schedule": ["before 8am every weekday"]
     },
     {
@@ -21,8 +21,8 @@
       "schedule": ["before 8am every weekday"]
     },
     {
-      "groupName": "Other dependencies",
-      "matchManagers": ["!gomod", "!dockerfile", "!github-actions"],
+      "groupName": "Rust dependencies",
+      "matchManagers": ["cargo"],
       "schedule": ["before 8am every weekday"]
     }
   ],


### PR DESCRIPTION
Renovate seems not to support negation for the matchManagers input.

Fixes #493