### PR TITLE
nodev8: add support for nsolid fork of node

### DIFF
--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -225,7 +225,7 @@ const (
 
 var (
 	// regex for the interpreter executable or shared library
-	v8Regex = regexp.MustCompile(`^(?:.*/)?node(\d+)?$|^(?:.*/)libnode\.so(\.\d+)?$`)
+	v8Regex = regexp.MustCompile(`^(?:.*/)?(?:node|nsolid)(\d+)?$|^(?:.*/)libnode\.so(\.\d+)?$`)
 
 	// The FileID used for V8 stub frames
 	v8StubsFileID = libpf.NewFileID(0x578b, 0x1d)

--- a/interpreter/nodev8/v8_test.go
+++ b/interpreter/nodev8/v8_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nodev8 // import "go.opentelemetry.io/ebpf-profiler/interpreter/nodev8"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexs(t *testing.T) {
+	shouldMatch := []string{
+		"node",
+		"node8",
+		"./node",
+		"/foo/bar/node",
+		"./foo/bar/node",
+		"nsolid",
+		"nsolid8",
+		"./nsolid",
+		"/foo/bar/nsolid",
+		"./foo/bar/nsolid",
+		"./libnode.so",
+		"/lib/libnode.so.12",
+	}
+	for _, s := range shouldMatch {
+		assert.True(t, v8Regex.MatchString(s), "regex %s should match %s",
+			v8Regex.String(), s)
+	}
+
+	shouldNotMatch := []string{
+		"node-foo",
+		"./nsolid-bar",
+		"/lib/libnodetest.so",
+		"/lib/libnode.so.1.2.3.4.5",
+		"node-nsolid",
+	}
+	for _, s := range shouldNotMatch {
+		assert.False(t, v8Regex.MatchString(s), "regex %s should not match %s",
+			v8Regex.String(), s)
+	}
+}


### PR DESCRIPTION
Extend the regexp to match also the nsolid binary name. Add tests for regexp.

fixes #219