### PR TITLE
CI: Skip automatic updates for golangci/golangci-lint-action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,23 +8,29 @@
     {
       "groupName": "Go dependencies",
       "matchManagers": ["gomod"],
-      "schedule": ["before 8am every weekday"]
+      "schedule": ["before 8am every weekday"],
+      "automerge": true
     },
     {
       "groupName": "Docker related dependencies",
       "matchManagers": ["buildpacks", "devcontainer", "docker-compose", "dockerfile"],
-      "schedule": ["before 8am every weekday"]
+      "schedule": ["before 8am every weekday"],
+      "automerge": true
     },
     {
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
-      "schedule": ["before 8am every weekday"]
+      "schedule": ["before 8am every weekday"],
+      "automerge": true
     },
     {
       "groupName": "Rust dependencies",
       "matchManagers": ["cargo"],
       "schedule": ["before 8am every weekday"]
     }
+  ],
+  "ignoreDeps": [
+    "golangci/golangci-lint-action"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/499#discussion_r2122844367. As automatic updates of the CI action golangci-lint-action conflicts with other parts, ignore this dependency.

Also set `automerge` for groups that will not break things. This should reduce maintenance burden.