### PR TITLE
Update linter

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -37,18 +37,14 @@ jobs:
       - name: Get linter version
         id: linter-version
         run: (echo -n "version="; make linter-version) >> "$GITHUB_OUTPUT"
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      - name: linter
         env:
           GOARCH: ${{ matrix.target-arch }}
           CGO_ENABLED: 1
-        with:
-          version: ${{ steps.linter-version.outputs.version }}
-      - name: Lint eBPF code
         run: |
           sudo apt update
           sudo apt install -y clang-format-17
-          make lint -C support/ebpf
+          make lint
 
   test:
     name: Test (${{ matrix.target_arch }})

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,34 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      # simplify code: gofmt with `-s` option, true by default
+      simplify: true
+    goimports:
+      # put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes
+      local-prefixes:
+        - github.com/open-telemetry/opentelemetry-ebpf-profiler
+
 run:
   timeout: 10m
   build-tags:
     - integration
     - linux
 
-issues:
-  exclude-dirs:
-    - artifacts
-    - build-targets
-    - design
-    - docker-images
-    - docs
-    - etc
-    - experiments
-    - infrastructure
-    - legal
-    - libpf-rs
-    - mocks
-    - pf-code-indexing-service/cibackend/gomock_*
-    - pf-debug-metadata-service/dmsbackend/gomock_*
-    - pf-host-agent/support/ci-kernels
-    - pf-storage-backend/storagebackend/gomock_*
-    - scratch
-    - systemtests/benchmarks/_outdata
-    - target
-    - virt-tests
-    - vm-images
-
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Don't complain about integer overflows
-    - text: "G115:"
-      linters:
-        - gosec
+#issues:
+#  exclude-dirs:
+#    - design-docs
+#    - doc
+#    - legal
+#    - target
 
 linters:
-  enable-all: true
+  default: all
   disable:
     # Disabled because of
     #   - too many non-sensical warnings
@@ -50,13 +43,14 @@ linters:
     - dupword
     - durationcheck # might be worth fixing
     - err113
+    - errcheck
     - errorlint # might be worth fixing
     - exhaustive
     - exhaustruct
     - forbidigo
     - forcetypeassert # might be worth fixing
     - funlen
-    - gci # might be worth fixing
+    - funcorder
     - gochecknoglobals
     - gochecknoinits
     - gocognit
@@ -64,8 +58,8 @@ linters:
     - gocyclo
     - godot
     - godox # complains about TODO etc
-    - gofumpt
     - gomoddirectives
+    - gosmopolitan
     - inamedparam
     - interfacebloat
     - ireturn
@@ -81,6 +75,7 @@ linters:
     - paralleltest
     - protogetter
     - sqlclosecheck # might be worth fixing
+    - staticcheck
     - tagalign
     - tagliatelle
     - testableexamples # might be worth fixing
@@ -94,45 +89,59 @@ linters:
     # we don't want to change code to Go 1.22+ yet
     - intrange
     - copyloopvar
-    - tenv
 
-linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - whyNoLint
-      - sloppyReassign
-      - uncheckedInlineErr # Experimental rule with high false positive rate.
-  gocyclo:
-    min-complexity: 15
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-    settings:
-      printf: # analyzer name, run `go tool vet help` to see all analyzers
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-          - debug,debugf,debugln
-          - error,errorf,errorln
-          - fatal,fatalf,fataln
-          - info,infof,infoln
-          - log,logf,logln
-          - warn,warnf,warnln
-          - print,printf,println,sprint,sprintf,sprintln,fprint,fprintf,fprintln
-  lll:
-    line-length: 100
-    tab-width: 4
-  misspell:
-    locale: US
-    ignore-words:
-      - rela
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - whyNoLint
+        - sloppyReassign
+        - uncheckedInlineErr # experimental rule with high false positive rate.
+        - importShadow # shadow of imported package
+    gocyclo:
+      min-complexity: 15
+    gosec:
+      excludes:
+        - G103 # unsafe calls should be audited
+        - G104 # unhandled errors
+        - G115 # integer overflow
+        - G204 # subprocess launched with variable
+        - G301 # directory permissions
+        - G302 # file permissions
+        - G304 # potential file inclusion via variable
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - unsafeptr
+      settings:
+        printf: # analyzer name, run `go tool vet help` to see all analyzers
+          funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+            - debug,debugf,debugln
+            - error,errorf,errorln
+            - fatal,fatalf,fataln
+            - info,infof,infoln
+            - log,logf,logln
+            - warn,warnf,warnln
+            - print,printf,println,sprint,sprintf,sprintln,fprint,fprintf,fprintln
+    lll:
+      line-length: 100
+      tab-width: 4
+    misspell:
+      locale: US
+      ignore-rules:
+        - rela
+    revive:
+      rules:
+        - name: unexported-naming
+          disabled: true

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,12 @@ rust-components: rust-targets
 rust-tests: rust-targets
 	cargo test
 
-GOLANGCI_LINT_VERSION = "v1.64.5"
+GOLANGCI_LINT_VERSION = "v2.1.6"
 lint: generate vanity-import-check
 	$(MAKE) lint -C support/ebpf
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+	docker run --rm -t -v $$(pwd):/app -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint version
+	docker run --rm -t -v $$(pwd):/app -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint config verify
+	docker run --rm -t -v $$(pwd):/app -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint run
 
 format-ebpf:
 	$(MAKE) format -C support/ebpf

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -13,8 +13,6 @@ import (
 )
 
 // Constants for the JVM internals that have never changed
-//
-//nolint:golint,stylecheck,revive
 const ConstMethod_has_linenumber_table = 0x0001
 
 // hotspotMethod contains symbolization information for one Java method. It caches

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -24,7 +24,6 @@ type perlData struct {
 	// vmStructs reflects the Perl internal class names and the offsets of named field
 	// The struct names are based on the Perl C "struct name", the alternate typedef seen
 	// mostly in code is in parenthesis.
-	//nolint:golint,stylecheck,revive
 	vmStructs struct {
 		// interpreter struct (PerlInterpreter) is defined in intrpvar.h via macro trickery
 		// https://github.com/Perl/perl5/blob/v5.32.0/intrpvar.h

--- a/interpreter/perl/perl.go
+++ b/interpreter/perl/perl.go
@@ -52,7 +52,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 )
 
-//nolint:golint,stylecheck,revive
 const (
 	// Scalar Value types (SVt)
 	// https://github.com/Perl/perl5/blob/v5.32.0/sv.h#L132-L166

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
-//nolint:golint,stylecheck,revive
 const (
 	// zend_function.type definitions from PHP sources
 	ZEND_USER_FUNCTION = (1 << 1)

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
-//nolint:golint,stylecheck,revive
 const (
 	// This is used to check if the VM mode is the default one
 	// From https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_vm_opcodes.h#L29
@@ -71,7 +70,6 @@ type phpData struct {
 	rtAddr libpf.Address
 
 	// vmStructs reflects the PHP internal class names and the offsets of named field
-	//nolint:golint,stylecheck,revive
 	vmStructs struct {
 		// https://github.com/php/php-src/blob/PHP-7.4/Zend/zend_globals.h#L135
 		zend_executor_globals struct {

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -94,7 +94,6 @@ type rubyData struct {
 	version uint32
 
 	// vmStructs reflects the Ruby internal names and offsets of named fields.
-	//nolint:golint,stylecheck,revive
 	vmStructs struct {
 		// rb_execution_context_struct
 		// https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/vm_core.h#L843

--- a/libpf/pfelf/pfelf_test.go
+++ b/libpf/pfelf/pfelf_test.go
@@ -69,7 +69,7 @@ func TestGetBuildIDError(t *testing.T) {
 
 	buildID, err := pfelf.GetBuildID(elfFile)
 	if assert.ErrorIs(t, pfelf.ErrNoBuildID, err) {
-		assert.Equal(t, "", buildID)
+		assert.Empty(t, buildID)
 	}
 }
 
@@ -83,7 +83,7 @@ func TestGetDebugLinkError(t *testing.T) {
 
 	debugLink, _, err := pfelf.GetDebugLink(elfFile)
 	if assert.ErrorIs(t, pfelf.ErrNoDebugLink, err) {
-		assert.Equal(t, "", debugLink)
+		assert.Empty(t, debugLink)
 	}
 }
 

--- a/nativeunwind/elfunwindinfo/elfehframe.go
+++ b/nativeunwind/elfunwindinfo/elfehframe.go
@@ -96,7 +96,6 @@ const (
 // The subset needed for normal .eh_frame handling
 type expressionOpcode uint8
 
-//nolint:deadcode,varcheck
 const (
 	opDeref      expressionOpcode = 0x06
 	opConstU     expressionOpcode = 0x10
@@ -123,7 +122,6 @@ type dwarfExpression struct {
 // https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/dwarfext.html
 type encoding uint8
 
-//nolint:deadcode,varcheck
 const (
 	encFormatNative  encoding = 0x00
 	encFormatLeb128  encoding = 0x01

--- a/nativeunwind/elfunwindinfo/elfehframe_aarch64.go
+++ b/nativeunwind/elfunwindinfo/elfehframe_aarch64.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
-//nolint:deadcode,varcheck
 const (
 	// Aarch64 ABI
 	armRegX0  uleb128 = 0

--- a/nativeunwind/elfunwindinfo/elfehframe_x86.go
+++ b/nativeunwind/elfunwindinfo/elfehframe_x86.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
-//nolint:deadcode,varcheck
 const (
 	// x86_64 abi (https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf, page 57)
 	x86RegRAX uleb128 = 0

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -46,8 +46,6 @@ const (
 )
 
 // pclntabHeader is the Golang pclntab header structure
-//
-//nolint:structcheck
 type pclntabHeader struct {
 	// magic is one of the magicGo1_xx constants identifying the version
 	magic uint32
@@ -63,8 +61,6 @@ type pclntabHeader struct {
 
 // pclntabHeader116 is the Golang pclntab header structure starting Go 1.16
 // structural definition of this is found in go/src/runtime/symtab.go as pcHeader
-//
-//nolint:structcheck
 type pclntabHeader116 struct {
 	pclntabHeader
 	nfiles         uint
@@ -77,8 +73,6 @@ type pclntabHeader116 struct {
 
 // pclntabHeader118 is the Golang pclntab header structure starting Go 1.18
 // structural definition of this is found in go/src/runtime/symtab.go as pcHeader
-//
-//nolint:structcheck
 type pclntabHeader118 struct {
 	pclntabHeader
 	nfiles         uint
@@ -91,16 +85,12 @@ type pclntabHeader118 struct {
 }
 
 // pclntabFuncMap is the Golang function symbol table map entry
-//
-//nolint:structcheck
 type pclntabFuncMap struct {
 	pc      uint64
 	funcOff uint64
 }
 
 // pclntabFunc is the Golang function definition (struct _func in the spec) as before Go 1.18.
-//
-//nolint:structcheck
 type pclntabFunc struct {
 	startPc                      uint64
 	nameOff, argsSize, frameSize int32
@@ -111,8 +101,6 @@ type pclntabFunc struct {
 // pclntabFunc118 is the Golang function definition (struct _func in the spec)
 // starting with Go 1.18.
 // see: go/src/runtime/runtime2.go (struct _func)
-//
-//nolint:structcheck
 type pclntabFunc118 struct {
 	entryoff                     uint32 // start pc, as offset from pcHeader.textStart
 	nameOff, argsSize, frameSize int32

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -86,7 +86,6 @@ type Note64 struct {
 	Namesz, Descsz, Type uint32
 }
 
-//nolint:revive,stylecheck
 const (
 	NAMESPACE_CORE  = "CORE\x00"
 	NAMESPACE_LINUX = "LINUX\x00"

--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -42,8 +42,6 @@ const (
 )
 
 // EbpfHandler provides the functionality to interact with eBPF maps.
-//
-//nolint:revive
 type EbpfHandler interface {
 	// Embed interpreter.EbpfHandler as subset of this interface.
 	interpreter.EbpfHandler
@@ -793,8 +791,6 @@ func (impl *ebpfMapsImpl) DeletePidPageMappingInfoBatch(pid libpf.PID, prefixes 
 // LookupPidPageInformation returns the fileID and bias for a given pid and page combination from
 // the eBPF map pid_page_to_mapping_info.
 // So far this function is used only in tests.
-//
-//nolint:deadcode
 func (impl *ebpfMapsImpl) LookupPidPageInformation(pid uint32, page uint64) (host.FileID,
 	uint64, error) {
 	// pid_page_to_mapping_info is a LPM trie and expects the pid and page

--- a/tools/coredump/new.go
+++ b/tools/coredump/new.go
@@ -236,7 +236,6 @@ func dumpCore(pid uint64, noModuleBundling bool) (string, error) {
 	}
 
 	// `gcore` only accepts a path-prefix, not an exact path.
-	//nolint:gosec
 	err := exec.Command("gcore", "-o", gcorePathPrefix, strconv.FormatUint(pid, 10)).Run()
 	if err != nil {
 		return "", fmt.Errorf("gcore failed: %w", err)


### PR DESCRIPTION
This PR does:
- update `golangci-lint` required to rewrite parts of the config file
- update the make target `lint` to use docker (building with go is no longer supported with v2)
- use `make lint` in the CI to keep it in sync with local linting (less maintenance)
- amend `nolint` directives as some linters are no longer available
- trivial code code changes to pass linting
