### PR TITLE
pfelf/mmap: map the memory as private

### DIFF
--- a/libpf/pfelf/internal/mmap/mmap.go
+++ b/libpf/pfelf/internal/mmap/mmap.go
@@ -103,7 +103,7 @@ func Open(filename string) (*ReaderAt, error) {
 		return nil, fmt.Errorf("mmap: file %q is too large", filename)
 	}
 
-	data, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_PRIVATE)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes sure that no other process can change the memory under our back after mmapping. In case someone writes the backed file, the kernel will copy-on-write the memory. This is important to make sure that data we verified in pfelf does not get changed by another process.