### PR TITLE
Add wire protocol benchmark agent and stub gRPC server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/otel-profiling-agent
 
-go 1.21.6
+go 1.24.3
+
+toolchain go1.24.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
@@ -19,8 +21,9 @@ require (
 	github.com/minio/sha256-simd v1.0.1
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/prometheus/procfs v0.12.0
+	github.com/rockdaboot/go-trie v0.0.0-20250601172917-22faa48a0b18
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/proto/otlp v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rockdaboot/go-trie v0.0.0-20250601172917-22faa48a0b18 h1:eqQC5TevjlDM31Gg5IRY6Edp9YGQEDC4SWZz/6WHG/o=
+github.com/rockdaboot/go-trie v0.0.0-20250601172917-22faa48a0b18/go.mod h1:ve/yxbm/4LNL0xdG8uLZlxXMNCa29IpniGG2CSyS9nA=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -220,8 +222,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/host/host.go
+++ b/host/host.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
+	"github.com/elastic/otel-profiling-agent/times"
 )
 
 // TraceHash is used for unique identifiers for traces, and is required to be 64-bits
@@ -61,6 +62,6 @@ type Trace struct {
 	Comm   string
 	Frames []Frame
 	Hash   TraceHash
-	KTime  libpf.KTime
+	KTime  times.KTime
 	PID    libpf.PID
 }

--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -33,7 +33,7 @@ import (
 // and since the code is mostly dealing with UNIX timestamps, we may
 // as well use uint32s instead.
 // To restore some semblance of type safety, we declare a type alias here.
-type UnixTime32 uint32
+type UnixTime32 uint64
 
 func (t *UnixTime32) MarshalJSON() ([]byte, error) {
 	return time.Unix(int64(*t), 0).UTC().MarshalJSON()
@@ -563,18 +563,6 @@ func Int64ToTime(t int64) time.Time {
 	}
 	return time.Unix(0, t)
 }
-
-// KTime stores a time value, retrieved from a monotonic clock, in nanoseconds
-type KTime int64
-
-// GetKTime gets the current time in same nanosecond format as bpf_ktime_get_ns() eBPF call
-// This relies runtime.nanotime to use CLOCK_MONOTONIC. If this changes, this needs to
-// be adjusted accordingly. Using this internal is superior in performance, as it is able
-// to use the vDSO to query the time without syscall.
-//
-//go:noescape
-//go:linkname GetKTime runtime.nanotime
-func GetKTime() KTime
 
 // Void allows to use maps as sets without memory allocation for the values.
 // From the "Go Programming Language":

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/metrics"
 	"github.com/elastic/otel-profiling-agent/metrics/agentmetrics"
 	"github.com/elastic/otel-profiling-agent/reporter"
+	tim "github.com/elastic/otel-profiling-agent/times"
 
 	"github.com/elastic/otel-profiling-agent/tracer"
 
@@ -318,6 +319,8 @@ func mainWithExitCode() exitCode {
 	// regularly. This is required so pf-web-service only needs to query metadata for bounded
 	// periods of time.
 	metadataCollector.StartMetadataCollection(mainCtx, rep)
+
+	tim.StartRealtimeSync()
 
 	// Start agent specific metric retrieval and report them every second.
 	agentMetricCancel, agentErr := agentmetrics.Start(mainCtx, 1*time.Second)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/tracehandler"
 
 	"github.com/elastic/otel-profiling-agent/hostmetadata"
-	"github.com/elastic/otel-profiling-agent/metrics/reportermetrics"
+	//	"github.com/elastic/otel-profiling-agent/metrics/reportermetrics"
 
 	"github.com/elastic/otel-profiling-agent/config"
 	"github.com/elastic/otel-profiling-agent/metrics"
@@ -329,7 +329,7 @@ func mainWithExitCode() exitCode {
 	}
 	defer agentMetricCancel()
 	// Start reporter metric reporting with 60 second intervals.
-	defer reportermetrics.Start(mainCtx, rep, 60*time.Second)()
+	//	defer reportermetrics.Start(mainCtx, rep, 60*time.Second)()
 
 	// Load the eBPF code and map definitions
 	trc, err := tracer.NewTracer(mainCtx, rep, times, includeTracers, !argSendErrorFrames)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -28,6 +28,7 @@ import (
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
 	eim "github.com/elastic/otel-profiling-agent/processmanager/execinfomanager"
 	"github.com/elastic/otel-profiling-agent/reporter"
+	"github.com/elastic/otel-profiling-agent/times"
 )
 
 const (
@@ -87,7 +88,7 @@ func New(ctx context.Context, includeTracers []bool, monitorInterval time.Durati
 		interpreterTracerEnabled: em.NumInterpreterLoaders() > 0,
 		eim:                      em,
 		interpreters:             interpreters,
-		exitEvents:               make(map[libpf.PID]libpf.KTime),
+		exitEvents:               make(map[libpf.PID]times.KTime),
 		pidToProcessInfo:         make(map[libpf.PID]*processInfo),
 		ebpf:                     ebpf,
 		FileIDMapper:             fileIDMapper,
@@ -292,11 +293,11 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 	return newTrace
 }
 
-func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime libpf.KTime) {
+func (pm *ProcessManager) SymbolizationComplete(traceCaptureKTime times.KTime) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	nowKTime := libpf.GetKTime()
+	nowKTime := times.GetKTime()
 
 	for pid, pidExitKTime := range pm.exitEvents {
 		if pidExitKTime > traceCaptureKTime {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/lpm"
 	"github.com/elastic/otel-profiling-agent/proc"
 	eim "github.com/elastic/otel-profiling-agent/processmanager/execinfomanager"
+	"github.com/elastic/otel-profiling-agent/times"
 	"github.com/elastic/otel-profiling-agent/tpbase"
 
 	log "github.com/sirupsen/logrus"
@@ -506,7 +507,7 @@ func (pm *ProcessManager) ProcessPIDExit(pid libpf.PID) bool {
 	defer pm.mu.Unlock()
 
 	symbolize := false
-	exitKTime := libpf.GetKTime()
+	exitKTime := times.GetKTime()
 	if pm.interpreterTracerEnabled {
 		if len(pm.interpreters[pid]) > 0 {
 			pm.exitEvents[pid] = exitKTime

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -20,6 +20,7 @@ import (
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
 	eim "github.com/elastic/otel-profiling-agent/processmanager/execinfomanager"
 	"github.com/elastic/otel-profiling-agent/reporter"
+	"github.com/elastic/otel-profiling-agent/times"
 	"github.com/elastic/otel-profiling-agent/tpbase"
 )
 
@@ -56,7 +57,7 @@ type ProcessManager struct {
 	pidToProcessInfo map[libpf.PID]*processInfo
 
 	// exitEvents records the pid exit time and is a list of pending exit events to be handled.
-	exitEvents map[libpf.PID]libpf.KTime
+	exitEvents map[libpf.PID]times.KTime
 
 	// ebpf contains the interface to manipulate ebpf maps
 	ebpf pmebpf.EbpfHandler

--- a/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
+++ b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
@@ -38,6 +38,7 @@ service ProfilesService {
   rpc ExportDeltaTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportDedup(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportStacks(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+  rpc ExportArrays(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 
 message ExportProfilesServiceRequest {

--- a/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
+++ b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
@@ -35,6 +35,7 @@ service ProfilesService {
   // alive for the entire life of the application.
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportZeroTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+  rpc ExportDeltaTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 
 message ExportProfilesServiceRequest {

--- a/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
+++ b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
@@ -34,6 +34,7 @@ service ProfilesService {
   // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+  rpc ExportZeroTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 
 message ExportProfilesServiceRequest {

--- a/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
+++ b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
@@ -36,6 +36,7 @@ service ProfilesService {
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportZeroTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportDeltaTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+  rpc ExportDedup(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportStacks(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 

--- a/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
+++ b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto
@@ -36,6 +36,7 @@ service ProfilesService {
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportZeroTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
   rpc ExportDeltaTime(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+  rpc ExportStacks(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 
 message ExportProfilesServiceRequest {

--- a/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
+++ b/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
@@ -87,6 +87,9 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
+
+  // Stacks referenced by samples via stack_index.
+  repeated Stack stack_table = 19;
 }
 // Represents a mapping between Attribute Keys and Units.
 message AttributeUnit {
@@ -174,6 +177,8 @@ message ValueType {
 // augmented with auxiliary information like the thread-id, some
 // indicator of a higher level request being handled etc.
 message Sample {
+ // Reference to stack in Profile.stack_table.
+  int32 stack_index = 1;
   // locations_start_index along with locations_length refers to to a slice of locations in Profile.location.
   // Supersedes location_index.
   uint64 locations_start_index = 7;
@@ -205,6 +210,13 @@ message Sample {
   // to fall within the Profile's time range. [optional]
   repeated uint64 timestamps = 13;
 }
+
+// A Stack represents a stack trace as a list of locations. The first location
+// is the leaf frame.
+message Stack {
+  repeated int32 location_indices = 1;
+}
+
 // Provides additional context for a sample,
 // such as thread ID or allocation size, with optional units. [deprecated]
 message Label {

--- a/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
+++ b/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
@@ -174,17 +174,12 @@ message ValueType {
 // augmented with auxiliary information like the thread-id, some
 // indicator of a higher level request being handled etc.
 message Sample {
-  // The indices recorded here correspond to locations in Profile.location.
-  // The leaf is at location_index[0]. [deprecated, superseded by locations_start_index / locations_length]
-  repeated uint64 location_index = 1;
   // locations_start_index along with locations_length refers to to a slice of locations in Profile.location.
   // Supersedes location_index.
   uint64 locations_start_index = 7;
   // locations_length along with locations_start_index refers to a slice of locations in Profile.location.
   // Supersedes location_index.
   uint64 locations_length = 8;
-  // A 128bit id that uniquely identifies this stacktrace, globally. Index into string table. [optional]
-  uint32 stacktrace_id_index = 9;
   // The type and unit of each value is defined by the corresponding
   // entry in Profile.sample_type. All samples must have the same
   // number of values, the same as the length of Profile.sample_type.

--- a/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
+++ b/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
@@ -91,6 +91,7 @@ message Profile {
   // Stacks referenced by samples via stack_index.
   repeated Stack stack_table = 19;
 }
+
 // Represents a mapping between Attribute Keys and Units.
 message AttributeUnit {
   // Index into string table.

--- a/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
+++ b/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
@@ -90,6 +90,9 @@ message Profile {
 
   // Stacks referenced by samples via stack_index.
   repeated Stack stack_table = 19;
+
+  repeated int32 stack_parent_array = 20;
+  repeated int32 stack_location_index = 21;
 }
 
 // Represents a mapping between Attribute Keys and Units.

--- a/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
+++ b/proto/opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto
@@ -180,10 +180,10 @@ message ValueType {
 message Sample {
  // Reference to stack in Profile.stack_table.
   int32 stack_index = 1;
-  // locations_start_index along with locations_length refers to to a slice of locations in Profile.location.
+  // locations_start_index along with locations_length refers to to a slice of locations in Profile.location_indices.
   // Supersedes location_index.
   uint64 locations_start_index = 7;
-  // locations_length along with locations_start_index refers to a slice of locations in Profile.location.
+  // locations_length along with locations_start_index refers to a slice of locations in Profile.location_indices.
   // Supersedes location_index.
   uint64 locations_length = 8;
   // The type and unit of each value is defined by the corresponding

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -417,7 +417,21 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	}
 
 	gzipOption := grpc.UseCompressor(gzip.Name)
+
+	// Base RPC (no proto changes)
 	_, err := r.client.Export(ctx, &req, gzipOption)
+
+	// Zeroed-out timestamps
+	for _, s := range profile.Sample {
+		for idx, _ := range s.Timestamps {
+			s.Timestamps[idx] = 0
+			// log.Warnf("TT: %v => %v", v, v-startTS)
+		}
+	}
+
+	// Timestamps set to zero
+	_, err = r.client.ExportZeroTime(ctx, &req, gzipOption)
+
 	r.LogMetrics()
 	return err
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -518,9 +518,6 @@ func (r *OTLPReporter) getProfile() (profile *pprofextended.Profile, startTS uin
 		// Earlier we peeked into traces for traceHash and know it exists.
 		trace, _ := r.traces.Get(traceHash)
 
-		sample.StacktraceIdIndex = getStringMapIndex(stringMap,
-			traceHash.StringNoQuotes())
-
 		sample.Timestamps = make([]uint64, 0, len(sampleInfo.timestamps))
 		for _, ts := range sampleInfo.timestamps {
 			sample.Timestamps = append(sample.Timestamps,

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -25,6 +25,8 @@ import (
 
 	lru "github.com/elastic/go-freelru"
 	"github.com/zeebo/xxh3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding/gzip"
 )
 
 // Assert that we implement the full Reporter interface.
@@ -391,7 +393,8 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 		ResourceProfiles: resourceProfiles,
 	}
 
-	_, err := r.client.Export(ctx, &req)
+	gzipOption := grpc.UseCompressor(gzip.Name)
+	_, err := r.client.Export(ctx, &req, gzipOption)
 	return err
 }
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -392,6 +392,7 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	}
 
 	profileStacks, _, _ := r.getProfileStacks(samples)
+	profileDedup, _, _ := r.getProfileDedup(samples)
 
 	pc := []*profiles.ProfileContainer{{
 		// Next step: not sure about the value of ProfileId
@@ -449,6 +450,10 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 		}
 	}
 	_, err = r.client.ExportZeroTime(ctx, &req, gzipOption)
+
+	// Deduped Locations
+	req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Profile = profileDedup
+	_, err = r.client.ExportDedup(ctx, &req, gzipOption)
 
 	// Alternate stack representation
 	req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Profile = profileStacks
@@ -722,7 +727,230 @@ func (r *OTLPReporter) getProfile() (profile *pprofextended.Profile, startTS uin
 	return profile, startTS, endTS, samplesCpy
 }
 
-// getProfile returns an OTLP profile containing all collected samples up to this moment.
+// getProfileDedup returns an OTLP profile containing all collected samples up to this moment (deduplicating Locations)
+func (r *OTLPReporter) getProfileDedup(samples map[libpf.TraceHash]sample) (profile *pprofextended.Profile, startTS uint64, endTS uint64) {
+	// stringMap is a temporary helper that will build the StringTable.
+	// By specification, the first element should be empty.
+	stringMap := make(map[string]uint32)
+	stringMap[""] = 0
+
+	// funcMap is a temporary helper that will build the Function array
+	// in profile and make sure information is deduplicated.
+	funcMap := make(map[funcInfo]uint64)
+	funcMap[funcInfo{name: "", fileName: ""}] = 0
+
+	// Used to deduplicate Locations
+	locationKeyMap := make(map[locationKey]uint32)
+
+	numSamples := len(samples)
+	profile = &pprofextended.Profile{
+		// SampleType - Next step: Figure out the correct SampleType.
+		Sample:          make([]*pprofextended.Sample, 0, numSamples),
+		LocationIndices: make([]int64, 0),
+		// LocationIndices - Optional element we do not use.
+		// AttributeTable - Optional element we do not use.
+		// AttributeUnits - Optional element we do not use.
+		// LinkTable - Optional element we do not use.
+		// DropFrames - Optional element we do not use.
+		// KeepFrames - Optional element we do not use.
+		// TimeNanos - Optional element we do not use.
+		// DurationNanos - Optional element we do not use.
+		// PeriodType - Optional element we do not use.
+		// Period - Optional element we do not use.
+		// Comment - Optional element we do not use.
+		// DefaultSampleType - Optional element we do not use.
+	}
+
+	locationIndex := uint64(0)
+
+	// Temporary lookup to reference existing Mappings.
+	fileIDtoMapping := make(map[libpf.FileID]uint64)
+	frameIDtoFunction := make(map[libpf.FrameID]uint64)
+
+	for traceHash, sampleInfo := range samples {
+		sample := &pprofextended.Sample{}
+		sample.LocationsStartIndex = locationIndex
+
+		// Earlier we peeked into traces for traceHash and know it exists.
+		trace, _ := r.traces.Get(traceHash)
+
+		sample.Timestamps = make([]uint64, 0, len(sampleInfo.timestamps))
+		for _, ts := range sampleInfo.timestamps {
+			sample.Timestamps = append(sample.Timestamps, uint64(ts))
+			if ts < startTS || startTS == 0 {
+				startTS = ts
+				continue
+			}
+			if ts > endTS {
+				endTS = ts
+			}
+		}
+
+		// Walk every frame of the trace.
+		for i := range trace.frameTypes {
+			loc := &pprofextended.Location{
+				// Id - Optional element we do not use.
+				TypeIndex: getStringMapIndex(stringMap,
+					trace.frameTypes[i].String()),
+				Address: uint64(trace.linenos[i]),
+				// IsFolded - Optional element we do not use.
+				// Attributes - Optional element we do not use.
+			}
+
+			switch frameKind := trace.frameTypes[i]; frameKind {
+			case libpf.NativeFrame:
+				// As native frames are resolved in the backend, we use Mapping to
+				// report these frames.
+
+				var locationMappingIndex uint64
+				if tmpMappingIndex, exists := fileIDtoMapping[trace.files[i]]; exists {
+					locationMappingIndex = tmpMappingIndex
+				} else {
+					idx := uint64(len(fileIDtoMapping))
+					fileIDtoMapping[trace.files[i]] = idx
+					locationMappingIndex = idx
+
+					execInfo, exists := r.executables.Get(trace.files[i])
+
+					// Next step: Select a proper default value,
+					// if the name of the executable is not known yet.
+					var fileName = "UNKNOWN"
+					if exists {
+						fileName = execInfo.fileName
+					}
+
+					profile.Mapping = append(profile.Mapping, &pprofextended.Mapping{
+						// Id - Optional element we do not use.
+						// MemoryStart - Optional element we do not use.
+						// MemoryLImit - Optional element we do not use.
+						FileOffset: uint64(trace.linenos[i]),
+						Filename:   int64(getStringMapIndex(stringMap, fileName)),
+						BuildId: int64(getStringMapIndex(stringMap,
+							trace.files[i].StringNoQuotes())),
+						BuildIdKind: *pprofextended.BuildIdKind_BUILD_ID_BINARY_HASH.Enum(),
+						// Attributes - Optional element we do not use.
+						// HasFunctions - Optional element we do not use.
+						// HasFilenames - Optional element we do not use.
+						// HasLineNumbers - Optional element we do not use.
+						// HasInlinedFrames - Optional element we do not use.
+					})
+				}
+				loc.MappingIndex = locationMappingIndex
+			case libpf.KernelFrame:
+				// Reconstruct frameID
+				frameID := libpf.NewFrameID(trace.files[i], trace.linenos[i])
+				// Store Kernel frame information as Line message:
+				line := &pprofextended.Line{}
+
+				if tmpFunctionIndex, exists := frameIDtoFunction[frameID]; exists {
+					line.FunctionIndex = tmpFunctionIndex
+				} else {
+					symbol, exists := r.fallbackSymbols.Get(frameID)
+					if !exists {
+						// TODO: choose a proper default value if the kernel symbol was not
+						// reported yet.
+						symbol = "UNKNOWN"
+					}
+					line.FunctionIndex = createFunctionEntry(funcMap,
+						symbol, "vmlinux")
+				}
+				loc.Line = append(loc.Line, line)
+
+				// To be compliant with the protocol generate a dummy mapping entry.
+				loc.MappingIndex = getDummyMappingIndex(fileIDtoMapping, stringMap,
+					profile, trace.files[i])
+			case libpf.AbortFrame:
+				// Next step: Figure out how the OTLP protocol
+				// could handle artificial frames, like AbortFrame,
+				// that are not originate from a native or interpreted
+				// program.
+			default:
+				// Store interpreted frame information as Line message:
+				line := &pprofextended.Line{}
+
+				fileIDInfo, exists := r.frames.Get(trace.files[i])
+				if !exists {
+					// At this point, we do not have enough information for the frame.
+					// Therefore, we report a dummy entry and use the interpreter as filename.
+					line.FunctionIndex = createFunctionEntry(funcMap,
+						"UNREPORTED", frameKind.String())
+				} else {
+					si, exists := fileIDInfo[trace.linenos[i]]
+					if !exists {
+						// At this point, we do not have enough information for the frame.
+						// Therefore, we report a dummy entry and use the interpreter as filename.
+						// To differentiate this case with the case where no information about
+						// the file ID is available at all, we use a different name for reported
+						// function.
+						line.FunctionIndex = createFunctionEntry(funcMap,
+							"UNRESOLVED", frameKind.String())
+					} else {
+						line.Line = int64(si.lineNumber)
+
+						line.FunctionIndex = createFunctionEntry(funcMap,
+							si.functionName, si.filePath)
+					}
+				}
+				loc.Line = append(loc.Line, line)
+
+				// To be compliant with the protocol generate a dummy mapping entry.
+				loc.MappingIndex = getDummyMappingIndex(fileIDtoMapping, stringMap,
+					profile, trace.files[i])
+			}
+
+			// Deduplicate Location
+			locKey := locationKey{
+				typeIndex:    loc.TypeIndex,
+				address:      loc.Address,
+				mappingIndex: loc.MappingIndex,
+				line:         fmt.Sprintf("%v", loc.Line),
+			}
+
+			locIdx, exists := getLocationIndex(locationKeyMap, locKey)
+			if !exists {
+				profile.Location = append(profile.Location, loc)
+			}
+			profile.LocationIndices = append(profile.LocationIndices, int64(locIdx))
+		}
+
+		sample.Label = getTraceLabels(stringMap, trace)
+		sample.LocationsLength = uint64(len(trace.frameTypes))
+		locationIndex += sample.LocationsLength
+
+		profile.Sample = append(profile.Sample, sample)
+	}
+	log.Debugf("Reporting OTLP profile with %d samples", len(profile.Sample))
+
+	// Populate the deduplicated functions into profile.
+	funcTable := make([]*pprofextended.Function, len(funcMap))
+	for v, idx := range funcMap {
+		funcTable[idx] = &pprofextended.Function{
+			Name:     int64(getStringMapIndex(stringMap, v.name)),
+			Filename: int64(getStringMapIndex(stringMap, v.fileName)),
+		}
+	}
+	profile.Function = append(profile.Function, funcTable...)
+
+	// When ranging over stringMap the order will be according to the
+	// hash value of the key. To get the correct order for profile.StringTable,
+	// put the values in stringMap in the correct array order.
+	stringTable := make([]string, len(stringMap))
+	for v, idx := range stringMap {
+		stringTable[idx] = v
+	}
+	profile.StringTable = append(profile.StringTable, stringTable...)
+
+	// profile.LocationIndices is not optional and we only write elements into
+	// profile.Location that are referenced by sample.
+	// profile.LocationIndices = make([]int64, len(profile.Location))
+	// for i := int64(0); i < int64(len(profile.Location)); i++ {
+	// 	profile.LocationIndices[i] = i
+	// }
+
+	return profile, startTS, endTS
+}
+
+// getProfileStacks returns an OTLP profile containing all collected samples up to this moment (deduplicating Locations and stacktraces)
 func (r *OTLPReporter) getProfileStacks(samples map[libpf.TraceHash]sample) (profile *pprofextended.Profile, startTS uint64, endTS uint64) {
 	// stringMap is a temporary helper that will build the StringTable.
 	// By specification, the first element should be empty.

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -9,6 +9,7 @@ package reporter
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -270,11 +271,19 @@ func (r *OTLPReporter) LogMetrics() {
 		}
 	}
 
-	for name, numWireBytes := range methodWireOut {
+	// Consistent ordering
+	keys := libpf.MapKeysToSlice(methodWireOut)
+	sort.Strings(keys)
+
+	for _, name := range keys {
 		if strings.HasPrefix(name, rpcPrefix) {
-			log.Warnf("Bytes: %v WireBytes: %v [%v]", rpcBytes[name], numWireBytes, name)
+			log.Warnf("Bytes: %v WireBytes: %v [%v]",
+				rpcBytes[name], methodWireOut[name],
+				name[strings.LastIndex(name, "/")+1:])
 		}
 	}
+
+	log.Warnf("")
 }
 
 // StartOTLP sets up and manages the reporting connection to a OTLP backend.

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -27,6 +27,7 @@ import (
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
 
 	lru "github.com/elastic/go-freelru"
+	"github.com/rockdaboot/go-trie/trie"
 	"github.com/zeebo/xxh3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
@@ -397,6 +398,7 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 
 	profileStacks, _, _ := r.getProfileStacks(hashes, samples)
 	profileDedup, _, _ := r.getProfileDedup(hashes, samples)
+	profileArrays, _, _ := r.getProfileArrays(hashes, samples)
 
 	pc := []*profiles.ProfileContainer{{
 		// Next step: not sure about the value of ProfileId
@@ -467,6 +469,10 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	// Alternate stack representation
 	req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Profile = profileStacks
 	_, err = r.client.ExportStacks(ctx, &req, gzipOption)
+
+	// Alternate stack representation - arrays
+	req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Profile = profileArrays
+	_, err = r.client.ExportArrays(ctx, &req, gzipOption)
 
 	r.LogMetrics()
 	r.count += 1
@@ -898,7 +904,6 @@ func (r *OTLPReporter) getProfileDedup(hashes []libpf.TraceHash, samples map[lib
 							"UNRESOLVED", frameKind.String())
 					} else {
 						line.Line = int64(si.lineNumber)
-
 						line.FunctionIndex = createFunctionEntry(funcMap,
 							si.functionName, si.filePath)
 					}
@@ -928,7 +933,6 @@ func (r *OTLPReporter) getProfileDedup(hashes []libpf.TraceHash, samples map[lib
 		sample.Label = getTraceLabels(stringMap, trace)
 		sample.LocationsLength = uint64(len(trace.frameTypes))
 		locationIndex += sample.LocationsLength
-
 		profile.Sample = append(profile.Sample, sample)
 	}
 	log.Debugf("Reporting OTLP profile with %d samples", len(profile.Sample))
@@ -1166,6 +1170,250 @@ func (r *OTLPReporter) getProfileStacks(hashes []libpf.TraceHash, samples map[li
 	}
 
 	log.Debugf("Reporting OTLP profile with %d samples", len(profile.Sample))
+
+	// Populate the deduplicated functions into profile.
+	funcTable := make([]*pprofextended.Function, len(funcMap))
+	for v, idx := range funcMap {
+		funcTable[idx] = &pprofextended.Function{
+			Name:     int64(getStringMapIndex(stringMap, v.name)),
+			Filename: int64(getStringMapIndex(stringMap, v.fileName)),
+		}
+	}
+	profile.Function = append(profile.Function, funcTable...)
+
+	// When ranging over stringMap the order will be according to the
+	// hash value of the key. To get the correct order for profile.StringTable,
+	// put the values in stringMap in the correct array order.
+	stringTable := make([]string, len(stringMap))
+	for v, idx := range stringMap {
+		stringTable[idx] = v
+	}
+	profile.StringTable = append(profile.StringTable, stringTable...)
+
+	return profile, startTS, endTS
+}
+
+// getProfileArrays returns an OTLP profile containing all collected samples up to this moment
+// (using arrays to deduplicate Locations and stacktraces)
+func (r *OTLPReporter) getProfileArrays(hashes []libpf.TraceHash, samples map[libpf.TraceHash]sample) (profile *pprofextended.Profile, startTS uint64, endTS uint64) {
+	// stringMap is a temporary helper that will build the StringTable.
+	// By specification, the first element should be empty.
+	stringMap := make(map[string]uint32)
+	stringMap[""] = 0
+
+	// funcMap is a temporary helper that will build the Function array
+	// in profile and make sure information is deduplicated.
+	funcMap := make(map[funcInfo]uint64)
+	funcMap[funcInfo{name: "", fileName: ""}] = 0
+
+	// Used to deduplicate Locations
+	locationKeyMap := make(map[locationKey]uint32)
+
+	numSamples := len(samples)
+	profile = &pprofextended.Profile{
+		// SampleType - Next step: Figure out the correct SampleType.
+		Sample: make([]*pprofextended.Sample, 0, numSamples),
+		// LocationIndices - Optional element we do not use.
+		// AttributeTable - Optional element we do not use.
+		// AttributeUnits - Optional element we do not use.
+		// LinkTable - Optional element we do not use.
+		// DropFrames - Optional element we do not use.
+		// KeepFrames - Optional element we do not use.
+		// TimeNanos - Optional element we do not use.
+		// DurationNanos - Optional element we do not use.
+		// PeriodType - Optional element we do not use.
+		// Period - Optional element we do not use.
+		// Comment - Optional element we do not use.
+		// DefaultSampleType - Optional element we do not use.
+	}
+
+	locationIndices := make([]int64, 0)
+	locationIndex := uint64(0)
+
+	// Temporary lookup to reference existing Mappings.
+	fileIDtoMapping := make(map[libpf.FileID]uint64)
+	frameIDtoFunction := make(map[libpf.FrameID]uint64)
+
+	profile.Location = append(profile.Location, &pprofextended.Location{})
+	locationKeyMap[locationKey{}] = 0
+
+	stacksTrie := trie.New[int64]()
+
+	for _, traceHash := range hashes {
+		sampleInfo := samples[traceHash]
+		sample := &pprofextended.Sample{}
+
+		// Earlier we peeked into traces for traceHash and know it exists.
+		trace, _ := r.traces.Get(traceHash)
+
+		sample.Timestamps = make([]uint64, 0, len(sampleInfo.timestamps))
+		for _, ts := range sampleInfo.timestamps {
+			sample.Timestamps = append(sample.Timestamps, uint64(ts))
+			if ts < startTS || startTS == 0 {
+				startTS = ts
+				continue
+			}
+			if ts > endTS {
+				endTS = ts
+			}
+		}
+
+		// Walk every frame of the trace.
+		for i := range trace.frameTypes {
+			loc := &pprofextended.Location{
+				// Id - Optional element we do not use.
+				TypeIndex: getStringMapIndex(stringMap,
+					trace.frameTypes[i].String()),
+				Address: uint64(trace.linenos[i]),
+				// IsFolded - Optional element we do not use.
+				// Attributes - Optional element we do not use.
+			}
+
+			switch frameKind := trace.frameTypes[i]; frameKind {
+			case libpf.NativeFrame:
+				// As native frames are resolved in the backend, we use Mapping to
+				// report these frames.
+
+				var locationMappingIndex uint64
+				if tmpMappingIndex, exists := fileIDtoMapping[trace.files[i]]; exists {
+					locationMappingIndex = tmpMappingIndex
+				} else {
+					idx := uint64(len(fileIDtoMapping))
+					fileIDtoMapping[trace.files[i]] = idx
+					locationMappingIndex = idx
+
+					execInfo, exists := r.executables.Get(trace.files[i])
+
+					// Next step: Select a proper default value,
+					// if the name of the executable is not known yet.
+					var fileName = "UNKNOWN"
+					if exists {
+						fileName = execInfo.fileName
+					}
+
+					profile.Mapping = append(profile.Mapping, &pprofextended.Mapping{
+						// Id - Optional element we do not use.
+						// MemoryStart - Optional element we do not use.
+						// MemoryLImit - Optional element we do not use.
+						FileOffset: uint64(trace.linenos[i]),
+						Filename:   int64(getStringMapIndex(stringMap, fileName)),
+						BuildId: int64(getStringMapIndex(stringMap,
+							trace.files[i].StringNoQuotes())),
+						BuildIdKind: *pprofextended.BuildIdKind_BUILD_ID_BINARY_HASH.Enum(),
+						// Attributes - Optional element we do not use.
+						// HasFunctions - Optional element we do not use.
+						// HasFilenames - Optional element we do not use.
+						// HasLineNumbers - Optional element we do not use.
+						// HasInlinedFrames - Optional element we do not use.
+					})
+				}
+				loc.MappingIndex = locationMappingIndex
+			case libpf.KernelFrame:
+				// Reconstruct frameID
+				frameID := libpf.NewFrameID(trace.files[i], trace.linenos[i])
+				// Store Kernel frame information as Line message:
+				line := &pprofextended.Line{}
+
+				if tmpFunctionIndex, exists := frameIDtoFunction[frameID]; exists {
+					line.FunctionIndex = tmpFunctionIndex
+				} else {
+					symbol, exists := r.fallbackSymbols.Get(frameID)
+					if !exists {
+						// TODO: choose a proper default value if the kernel symbol was not
+						// reported yet.
+						symbol = "UNKNOWN"
+					}
+					line.FunctionIndex = createFunctionEntry(funcMap,
+						symbol, "vmlinux")
+				}
+				loc.Line = append(loc.Line, line)
+
+				// To be compliant with the protocol generate a dummy mapping entry.
+				loc.MappingIndex = getDummyMappingIndex(fileIDtoMapping, stringMap,
+					profile, trace.files[i])
+			case libpf.AbortFrame:
+				// Next step: Figure out how the OTLP protocol
+				// could handle artificial frames, like AbortFrame,
+				// that are not originate from a native or interpreted
+				// program.
+			default:
+				// Store interpreted frame information as Line message:
+				line := &pprofextended.Line{}
+
+				fileIDInfo, exists := r.frames.Get(trace.files[i])
+				if !exists {
+					// At this point, we do not have enough information for the frame.
+					// Therefore, we report a dummy entry and use the interpreter as filename.
+					line.FunctionIndex = createFunctionEntry(funcMap,
+						"UNREPORTED", frameKind.String())
+				} else {
+					si, exists := fileIDInfo[trace.linenos[i]]
+					if !exists {
+						// At this point, we do not have enough information for the frame.
+						// Therefore, we report a dummy entry and use the interpreter as filename.
+						// To differentiate this case with the case where no information about
+						// the file ID is available at all, we use a different name for reported
+						// function.
+						line.FunctionIndex = createFunctionEntry(funcMap,
+							"UNRESOLVED", frameKind.String())
+					} else {
+						line.Line = int64(si.lineNumber)
+						line.FunctionIndex = createFunctionEntry(funcMap,
+							si.functionName, si.filePath)
+					}
+				}
+				loc.Line = append(loc.Line, line)
+
+				// To be compliant with the protocol generate a dummy mapping entry.
+				loc.MappingIndex = getDummyMappingIndex(fileIDtoMapping, stringMap,
+					profile, trace.files[i])
+			}
+
+			// Deduplicate Location
+			locKey := locationKey{
+				typeIndex:    loc.TypeIndex,
+				address:      loc.Address,
+				mappingIndex: loc.MappingIndex,
+				line:         fmt.Sprintf("%v", loc.Line),
+			}
+
+			locIdx, exists := getLocationIndex(locationKeyMap, locKey)
+			if !exists {
+				profile.Location = append(profile.Location, loc)
+			}
+
+			locationIndices = append(locationIndices, int64(locIdx))
+		}
+
+		sample.Label = getTraceLabels(stringMap, trace)
+
+		locLen := uint64(len(trace.frameTypes))
+		locStart := locationIndex
+		locEnd := locStart + locLen
+		locationIndex += locLen
+
+		sample.StackIndex = int32(stacksTrie.AddStack(locationIndices[locStart:locEnd]))
+		profile.Sample = append(profile.Sample, sample)
+	}
+
+	log.Debugf("Reporting OTLP profile with %d samples", len(profile.Sample))
+
+	// Populate the two stack arrays
+	locIdxTable, stackParent, stackLocation, _ := stacksTrie.ToArrays()
+	profile.StackParentArray = make([]int32, len(stackParent))
+	profile.StackLocationIndex = make([]int32, len(stackLocation))
+
+	locTable := profile.Location
+	profile.Location = make([]*pprofextended.Location, len(locIdxTable))
+
+	for idx := 0; idx < len(locIdxTable); idx++ {
+		profile.Location[idx] = locTable[locIdxTable[idx]]
+	}
+
+	for i, _ := range stackParent {
+		profile.StackParentArray[i] = int32(stackParent[i])
+		profile.StackLocationIndex[i] = int32(stackLocation[i])
+	}
 
 	// Populate the deduplicated functions into profile.
 	funcTable := make([]*pprofextended.Function, len(funcMap))

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -424,8 +424,8 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	// Zeroed-out timestamps
 	for _, s := range profile.Sample {
 		for idx, _ := range s.Timestamps {
+			//			log.Warnf("TT: %v", time.Unix(0, int64(s.Timestamps[idx])))
 			s.Timestamps[idx] = 0
-			// log.Warnf("TT: %v => %v", v, v-startTS)
 		}
 	}
 
@@ -534,8 +534,7 @@ func (r *OTLPReporter) getProfile() (profile *pprofextended.Profile, startTS uin
 
 		sample.Timestamps = make([]uint64, 0, len(sampleInfo.timestamps))
 		for _, ts := range sampleInfo.timestamps {
-			sample.Timestamps = append(sample.Timestamps,
-				uint64(time.Unix(int64(ts), 0).UnixMilli()))
+			sample.Timestamps = append(sample.Timestamps, uint64(ts))
 			if ts < startTS || startTS == 0 {
 				startTS = ts
 				continue

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,83 @@
+// Package main implements a stub gRPC server.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+
+	pb "github.com/elastic/otel-profiling-agent/proto/experiments/opentelemetry/proto/collector/profiles/v1"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+)
+
+type exitCode int
+
+const (
+	RPCMaxMsgSize int = 33554432 // 32 MiB
+
+	exitSuccess exitCode = 0
+	exitFailure exitCode = 1
+)
+
+var (
+	port = flag.Int("port", 8260, "The gRPC server port")
+)
+
+type profilesServer struct {
+	pb.UnimplementedProfilesServiceServer
+}
+
+func (p *profilesServer) Export(context.Context, *pb.ExportProfilesServiceRequest) (
+	*pb.ExportProfilesServiceResponse, error) {
+	log.Printf("Export!")
+	return &pb.ExportProfilesServiceResponse{}, nil
+}
+
+func newServer() *profilesServer {
+	p := &profilesServer{}
+	return p
+}
+
+func main() {
+	os.Exit(int(mainWithExitCode()))
+}
+
+func mainWithExitCode() exitCode {
+	flag.Parse()
+
+	listenAddress := fmt.Sprintf("localhost:%d", *port)
+	lis, err := net.Listen("tcp", listenAddress)
+	if err != nil {
+		log.Printf("Error: failed to listen at %v: %v", listenAddress, err)
+		return exitFailure
+	}
+
+	opts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(RPCMaxMsgSize),
+		grpc.MaxSendMsgSize(RPCMaxMsgSize),
+	}
+	grpcServer := grpc.NewServer(opts...)
+	pb.RegisterProfilesServiceServer(grpcServer, newServer())
+
+	ctx, stop := signal.NotifyContext(context.Background(),
+		unix.SIGINT, unix.SIGTERM, unix.SIGABRT)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		grpcServer.GracefulStop()
+		log.Printf("Stopping gRPC server")
+	}()
+
+	log.Printf("Serving gRPC at: %v", listenAddress)
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Printf("Error: serving gRPC: %v", err)
+		return exitFailure
+	}
+	return exitSuccess
+}

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,13 @@ type profilesServer struct {
 
 func (p *profilesServer) Export(context.Context, *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("Export!")
+	log.Printf("Export")
+	return &pb.ExportProfilesServiceResponse{}, nil
+}
+
+func (p *profilesServer) ExportZeroTime(context.Context, *pb.ExportProfilesServiceRequest) (
+	*pb.ExportProfilesServiceResponse, error) {
+	log.Printf("ExportZeroTime")
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,12 @@ func (p *profilesServer) ExportZeroTime(context.Context, *pb.ExportProfilesServi
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
+func (p *profilesServer) ExportDeltaTime(context.Context, *pb.ExportProfilesServiceRequest) (
+	*pb.ExportProfilesServiceResponse, error) {
+	log.Printf("ExportDeltaTime")
+	return &pb.ExportProfilesServiceResponse{}, nil
+}
+
 func newServer() *profilesServer {
 	p := &profilesServer{}
 	return p

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"log"
@@ -33,33 +34,49 @@ type profilesServer struct {
 	pb.UnimplementedProfilesServiceServer
 }
 
-func (p *profilesServer) Export(context.Context, *pb.ExportProfilesServiceRequest) (
+func (p *profilesServer) Export(ctx context.Context, req *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("Export")
+
+	container := req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0]
+	id := binary.BigEndian.Uint32(container.ProfileId)
+	log.Printf("Export[%d]", id)
+
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
-func (p *profilesServer) ExportZeroTime(context.Context, *pb.ExportProfilesServiceRequest) (
+func (p *profilesServer) ExportZeroTime(ctx context.Context, req *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("ExportZeroTime")
+
+	container := req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0]
+	id := binary.BigEndian.Uint32(container.ProfileId)
+	log.Printf("ExportZeroTime[%d]", id)
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
-func (p *profilesServer) ExportDeltaTime(context.Context, *pb.ExportProfilesServiceRequest) (
+func (p *profilesServer) ExportDeltaTime(ctx context.Context, req *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("ExportDeltaTime")
+
+	container := req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0]
+	id := binary.BigEndian.Uint32(container.ProfileId)
+	log.Printf("ExportDeltaTime[%d]", id)
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
-func (p *profilesServer) ExportDedup(context.Context, *pb.ExportProfilesServiceRequest) (
+func (p *profilesServer) ExportDedup(ctx context.Context, req *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("ExportDedup")
+
+	container := req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0]
+	id := binary.BigEndian.Uint32(container.ProfileId)
+	log.Printf("ExportDedup[%d]", id)
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
-func (p *profilesServer) ExportStacks(context.Context, *pb.ExportProfilesServiceRequest) (
+func (p *profilesServer) ExportStacks(ctx context.Context, req *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
-	log.Printf("ExportStacks")
+
+	container := req.ResourceProfiles[0].ScopeProfiles[0].Profiles[0]
+	id := binary.BigEndian.Uint32(container.ProfileId)
+	log.Printf("ExportStacks[%d]", id)
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,12 @@ func (p *profilesServer) ExportDeltaTime(context.Context, *pb.ExportProfilesServ
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
+func (p *profilesServer) ExportStacks(context.Context, *pb.ExportProfilesServiceRequest) (
+	*pb.ExportProfilesServiceResponse, error) {
+	log.Printf("ExportStacks")
+	return &pb.ExportProfilesServiceResponse{}, nil
+}
+
 func newServer() *profilesServer {
 	p := &profilesServer{}
 	return p

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/elastic/otel-profiling-agent/proto/experiments/opentelemetry/proto/collector/profiles/v1"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 type exitCode int

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,12 @@ func (p *profilesServer) ExportDeltaTime(context.Context, *pb.ExportProfilesServ
 	return &pb.ExportProfilesServiceResponse{}, nil
 }
 
+func (p *profilesServer) ExportDedup(context.Context, *pb.ExportProfilesServiceRequest) (
+	*pb.ExportProfilesServiceResponse, error) {
+	log.Printf("ExportDedup")
+	return &pb.ExportProfilesServiceResponse{}, nil
+}
+
 func (p *profilesServer) ExportStacks(context.Context, *pb.ExportProfilesServiceRequest) (
 	*pb.ExportProfilesServiceResponse, error) {
 	log.Printf("ExportStacks")

--- a/times/ktime.go
+++ b/times/ktime.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package times
+
+import (
+	"time"
+	_ "unsafe" // required to use //go:linkname for runtime.nanotime
+)
+
+// KTime stores a time value, retrieved from a monotonic clock, in nanoseconds
+type KTime int64
+
+// GetKTime gets the current time in same nanosecond format as bpf_ktime_get_ns() eBPF call
+// This relies runtime.nanotime to use CLOCK_MONOTONIC. If this changes, this needs to
+// be adjusted accordingly. Using this internal is superior in performance, as it is able
+// to use the vDSO to query the time without syscall.
+//
+//go:noescape
+//go:linkname GetKTime runtime.nanotime
+func GetKTime() KTime
+
+// Time converts the kernel timestamp into a Go time object.
+func (t KTime) Time() time.Time {
+	return time.Unix(0, t.UnixNano())
+}
+
+// UnixNano converts the kernel timestamp to nanoseconds since the epoch.
+func (t KTime) UnixNano() int64 {
+	return int64(t) + bootTimeUnixNano.Load()
+}

--- a/times/times.go
+++ b/times/times.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package times
+
+import (
+	"runtime"
+	"sort"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// Number of timing samples to use when retrieving system boot time.
+	sampleSize = 5
+)
+
+var (
+	// Monotonic-to-unixtime delta that can be added to a monotonic (CLOCK_MONOTONIC)
+	// timestamp to convert it to time-since-epoch.
+	bootTimeUnixNano atomic.Int64
+)
+
+// StartRealtimeSync calculates a delta between the monotonic clock
+// (CLOCK_MONOTONIC, rebased to unixtime) and the realtime clock. If syncInterval is
+// greater than zero, it also starts a goroutine to perform that calculation periodically.
+func StartRealtimeSync() {
+	bootTimeUnixNano.Store(getBootTimeUnixNano())
+}
+
+// getBootTimeUnixNano returns system boot time in nanoseconds since the
+// epoch, temporarily locking the calling goroutine to its OS thread.
+func getBootTimeUnixNano() int64 {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	samples := make([]struct {
+		t1    time.Time
+		ktime int64
+		t2    time.Time
+	}, sampleSize)
+
+	for i := range samples {
+		// To avoid noise from scheduling / other delays, we perform a
+		// series of measurements and pick the one with the lowest delta.
+		samples[i].t1 = time.Now()
+		samples[i].ktime = int64(GetKTime())
+		samples[i].t2 = time.Now()
+	}
+
+	sort.Slice(samples, func(i, j int) bool {
+		di := samples[i].t2.UnixNano() - samples[i].t1.UnixNano()
+		dj := samples[j].t2.UnixNano() - samples[j].t1.UnixNano()
+		if di < 0 {
+			di = -di
+		}
+		if dj < 0 {
+			dj = -dj
+		}
+		return di < dj
+	})
+
+	// This should never be negative, as t1.UnixNano() >> ktime
+	return samples[0].t1.UnixNano() - samples[0].ktime
+}

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/libpf/memorydebug"
 	"github.com/elastic/otel-profiling-agent/reporter"
+	"github.com/elastic/otel-profiling-agent/times"
 	"github.com/elastic/otel-profiling-agent/tracer"
 	log "github.com/sirupsen/logrus"
 )
@@ -49,7 +50,7 @@ type TraceProcessor interface {
 	// It gets the timestamp of when the Traces (if any) were captured. The timestamp
 	// is in essence an indicator that all Traces until that time have been now processed,
 	// and any events up to this time can be processed.
-	SymbolizationComplete(traceCaptureKTime libpf.KTime)
+	SymbolizationComplete(traceCaptureKTime times.KTime)
 }
 
 // Compile time check to make sure Tracer satisfies the interfaces.
@@ -132,7 +133,8 @@ func newTraceHandler(ctx context.Context, rep reporter.TraceReporter,
 }
 
 func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
-	timestamp := libpf.UnixTime32(libpf.NowAsUInt32())
+	//timestamp := libpf.UnixTime32(libpf.NowAsUInt32())
+	timestamp := libpf.UnixTime32(bpfTrace.KTime.UnixNano())
 	defer m.traceProcessor.SymbolizationComplete(bpfTrace.KTime)
 
 	meta, err := m.containerMetadataHandler.GetContainerMetadata(bpfTrace.PID)

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/elastic/otel-profiling-agent/host"
 	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/elastic/otel-profiling-agent/times"
 )
 
 type fakeTimes struct {
@@ -39,7 +40,7 @@ func (f *fakeTraceProcessor) ConvertTrace(trace *host.Trace) *libpf.Trace {
 	return &newTrace
 }
 
-func (f *fakeTraceProcessor) SymbolizationComplete(libpf.KTime) {
+func (f *fakeTraceProcessor) SymbolizationComplete(times.KTime) {
 }
 
 // arguments holds the inputs to test the appropriate functions.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -42,6 +42,7 @@ import (
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
 	"github.com/elastic/otel-profiling-agent/reporter"
 	"github.com/elastic/otel-profiling-agent/support"
+	"github.com/elastic/otel-profiling-agent/times"
 )
 
 /*
@@ -840,7 +841,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) *host.Trace {
 	trace := &host.Trace{
 		Comm:  C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
 		PID:   libpf.PID(ptr.pid),
-		KTime: libpf.KTime(ptr.ktime),
+		KTime: times.KTime(ptr.ktime),
 	}
 
 	// Trace fields included in the hash:
@@ -1128,6 +1129,6 @@ func (t *Tracer) ConvertTrace(trace *host.Trace) *libpf.Trace {
 	return t.processManager.ConvertTrace(trace)
 }
 
-func (t *Tracer) SymbolizationComplete(traceCaptureKTime libpf.KTime) {
+func (t *Tracer) SymbolizationComplete(traceCaptureKTime times.KTime) {
 	t.processManager.SymbolizationComplete(traceCaptureKTime)
 }

--- a/utils/coredump/ebpfhelpers.go
+++ b/utils/coredump/ebpfhelpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/host"
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/support"
+	"github.com/elastic/otel-profiling-agent/times"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -56,7 +57,7 @@ func __push_frame(id, file, line C.u64, frameType C.uchar) C.int {
 //nolint:gocritic
 //export bpf_ktime_get_ns
 func bpf_ktime_get_ns() C.ulonglong {
-	return C.ulonglong(libpf.GetKTime())
+	return C.ulonglong(times.GetKTime())
 }
 
 //nolint:gocritic


### PR DESCRIPTION
### Introduction

This is an older version of the agent with an updated OTLP reporter that records payload sizes (both pre and after compression) for every RPC made. It also adds [new](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/0bcaabeb1fcdbbc153572b6b92745aa022c99e1b/proto/opentelemetry/proto/collector/profiles/v1/profiles_service.proto#L37-L41) `ExportXYZ` RPCs corresponding to open proposals for OTLP profiling protocol modifications and a gRPC server that accepts them. In details, the RPCs are:

1. `Export`: baseline, no `Location` deduplication
2. `ExportZeroTime`: baseline with all timestamps set to zero (theoretical best case)
3. `ExportDeltaTime`: baseline with timestamps in `Sample` set to delta from `Profile` start time
4. `ExportDedup`: `Location` deduplication (no protocol changes)
5. `ExportStacks`: `Location` and stacktrace deduplication using a new `Stack` message
6. `ExportArrays`: `Location` and stacktrace deduplication using two arrays

### To build and run

First build and install Zydis 3.1.0:

```
git clone --depth 1 --branch v3.1.0 --recursive https://github.com/zyantific/zydis.git && \
    cd zydis && mkdir build && cd build && \
    cmake -DZYDIS_BUILD_EXAMPLES=OFF .. && make -j$(nproc) && make install && \
    cd zycore && make install && \
    cd ../../.. && rm -rf zydis
```

Then:

1. `make` will build the agent and the stub gRPC server
2. Run the server: `./server/server`
3. Run the agent: `make bench`

### Output

Agent log output will look like this (RPCs are grouped and logged by each batch. Input data is identical for each batch).

```
msg="Bytes: 2157110 WireBytes: 586905 [Export]"
msg="Bytes: 602920  WireBytes: 305235 [ExportArrays]"
msg="Bytes: 688709  WireBytes: 277955 [ExportDedup]"
msg="Bytes: 2130539 WireBytes: 586135 [ExportDeltaTime]"
msg="Bytes: 703704  WireBytes: 277713 [ExportStacks]"
msg="Bytes: 2104766 WireBytes: 553528 [ExportZeroTime]"
```

`Bytes` refers to payload size before compression, `WireBytes` refers to payload size on the wire, post-compression.

In my workloads, `ExportArrays` is always better (smaller payload) without compression (5-20% reduction depending on workload) but always worse after compression (with significant size overhead if the data exhibits a lot of redundancy).

`ExportDedup` and `ExportStacks` are roughly equivalent.

Setting all timestamps to zero shows a 5-6% reduction (theoretical best case). The simple delta scheme shows less than 1% reduction on average.

