### PR TITLE
pfelf: fix and optimize mmapped section reading

### DIFF
--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -734,10 +734,16 @@ func (sh *Section) ReadAt(p []byte, off int64) (n int, err error) {
 	if off < 0 || uint64(off) >= sh.FileSize {
 		return 0, io.EOF
 	}
+	truncated := false
 	if uint64(off)+uint64(len(p)) > sh.FileSize {
 		p = p[:sh.FileSize-uint64(off)]
+		truncated = true
 	}
-	return sh.elfReader.ReadAt(p, off+int64(sh.Offset))
+	n, err = sh.elfReader.ReadAt(p, off+int64(sh.Offset))
+	if err == nil && truncated {
+		err = io.EOF
+	}
+	return n, err
 }
 
 // Data loads the whole section header referenced data, and returns it as a slice.


### PR DESCRIPTION
The Section reader elfReader was assigned the SectionReader, not the backing pfelf.File's elfReader. This caused the dynamic cast to mmap.ReaderAt always fail in Section.Data().

Fix the assignment to pass the backing elfReader, for the cast to work correctly. And while at it, remove the SectionReader as it causes GC pressure and implement the ReadAt() function on the struct directly. This also fixes the Section to implement io.ReaderAt itnerface which commit 9788d396 accidentally removed by removing the embedded io.ReaderAt interface. Add also interace contract tests in the file.