### PR TITLE
reporter: replace per-fileID LRU with a global LRU

### DIFF
--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -34,7 +34,7 @@ func NewController(cfg *controller.Config,
 		ReportInterval:           intervals.ReportInterval(),
 		ExecutablesCacheElements: 16384,
 		// Next step: Calculate FramesCacheElements from numCores and samplingRate.
-		FramesCacheElements: 65536,
+		FramesCacheElements: 131072,
 		CGroupCacheElements: 1024,
 		SamplesPerSecond:    cfg.SamplesPerSecond,
 	}, nextConsumer)

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func mainWithExitCode() exitCode {
 		ReportInterval:           intervals.ReportInterval(),
 		ExecutablesCacheElements: 16384,
 		// Next step: Calculate FramesCacheElements from numCores and samplingRate.
-		FramesCacheElements: 65536,
+		FramesCacheElements: 131072,
 		CGroupCacheElements: 1024,
 		SamplesPerSecond:    cfg.SamplesPerSecond,
 		KernelVersion:       kernelVersion,

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -73,13 +73,7 @@ func (b *baseReporter) ExecutableKnown(fileID libpf.FileID) bool {
 }
 
 func (b *baseReporter) FrameKnown(frameID libpf.FrameID) bool {
-	known := false
-	if frameMapLock, exists := b.pdata.Frames.GetAndRefresh(frameID.FileID(),
-		pdata.FramesCacheLifetime); exists {
-		frameMap := frameMapLock.WLock()
-		defer frameMapLock.WUnlock(&frameMap)
-		_, known = (*frameMap).GetAndRefresh(frameID.AddressOrLine(), pdata.FrameMapLifetime)
-	}
+	_, known := b.pdata.Frames.GetAndRefresh(frameID, pdata.FrameMapLifetime)
 	return known
 }
 
@@ -145,53 +139,19 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 }
 
 func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
-	fileID := args.FrameID.FileID()
-	addressOrLine := args.FrameID.AddressOrLine()
-
 	log.Debugf("FrameMetadata [%x] %v+%v at %v:%v",
-		fileID, args.FunctionName, args.FunctionOffset,
+		args.FrameID.FileID(), args.FunctionName, args.FunctionOffset,
 		args.SourceFile, args.SourceLine)
-
-	if frameMapLock, exists := b.pdata.Frames.GetAndRefresh(fileID,
-		pdata.FramesCacheLifetime); exists {
-		frameMap := frameMapLock.WLock()
-		defer frameMapLock.WUnlock(&frameMap)
-
-		sourceFile := args.SourceFile
-		if sourceFile == "" {
-			// The new SourceFile may be empty, and we don't want to overwrite
-			// an existing filePath with it.
-			if source, exists := (*frameMap).GetAndRefresh(addressOrLine,
-				pdata.FrameMapLifetime); exists {
-				sourceFile = source.FilePath
-			}
-		}
-
-		(*frameMap).Add(addressOrLine, samples.SourceInfo{
-			LineNumber:     args.SourceLine,
-			FilePath:       sourceFile,
-			FunctionOffset: args.FunctionOffset,
-			FunctionName:   args.FunctionName,
-		})
-
-		return
-	}
-
-	frameMap, err := lru.New[libpf.AddressOrLineno, samples.SourceInfo](1024,
-		func(k libpf.AddressOrLineno) uint32 { return uint32(k) })
-	if err != nil {
-		log.Errorf("Failed to create inner frameMap for %x: %v", fileID, err)
-		return
-	}
-	frameMap.SetLifetime(pdata.FrameMapLifetime)
-
-	frameMap.Add(addressOrLine, samples.SourceInfo{
+	si := samples.SourceInfo{
 		LineNumber:     args.SourceLine,
 		FilePath:       args.SourceFile,
 		FunctionOffset: args.FunctionOffset,
 		FunctionName:   args.FunctionName,
-	})
-
-	mu := xsync.NewRWMutex(frameMap)
-	b.pdata.Frames.Add(fileID, &mu)
+	}
+	if si.FilePath == "" {
+		if oldsi, exists := b.pdata.Frames.Get(args.FrameID); exists {
+			si.FilePath = oldsi.FilePath
+		}
+	}
+	b.pdata.Frames.Add(args.FrameID, si)
 }

--- a/reporter/internal/pdata/pdata.go
+++ b/reporter/internal/pdata/pdata.go
@@ -7,7 +7,6 @@ import (
 	lru "github.com/elastic/go-freelru"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 )
 
@@ -21,10 +20,7 @@ type Pdata struct {
 	Executables *lru.SyncedLRU[libpf.FileID, samples.ExecInfo]
 
 	// Frames maps frame information to its source location.
-	Frames *lru.SyncedLRU[
-		libpf.FileID,
-		*xsync.RWMutex[*lru.LRU[libpf.AddressOrLineno, samples.SourceInfo]],
-	]
+	Frames *lru.SyncedLRU[libpf.FrameID, samples.SourceInfo]
 
 	// ExtraSampleAttrProd is an optional hook point for adding custom
 	// attributes to samples.
@@ -40,9 +36,8 @@ func New(samplesPerSecond int, executablesCacheElements, framesCacheElements uin
 	}
 	executables.SetLifetime(ExecutableCacheLifetime) // Allow GC to clean stale items.
 
-	frames, err := lru.NewSynced[libpf.FileID,
-		*xsync.RWMutex[*lru.LRU[libpf.AddressOrLineno, samples.SourceInfo]]](
-		framesCacheElements, libpf.FileID.Hash32)
+	frames, err :=
+		lru.NewSynced[libpf.FrameID, samples.SourceInfo](framesCacheElements, libpf.FrameID.Hash32)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Significantly reduces memory usage in various scenarios.

fixes #525
ref #457 (possibly fixes this one too?)
ref #413 (fixes likely the excess memory usage)