### PR TITLE
libpf/cgroup: extract container ID

### DIFF
--- a/libpf/cgroupv2.go
+++ b/libpf/cgroupv2.go
@@ -8,16 +8,23 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	lru "github.com/elastic/go-freelru"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
-	cgroupv2PathPattern = regexp.MustCompile(`0:.*?:(.*)`)
+	// `([0-9a-fA-F]+)`       : This is the main capturing group. It greedily matches
+	//                         one or more hexadecimal characters (0-9, a-f, A-F).
+	//                         This will capture the full hash regardless of its length.
+	// `(?:\.scope)?`        : Non-capturing group that optionally matches the literal ".scope" suffix.
+	// `$`                   : Anchors the match to the end of the line.
+	// This regex effectively finds the last hexadecimal string right before the end
+	// of the line, optionally preceded by ".scope".
+	containerIDRegex = regexp.MustCompile(`([0-9a-fA-F]+)(?:\.scope)?$`)
 )
 
-// LookupCgroupv2 returns the cgroupv2 ID for pid.
+// LookupCgroupv2 returns the container ID for pid.
 func LookupCgroupv2(cgrouplru *lru.SyncedLRU[PID, string], pid PID) (string, error) {
 	id, ok := cgrouplru.Get(pid)
 	if ok {
@@ -31,29 +38,41 @@ func LookupCgroupv2(cgrouplru *lru.SyncedLRU[PID, string], pid PID) (string, err
 	}
 	defer f.Close()
 
-	var genericCgroupv2 string
-	scanner := bufio.NewScanner(f)
-	buf := make([]byte, 512)
-	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
-	// We can do that and also set a maximum allocation size on the following call.
-	// With a maximum of 4096 characters path in the kernel, 8192 should be fine here. We don't
-	// expect lines in /proc/<PID>/cgroup to be longer than that.
-	scanner.Buffer(buf, 8192)
-	var pathParts []string
-	for scanner.Scan() {
-		line := scanner.Text()
-		pathParts = cgroupv2PathPattern.FindStringSubmatch(line)
-		if pathParts == nil {
-			log.Debugf("Could not extract cgroupv2 path from line: %s", line)
-			continue
-		}
-		genericCgroupv2 = pathParts[1]
-		break
+	containerID, err := extractContainerID(f)
+	if err != nil {
+		return "", err
 	}
 
 	// Cache the cgroupv2 information.
 	// To avoid busy lookups, also empty cgroupv2 information is cached.
-	cgrouplru.Add(pid, genericCgroupv2)
+	cgrouplru.Add(pid, containerID)
 
-	return genericCgroupv2, nil
+	return containerID, nil
+}
+
+func extractContainerID(f *os.File) (string, error) {
+	scanner := bufio.NewScanner(f)
+	var extractedID string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "kubepods") {
+			continue
+		}
+		matches := containerIDRegex.FindStringSubmatch(line)
+		if len(matches) > 1 {
+			extractedID = matches[1]
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading file: %w", err)
+	}
+
+	if extractedID == "" {
+		return "", fmt.Errorf("could not find a valid container ID")
+	}
+
+	return extractedID, nil
 }

--- a/libpf/cgroupv2_test.go
+++ b/libpf/cgroupv2_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+//nolint:lll
 func TestExtractContainerID(t *testing.T) {
 	tests := map[string]struct {
 		input    string
@@ -32,17 +33,17 @@ func TestExtractContainerID(t *testing.T) {
 		name := name
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			tmpFile, err := os.CreateTemp("", name)
+			tmpFile, err := os.CreateTemp(t.TempDir(), name)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer tmpFile.Close()
 
-			if _, err := tmpFile.Write([]byte(tc.input)); err != nil {
+			if _, err = tmpFile.WriteString(tc.input); err != nil {
 				t.Fatal(err)
 			}
 
-			if _, err := tmpFile.Seek(0, 0); err != nil {
+			if _, err = tmpFile.Seek(0, 0); err != nil {
 				t.Fatal(err)
 			}
 
@@ -50,11 +51,9 @@ func TestExtractContainerID(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			//t.Log(result)
 			if result != tc.expected {
 				t.Fatalf("expected '%s' but got '%s'", tc.expected, result)
 			}
-
 		})
 	}
 }

--- a/libpf/cgroupv2_test.go
+++ b/libpf/cgroupv2_test.go
@@ -1,0 +1,60 @@
+package libpf
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExtractContainerID(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"perf": {
+			input:    "10:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa-95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope",
+			expected: "b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc",
+		},
+		"besteffort": {
+			input:    "2:foobar:/kubepods/besteffort/pod05e102bf-8744-4942-a241-9b6f07983a53/f52a212505a606972cf8614c3cb856539e71b77ecae33436c5ac442232fbacf8",
+			expected: "f52a212505a606972cf8614c3cb856539e71b77ecae33436c5ac442232fbacf8",
+		},
+		"crio": {
+			input:    "3:crio:/kubepods/besteffort/pod897277d4-5e6f-4999-a976-b8340e8d075e/crio-a4d6b686848a610472a2eed3ae20d4d64b6b4819feb9fdfc7fd7854deaf59ef3",
+			expected: "a4d6b686848a610472a2eed3ae20d4d64b6b4819feb9fdfc7fd7854deaf59ef3",
+		},
+		"scope": {
+			input:    "4:scope:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod4c9f1974_5c46_44c2_b42f_3bbf0e98eef9.slice/cri-containerd-bacb920470900725e0aa7d914fee5eb0854315448b024b6b8420ad8429c607ba.scope",
+			expected: "bacb920470900725e0aa7d914fee5eb0854315448b024b6b8420ad8429c607ba",
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tmpFile.Close()
+
+			if _, err := tmpFile.Write([]byte(tc.input)); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := tmpFile.Seek(0, 0); err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := extractContainerID(tmpFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			//t.Log(result)
+			if result != tc.expected {
+				t.Fatalf("expected '%s' but got '%s'", tc.expected, result)
+			}
+
+		})
+	}
+}

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -34,8 +34,8 @@ type baseReporter struct {
 	// pdata holds the generator for the data being exported.
 	pdata *pdata.Pdata
 
-	// cgroupv2ID caches PID to container ID information for cgroupv2 containers.
-	cgroupv2ID *lru.SyncedLRU[libpf.PID, string]
+	// containerID caches PID to container ID information.
+	containerID *lru.SyncedLRU[libpf.PID, string]
 
 	// traceEvents stores reported trace events (trace metadata with frames and counts)
 	traceEvents xsync.RWMutex[map[libpf.Origin]samples.KeyToEventMapping]
@@ -96,7 +96,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		extraMeta = b.cfg.ExtraSampleAttrProd.CollectExtraSampleMeta(trace, meta)
 	}
 
-	containerID, err := libpf.LookupCgroupv2(b.cgroupv2ID, meta.PID)
+	containerID, err := libpf.LookupContainerIDFromCgroup(b.containerID, meta.PID)
 	if err != nil {
 		log.Debugf("Failed to get a cgroupv2 ID as container ID for PID %d: %v",
 			meta.PID, err)

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -31,13 +31,13 @@ type CollectorReporter struct {
 
 // NewCollector builds a new CollectorReporter
 func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorReporter, error) {
-	cgroupv2ID, err := lru.NewSynced[libpf.PID, string](cfg.CGroupCacheElements,
+	containerID, err := lru.NewSynced[libpf.PID, string](cfg.CGroupCacheElements,
 		func(pid libpf.PID) uint32 { return uint32(pid) })
 	if err != nil {
 		return nil, err
 	}
 	// Set a lifetime to reduce the risk of invalid data in case of PID reuse.
-	cgroupv2ID.SetLifetime(90 * time.Second)
+	containerID.SetLifetime(90 * time.Second)
 
 	// Next step: Dynamically configure the size of this LRU.
 	// Currently, we use the length of the JSON array in
@@ -69,7 +69,7 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 			name:         cfg.Name,
 			version:      cfg.Version,
 			pdata:        data,
-			cgroupv2ID:   cgroupv2ID,
+			containerID:  containerID,
 			traceEvents:  xsync.NewRWMutex(originsMap),
 			hostmetadata: hostmetadata,
 			runLoop: &runLoop{
@@ -91,7 +91,7 @@ func (r *CollectorReporter) Start(ctx context.Context) error {
 	}, func() {
 		// Allow the GC to purge expired entries to avoid memory leaks.
 		r.pdata.Purge()
-		r.cgroupv2ID.PurgeExpired()
+		r.containerID.PurgeExpired()
 	})
 
 	// When Stop() is called and a signal to 'stop' is received, then:

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -58,13 +58,13 @@ type OTLPReporter struct {
 
 // NewOTLP returns a new instance of OTLPReporter
 func NewOTLP(cfg *Config) (*OTLPReporter, error) {
-	cgroupv2ID, err := lru.NewSynced[libpf.PID, string](cfg.CGroupCacheElements,
+	containerID, err := lru.NewSynced[libpf.PID, string](cfg.CGroupCacheElements,
 		func(pid libpf.PID) uint32 { return uint32(pid) })
 	if err != nil {
 		return nil, err
 	}
 	// Set a lifetime to reduce risk of invalid data in case of PID reuse.
-	cgroupv2ID.SetLifetime(90 * time.Second)
+	containerID.SetLifetime(90 * time.Second)
 
 	// Next step: Dynamically configure the size of this LRU.
 	// Currently, we use the length of the JSON array in
@@ -96,7 +96,7 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 			name:         cfg.Name,
 			version:      cfg.Version,
 			pdata:        data,
-			cgroupv2ID:   cgroupv2ID,
+			containerID:  containerID,
 			traceEvents:  xsync.NewRWMutex(originsMap),
 			hostmetadata: hostmetadata,
 			runLoop: &runLoop{
@@ -135,7 +135,7 @@ func (r *OTLPReporter) Start(ctx context.Context) error {
 	}, func() {
 		// Allow the GC to purge expired entries to avoid memory leaks.
 		r.pdata.Purge()
-		r.cgroupv2ID.PurgeExpired()
+		r.containerID.PurgeExpired()
 	})
 
 	// When Stop() is called and a signal to 'stop' is received, then:


### PR DESCRIPTION
While trying to enrich OTel Profiling with k8sattributes via the container.id it was noticed, that the expected and the provided format does not match.

OTel eBPF profiler reported container.id's in the format:
```
/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa_95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope
```

While the `container.id` expected by k8sattributes should be the following for this case:
```
b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc
```

Update the cgroup lookup to extract the expected container.id to enable compatibility with k8s processors in OTel.