### PR TITLE
coredump: add checksum for uploads

### DIFF
--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -200,7 +200,7 @@ func (store *Store) UploadModule(id ID) error {
 	}
 
 	hasher := sha256.New()
-	if _, err := io.Copy(hasher, file); err != nil {
+	if _, err = io.Copy(hasher, file); err != nil {
 		return fmt.Errorf("failed to hash content of %q: %v", localPath, err)
 	}
 	contentSHA256 := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
@@ -209,7 +209,9 @@ func (store *Store) UploadModule(id ID) error {
 	contentType := "application/octet-stream"
 	contentDisposition := "attachment"
 
-	file.Seek(0, io.SeekStart)
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to set position in file %q: %v", localPath, err)
+	}
 
 	_, err = store.s3client.PutObject(context.TODO(), &s3.PutObjectInput{
 		Bucket:             &store.bucket,

--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -202,7 +202,7 @@ func (store *Store) UploadModule(id ID) error {
 
 	fileData, err := io.ReadAll(file)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w")
+		return fmt.Errorf("failed to read file: %w", err)
 	}
 
 	hasher := sha256.New()


### PR DESCRIPTION
It seems the OTel S3 endpoint did get more restrictive and now requires a checksum for uploaded items.

Without this checksum, the following error is returned:

failed to upload file: operation error S3: PutObject, https response error StatusCode: 400, RequestID: sjc-1:<some-random-ID>, HostID: , api error InvalidArgument: x-amz-content-sha256 must be UNSIGNED-PAYLOAD or a valid sha256 value.