### PR TITLE
chore(modulestore): add public coredump modulestore API

### DIFF
--- a/tools/coredump/coredump_test.go
+++ b/tools/coredump/coredump_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/tools/coredump/coredumpstore"
 )
 
 func TestCoreDumps(t *testing.T) {
@@ -15,7 +16,7 @@ func TestCoreDumps(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, cases)
 
-	store, err := initModuleStore()
+	store, err := coredumpstore.New()
 	require.NoError(t, err)
 
 	for _, filename := range cases {

--- a/tools/coredump/coredumpstore/coredumpstore.go
+++ b/tools/coredump/coredumpstore/coredumpstore.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coredumpstore // import "go.opentelemetry.io/ebpf-profiler/tools/coredump/coredumpstore"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.opentelemetry.io/ebpf-profiler/tools/coredump/modulestore"
+)
+
+// moduleStoreRegion defines the S3 bucket OCI region.
+const moduleStoreRegion = "us-sanjose-1"
+
+// moduleStoreObjectNamespace defines the S3 bucket OCI object name space.
+const moduleStoreObjectNamespace = "axtwf1hkrwcy"
+
+// modulePublicReadUrl defines the S3 bucket OCI public read only base path.
+//
+//nolint:lll
+const modulePublicReadURL = "sm-wftyyzHJkBghWeexmK1o5ArimNwZC-5eBej5Lx4e46sLVHtO_y7Zf7FZgoIu_/n/axtwf1hkrwcy"
+
+// moduleStoreS3Bucket defines the S3 bucket used for the module store.
+const moduleStoreS3Bucket = "ebpf-profiling-coredumps"
+
+const localCachePath = "tools/coredump/modulecache"
+
+// New creates a new modulestore.Store pointing to the public s3 used for coredump tests
+func New() (*modulestore.Store, error) {
+	gitRoot, err := findGitRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	localCachePath := filepath.Join(gitRoot, localCachePath)
+	publicReadURL := fmt.Sprintf("https://%s.objectstorage.%s.oci.customer-oci.com/p/%s/b/%s/o/",
+		moduleStoreObjectNamespace, moduleStoreRegion, modulePublicReadURL, moduleStoreS3Bucket)
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		baseEndpoint := fmt.Sprintf("https://%s.compat.objectstorage.%s.oraclecloud.com/",
+			moduleStoreObjectNamespace, moduleStoreRegion)
+		o.Region = moduleStoreRegion
+		o.BaseEndpoint = aws.String(baseEndpoint)
+		o.UsePathStyle = true
+	})
+	return modulestore.New(s3Client, publicReadURL, moduleStoreS3Bucket, localCachePath)
+}
+
+func findGitRoot() (string, error) {
+	it, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for len(it) > 1 {
+		_, err = os.Stat(filepath.Join(it, ".git"))
+		if err == nil {
+			return it, nil
+		}
+		it = filepath.Dir(it)
+	}
+	return "", errors.New("git not found")
+}

--- a/tools/coredump/main.go
+++ b/tools/coredump/main.go
@@ -11,37 +11,18 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"fmt"
 	"os"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	log "github.com/sirupsen/logrus"
-	"go.opentelemetry.io/ebpf-profiler/tools/coredump/modulestore"
+	"go.opentelemetry.io/ebpf-profiler/tools/coredump/coredumpstore"
 )
-
-// moduleStoreRegion defines the S3 bucket OCI region.
-const moduleStoreRegion = "us-sanjose-1"
-
-// moduleStoreObjectNamespace defines the S3 bucket OCI object name space.
-const moduleStoreObjectNamespace = "axtwf1hkrwcy"
-
-// modulePublicReadUrl defines the S3 bucket OCI public read only base path.
-//
-//nolint:lll
-const modulePublicReadURL = "sm-wftyyzHJkBghWeexmK1o5ArimNwZC-5eBej5Lx4e46sLVHtO_y7Zf7FZgoIu_/n/axtwf1hkrwcy"
-
-// moduleStoreS3Bucket defines the S3 bucket used for the module store.
-const moduleStoreS3Bucket = "ebpf-profiling-coredumps"
 
 func main() {
 	log.SetReportCaller(false)
 	log.SetFormatter(&log.TextFormatter{})
 
-	store, err := initModuleStore()
+	store, err := coredumpstore.New()
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -69,23 +50,4 @@ func main() {
 			log.Fatalf("%v", err)
 		}
 	}
-}
-
-func initModuleStore() (*modulestore.Store, error) {
-	publicReadURL := fmt.Sprintf("https://%s.objectstorage.%s.oci.customer-oci.com/p/%s/b/%s/o/",
-		moduleStoreObjectNamespace, moduleStoreRegion, modulePublicReadURL, moduleStoreS3Bucket)
-
-	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
-	if err != nil {
-		return nil, err
-	}
-
-	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		baseEndpoint := fmt.Sprintf("https://%s.compat.objectstorage.%s.oraclecloud.com/",
-			moduleStoreObjectNamespace, moduleStoreRegion)
-		o.Region = moduleStoreRegion
-		o.BaseEndpoint = aws.String(baseEndpoint)
-		o.UsePathStyle = true
-	})
-	return modulestore.New(s3Client, publicReadURL, moduleStoreS3Bucket, "modulecache")
 }


### PR DESCRIPTION
Move public coredump modulestore definitions from `tools/coredump/main` package to a new `coredumpstore` package.

This allows to use the `coredumpstore` in multiple packages, not just coredump main. This may be handy for unit tests.