### PR TITLE
feat(elfunwindinfo): allow capturing an FDE during deltas extraction

### DIFF
--- a/nativeunwind/elfunwindinfo/stackdeltaextraction.go
+++ b/nativeunwind/elfunwindinfo/stackdeltaextraction.go
@@ -57,7 +57,9 @@ var _ ehframeHooks = &extractionFilter{}
 
 // fdeHook filters out .eh_frame data that is superseded by .gopclntab data
 func (f *extractionFilter) fdeHook(_ *cieInfo, fde *fdeInfo) bool {
-	if f.captureFDEAt != 0 && f.captureFDEAt >= fde.ipStart && f.captureFDEAt < fde.ipStart+fde.ipLen {
+	if f.captureFDEAt != 0 &&
+		f.captureFDEAt >= fde.ipStart &&
+		f.captureFDEAt < fde.ipStart+fde.ipLen {
 		f.capturedFDEHook(util.Range{
 			Start: uint64(fde.ipStart),
 			End:   uint64(fde.ipStart + fde.ipLen),

--- a/nativeunwind/elfunwindinfo/stackdeltaextraction_test.go
+++ b/nativeunwind/elfunwindinfo/stackdeltaextraction_test.go
@@ -165,7 +165,7 @@ func TestCaptureFDE(t *testing.T) {
 	buffer, err := base64.StdEncoding.DecodeString(usrBinVolname)
 	require.NoError(t, err)
 	filename := filepath.Join(t.TempDir(), "dwarf_extract_elf_")
-	err = os.WriteFile(filename, buffer, 0644)
+	err = os.WriteFile(filename, buffer, 0600)
 	require.NoError(t, err)
 	elfRef := pfelf.NewReference(filename, pfelf.SystemOpener)
 	defer elfRef.Close()

--- a/nativeunwind/elfunwindinfo/stackdeltaextraction_test.go
+++ b/nativeunwind/elfunwindinfo/stackdeltaextraction_test.go
@@ -165,7 +165,7 @@ func TestCaptureFDE(t *testing.T) {
 	buffer, err := base64.StdEncoding.DecodeString(usrBinVolname)
 	require.NoError(t, err)
 	filename := filepath.Join(t.TempDir(), "dwarf_extract_elf_")
-	err = os.WriteFile(filename, buffer, 0600)
+	err = os.WriteFile(filename, buffer, 0o600)
 	require.NoError(t, err)
 	elfRef := pfelf.NewReference(filename, pfelf.SystemOpener)
 	defer elfRef.Close()


### PR DESCRIPTION
This is a helper for https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/416

The new functionality is useful if someone knows an address in the middle of a function but does not know the range of the function and would like to find out the range of the function. (for example `_PyEval_EvalFrameDefault.cold` function, see the linked issue and comments)
 