### PR TITLE
offcpu: Fix incorrect OffTimes values in offcpu profiling.

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -6,6 +6,7 @@ package pdata // import "go.opentelemetry.io/ebpf-profiler/reporter/internal/pda
 import (
 	"path/filepath"
 	"slices"
+	"sort"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -109,7 +110,12 @@ func (p *Pdata) setProfile(
 		sample := profile.Sample().AppendEmpty()
 		sample.SetLocationsStartIndex(locationIndex)
 
-		slices.Sort(traceInfo.Timestamps)
+		if origin == support.TraceOriginSampling {
+			slices.Sort(traceInfo.Timestamps)
+		} else {
+			sort.Sort(traceInfo)
+		}
+
 		startTS = pcommon.Timestamp(traceInfo.Timestamps[0])
 		endTS = pcommon.Timestamp(traceInfo.Timestamps[len(traceInfo.Timestamps)-1])
 

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -31,6 +31,19 @@ type TraceEvents struct {
 	EnvVars            map[string]string
 }
 
+func (t *TraceEvents) Len() int {
+	return len(t.Timestamps)
+}
+
+func (t *TraceEvents) Less(i, j int) bool {
+	return t.Timestamps[i] < t.Timestamps[j]
+}
+
+func (t *TraceEvents) Swap(i, j int) {
+	t.Timestamps[i], t.Timestamps[j] = t.Timestamps[j], t.Timestamps[i]
+	t.OffTimes[i], t.OffTimes[j] = t.OffTimes[j], t.OffTimes[i]
+}
+
 // TraceAndMetaKey is the deduplication key for samples. This **must always**
 // contain all trace fields that aren't already part of the trace hash to ensure
 // that we don't accidentally merge traces with different fields.


### PR DESCRIPTION
In the original code, while sorting the samples by timestamp, the corresponding offcpu profiling values were not sorted accordingly, leading to incorrect samples mappings and overlapping offcpu time intervals.