### PR TITLE
Drop ContainerID attribute from samples

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -249,8 +249,6 @@ func (p *Pdata) setProfile(
 		}
 
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
-			semconv.ContainerIDKey, traceKey.ContainerID)
-		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ThreadNameKey, traceKey.Comm)
 
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),


### PR DESCRIPTION
Since we store the ContainerID attribute on the Resource level, we no longer need it at the `sample` level.