### PR TITLE
interpreters, reporter: intern symbolization strings

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
+	"unique"
 
 	log "github.com/sirupsen/logrus"
 
@@ -176,7 +177,8 @@ func (i *dotnetInstance) insertAndSymbolizeStubFrame(symbolReporter reporter.Sym
 	trace.AppendFrameID(libpf.DotnetFrame, frameID)
 	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
 		FrameID:      frameID,
-		FunctionName: name,
+		FunctionName: unique.Make(name),
+		SourceFile:   unique.Make(""),
 	})
 }
 
@@ -307,7 +309,7 @@ func (i *dotnetInstance) addRangeSection(ebpf interpreter.EbpfHandler, pid libpf
 		i.moduleToPEInfo[modulePtr] = info
 		log.Debugf("%x-%x flags:%x  module: %x -> %s",
 			lowAddress, highAddress, flags,
-			modulePtr, info.simpleName)
+			modulePtr, info.simpleName.Value())
 		i.addRange(ebpf, pid, lowAddress, highAddress, lowAddress, codeReadyToRun)
 	}
 
@@ -649,7 +651,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 	i.mappings = dotnetMappings
 
 	for _, m := range dotnetMappings {
-		log.Debugf("mapped %x-%x %s", m.start, m.end, m.info.simpleName)
+		log.Debugf("mapped %x-%x %s", m.start, m.end, m.info.simpleName.Value())
 	}
 
 	if err := i.d.walkRangeSectionsMethod(i, ebpf, pr.PID()); err != nil {

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"sync/atomic"
 	"time"
+	"unique"
 
 	"github.com/elastic/go-freelru"
 
@@ -257,7 +258,7 @@ type peInfo struct {
 	err          error
 	lastModified int64
 	fileID       libpf.FileID
-	simpleName   string
+	simpleName   unique.Handle[string]
 	guid         string
 	typeSpecs    []peTypeSpec
 	methodSpecs  []peMethodSpec
@@ -697,7 +698,7 @@ func (pp *peParser) parseModuleTable() {
 		guidIdx := pp.readDotnetIndex(indexGUID)
 		pp.skipDotnetBytes(2 * pp.indexSizes[indexGUID])
 
-		pp.info.simpleName = pp.readDotnetString(nameIdx)
+		pp.info.simpleName = unique.Make(pp.readDotnetString(nameIdx))
 		pp.info.guid = pp.readDotnetGUID(guidIdx)
 	}
 }
@@ -1132,9 +1133,10 @@ func (pp *peParser) parse() error {
 	return pp.parseCLI()
 }
 
-func (pi *peInfo) resolveMethodName(methodIdx uint32) string {
+func (pi *peInfo) resolveMethodName(methodIdx uint32) unique.Handle[string] {
 	if methodIdx == 0 || methodIdx > uint32(len(pi.methodSpecs)) {
-		return fmt.Sprintf("<invalid method index %d/%d>", methodIdx, len(pi.methodSpecs))
+		return unique.Make(fmt.Sprintf("<invalid method index %d/%d>",
+			methodIdx, len(pi.methodSpecs)))
 	}
 
 	idx, ok := slices.BinarySearchFunc(pi.typeSpecs, methodIdx,
@@ -1160,14 +1162,14 @@ func (pi *peInfo) resolveMethodName(methodIdx uint32) string {
 	}
 	methodName := pi.strings[pi.methodSpecs[methodIdx-1].methodNameIdx]
 	if typeSpec.namespaceIdx != 0 {
-		return fmt.Sprintf("%s.%s.%s",
+		return unique.Make(fmt.Sprintf("%s.%s.%s",
 			pi.strings[typeSpec.namespaceIdx],
-			typeName, methodName)
+			typeName, methodName))
 	}
-	return fmt.Sprintf("%s.%s", typeName, methodName)
+	return unique.Make(fmt.Sprintf("%s.%s", typeName, methodName))
 }
 
-func (pi *peInfo) resolveR2RMethodName(pcRVA uint32) string {
+func (pi *peInfo) resolveR2RMethodName(pcRVA uint32) unique.Handle[string] {
 	idx, ok := slices.BinarySearchFunc(pi.methodSpecs, pcRVA<<1,
 		func(methodspec peMethodSpec, pcRVA uint32) int {
 			if pcRVA < methodspec.startRVA {
@@ -1181,8 +1183,7 @@ func (pi *peInfo) resolveR2RMethodName(pcRVA uint32) string {
 	if !ok {
 		idx--
 	}
-	str := pi.resolveMethodName(uint32(idx + 1))
-	return str
+	return pi.resolveMethodName(uint32(idx + 1))
 }
 
 func (pi *peInfo) parse(r io.ReaderAt) error {

--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -95,10 +95,6 @@ func (g *goInstance) Detach(_ interpreter.EbpfHandler, _ libpf.PID) error {
 	return nil
 }
 
-func intern(str string) string {
-	return unique.Make(str).Value()
-}
-
 func (g *goInstance) Symbolize(symbolReporter reporter.SymbolReporter, frame *host.Frame,
 	trace *libpf.Trace) error {
 	if !frame.Type.IsInterpType(libpf.Native) {
@@ -128,8 +124,8 @@ func (g *goInstance) Symbolize(symbolReporter reporter.SymbolReporter, frame *ho
 
 	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
 		FrameID:      frameID,
-		FunctionName: intern(fn),
-		SourceFile:   intern(sourceFile),
+		FunctionName: unique.Make(fn),
+		SourceFile:   unique.Make(sourceFile),
 		SourceLine:   libpf.SourceLineno(lineNo),
 	})
 

--- a/interpreter/go/go_test.go
+++ b/interpreter/go/go_test.go
@@ -36,8 +36,8 @@ func (m *mockReporter) CompareFunctionName(fn string) {
 	for _, v := range m.frameMetadata {
 		// The returned anonymous function has the suffic 'func1'.
 		// Therefore check only for a matching prefix.
-		if !strings.HasPrefix(v.FunctionName, fn) {
-			m.b.Fatalf("Expected '%s()' but got '%s()'", fn, v.FunctionName)
+		if !strings.HasPrefix(v.FunctionName.Value(), fn) {
+			m.b.Fatalf("Expected '%s()' but got '%s()'", fn, v.FunctionName.Value())
 		}
 	}
 }

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"unique"
 
 	log "github.com/sirupsen/logrus"
 
@@ -342,7 +343,7 @@ func (d *hotspotData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.
 	// method name and signature. However, most of them are shared across
 	// different methods, so assume about 2 unique symbols per function.
 	addrToSymbol, err :=
-		freelru.New[libpf.Address, string](2*interpreter.LruFunctionCacheSize,
+		freelru.New[libpf.Address, unique.Handle[string]](2*interpreter.LruFunctionCacheSize,
 			libpf.Address.Hash32)
 	if err != nil {
 		return nil, err

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"runtime"
 	"sync/atomic"
+	"unique"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
@@ -74,7 +75,7 @@ type hotspotInstance struct {
 	prefixes libpf.Set[lpm.Prefix]
 
 	// addrToSymbol maps a JVM class Symbol address to it's string value
-	addrToSymbol *freelru.LRU[libpf.Address, string]
+	addrToSymbol *freelru.LRU[libpf.Address, unique.Handle[string]]
 
 	// addrToMethod maps a JVM class Method to a hotspotMethod which caches
 	// the needed data from it.
@@ -180,7 +181,7 @@ func (d *hotspotInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
 }
 
 // getSymbol extracts a class Symbol value from the given address in the target JVM process
-func (d *hotspotInstance) getSymbol(addr libpf.Address) string {
+func (d *hotspotInstance) getSymbol(addr libpf.Address) unique.Handle[string] {
 	if value, ok := d.addrToSymbol.Get(addr); ok {
 		return value
 	}
@@ -191,11 +192,11 @@ func (d *hotspotInstance) getSymbol(addr libpf.Address) string {
 	// good enough"; this value can be increased if it turns out to be necessary.
 	var buf [128]byte
 	if d.rm.Read(addr, buf[:]) != nil {
-		return ""
+		return unique.Make("")
 	}
 	symLen := npsr.Uint16(buf[:], vms.Symbol.Length)
 	if symLen == 0 {
-		return ""
+		return unique.Make("")
 	}
 
 	// Always allocate the string separately so it does not hold the backing
@@ -205,24 +206,25 @@ func (d *hotspotInstance) getSymbol(addr libpf.Address) string {
 	if vms.Symbol.Body+uint(symLen) > uint(len(buf)) {
 		prefixLen := uint(len(buf[vms.Symbol.Body:]))
 		if d.rm.Read(addr+libpf.Address(vms.Symbol.Body+prefixLen), tmp[prefixLen:]) != nil {
-			return ""
+			return unique.Make("")
 		}
 	}
 	s := string(tmp)
 	if !util.IsValidString(s) {
 		log.Debugf("Extracted Hotspot symbol is invalid at 0x%x '%v'", addr, []byte(s))
-		return ""
+		return unique.Make("")
 	}
-	d.addrToSymbol.Add(addr, s)
-	return s
+	value := unique.Make(s)
+	d.addrToSymbol.Add(addr, value)
+	return value
 }
 
 // getPoolSymbol reads a class ConstantPool value from given index, and reads the
 // symbol value it is referencing
-func (d *hotspotInstance) getPoolSymbol(addr libpf.Address, ndx uint16) string {
+func (d *hotspotInstance) getPoolSymbol(addr libpf.Address, ndx uint16) unique.Handle[string] {
 	// Zero index is not valid
 	if ndx == 0 {
-		return ""
+		return unique.Make("")
 	}
 
 	vms := &d.d.Get().vmStructs
@@ -258,7 +260,8 @@ func (d *hotspotInstance) getStubNameID(symbolReporter reporter.SymbolReporter, 
 	stubID := libpf.AddressOrLineno(npsr.Uint64(nameHash, 0))
 	symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
 		FrameID:      libpf.NewFrameID(hotspotStubsFileID, stubID),
-		FunctionName: stubName,
+		FunctionName: unique.Make(stubName),
+		SourceFile:   unique.Make(""),
 	})
 	d.addrToStubNameID.Add(addr, stubID)
 
@@ -289,7 +292,7 @@ func (d *hotspotInstance) getMethod(addr libpf.Address, _ uint32) (*hotspotMetho
 		return nil, fmt.Errorf("invalid PoolHolder ptr: %v", err)
 	}
 
-	var sourceFileName string
+	var sourceFileName unique.Handle[string]
 	switch {
 	case vms.ConstantPool.SourceFileNameIndex != 0:
 		// JDK15
@@ -304,17 +307,17 @@ func (d *hotspotInstance) getMethod(addr libpf.Address, _ uint32) (*hotspotMetho
 		sourceFileName = d.getSymbol(
 			npsr.Ptr(instanceKlass, vms.InstanceKlass.SourceFileName))
 	}
-	klassName := d.getSymbol(npsr.Ptr(instanceKlass, vms.Klass.Name))
+	klassName := d.getSymbol(npsr.Ptr(instanceKlass, vms.Klass.Name)).Value()
 	methodName := d.getPoolSymbol(cpoolAddr, npsr.Uint16(constMethod,
 		vms.ConstMethod.NameIndex))
 	signature := d.getPoolSymbol(cpoolAddr, npsr.Uint16(constMethod,
 		vms.ConstMethod.SignatureIndex))
 
-	if sourceFileName == "" {
+	if sourceFileName.Value() == "" {
 		// Java and Scala can autogenerate lambdas which have no source
 		// information available. The HotSpot VM backtraces displays
 		// "Unknown Source" as the filename for these.
-		sourceFileName = interpreter.UnknownSourceFile
+		sourceFileName = unique.Make(interpreter.UnknownSourceFile)
 
 		// Java 15 introduced "Hidden Classes" via JEP 371. These class names
 		// contain pointers. Mask the pointers to reduce cardinality.
@@ -326,10 +329,10 @@ func (d *hotspotInstance) getMethod(addr libpf.Address, _ uint32) (*hotspotMetho
 	// Keep the sourcefileName there to start with, and add klass name, method
 	// name, byte code and the JVM presentation of the source line table.
 	h := fnv.New128a()
-	_, _ = h.Write([]byte(sourceFileName))
+	_, _ = h.Write([]byte(sourceFileName.Value()))
 	_, _ = h.Write([]byte(klassName))
-	_, _ = h.Write([]byte(methodName))
-	_, _ = h.Write([]byte(signature))
+	_, _ = h.Write([]byte(methodName.Value()))
+	_, _ = h.Write([]byte(signature.Value()))
 
 	// Read the byte code for CodeObjectID
 	bytecodeSize := npsr.Uint16(constMethod, vms.ConstMethod.CodeSize)
@@ -394,10 +397,11 @@ func (d *hotspotInstance) getMethod(addr libpf.Address, _ uint32) (*hotspotMetho
 		return nil, fmt.Errorf("failed to create a code object ID: %v", err)
 	}
 
+	demangledName := demangleJavaMethod(klassName, methodName.Value(), signature.Value())
 	sym := &hotspotMethod{
 		sourceFileName: sourceFileName,
 		objectID:       objectID,
-		methodName:     demangleJavaMethod(klassName, methodName, signature),
+		methodName:     unique.Make(demangledName),
 		bytecodeSize:   bytecodeSize,
 		lineTable:      lineTable,
 		startLineNo:    uint16(startLine),

--- a/interpreter/hotspot/instance_test.go
+++ b/interpreter/hotspot/instance_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"strings"
 	"testing"
+	"unique"
 
 	"github.com/elastic/go-freelru"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestJavaSymbolExtraction(t *testing.T) {
 	rd := bytes.NewReader(sym)
 	rm := remotememory.RemoteMemory{ReaderAt: rd}
 
-	addrToSymbol, err := freelru.New[libpf.Address, string](2, libpf.Address.Hash32)
+	addrToSymbol, err := freelru.New[libpf.Address, unique.Handle[string]](2, libpf.Address.Hash32)
 	require.NoError(t, err, "symbol cache failed")
 
 	ii := hotspotInstance{
@@ -47,7 +48,7 @@ func TestJavaSymbolExtraction(t *testing.T) {
 	for i := 0; i <= maxLength; i++ {
 		binary.LittleEndian.PutUint16(sym[vmd.vmStructs.Symbol.Length:], uint16(i))
 		got := ii.getSymbol(0)
-		assert.Equal(t, str[:i], got, "symbol length %d mismatched read", i)
+		assert.Equal(t, str[:i], got.Value(), "symbol length %d mismatched read", i)
 		ii.addrToSymbol.Purge()
 	}
 }

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -6,6 +6,7 @@ package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot
 import (
 	"bytes"
 	"fmt"
+	"unique"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	npsr "go.opentelemetry.io/ebpf-profiler/nopanicslicereader"
@@ -19,9 +20,9 @@ const ConstMethod_has_linenumber_table = 0x0001
 // information from Hotspot class Method, the connected class ConstMethod, and
 // chasing the pointers in the ConstantPool and other dynamic parts.
 type hotspotMethod struct {
-	sourceFileName string
+	sourceFileName unique.Handle[string]
 	objectID       libpf.FileID
-	methodName     string
+	methodName     unique.Handle[string]
 	bytecodeSize   uint16
 	startLineNo    uint16
 	lineTable      []byte

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -163,6 +163,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"unique"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
@@ -231,7 +232,7 @@ var (
 	v8StubsFileID = libpf.NewStubFileID(libpf.V8Frame)
 
 	// the source file entry for unknown code blobs
-	unknownSource = &v8Source{fileName: interpreter.UnknownSourceFile}
+	unknownSource = &v8Source{fileName: unique.Make(interpreter.UnknownSourceFile)}
 
 	// compiler check to make sure the needed interfaces are satisfied
 	_ interpreter.Data     = &v8Data{}
@@ -508,7 +509,7 @@ type v8Instance struct {
 	rm remotememory.RemoteMemory
 
 	// addrToString maps a V8 string object address to a Go string literal
-	addrToString *freelru.LRU[libpf.Address, string]
+	addrToString *freelru.LRU[libpf.Address, unique.Handle[string]]
 	addrToSFI    *freelru.LRU[libpf.Address, *v8SFI]
 	addrToCode   *freelru.LRU[libpf.Address, *v8Code]
 	addrToSource *freelru.LRU[libpf.Address, *v8Source]
@@ -525,7 +526,7 @@ type v8Instance struct {
 // v8Source caches the data we need from V8 class Source
 type v8Source struct {
 	lineTable []uint32
-	fileName  string
+	fileName  unique.Handle[string]
 }
 
 // v8Code caches the data we need from V8 class Code
@@ -545,7 +546,7 @@ type v8SFI struct {
 	bytecodeDeltaSeen     libpf.Set[uint32]
 	bytecodePositionTable []byte
 	bytecode              []byte
-	funcName              string
+	funcName              unique.Handle[string]
 	funcID                libpf.FileID
 	funcStartLine         libpf.SourceLineno
 	funcStartPos          int
@@ -766,7 +767,8 @@ func (i *v8Instance) symbolizeMarkerFrame(symbolReporter reporter.SymbolReporter
 		i.d.frametypeToID[marker] = stubID
 		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
 			FrameID:      frameID,
-			FunctionName: name,
+			FunctionName: unique.Make(name),
+			SourceFile:   unique.Make(""),
 		})
 	}
 	trace.AppendFrameID(libpf.V8Frame, frameID)
@@ -903,7 +905,7 @@ func (i *v8Instance) extractStringPtr(ptr libpf.Address, cb func(string) error) 
 }
 
 // getString extracts and caches a small string object from given address.
-func (i *v8Instance) getString(ptr libpf.Address, tag uint16) (string, error) {
+func (i *v8Instance) getString(ptr libpf.Address, tag uint16) (unique.Handle[string], error) {
 	taggedPtr := ptr | HeapObjectTag
 	if value, ok := i.addrToString.Get(taggedPtr); ok {
 		return value, nil
@@ -920,24 +922,25 @@ func (i *v8Instance) getString(ptr libpf.Address, tag uint16) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return unique.Make(""), err
 	}
 	if str != "" && !util.IsValidString(str) {
-		return "", fmt.Errorf("invalid string at 0x%x", ptr)
+		return unique.Make(""), fmt.Errorf("invalid string at 0x%x", ptr)
 	}
 
-	i.addrToString.Add(taggedPtr, str)
-	return str, nil
+	value := unique.Make(str)
+	i.addrToString.Add(taggedPtr, value)
+	return value, nil
 }
 
 // getStringPtr reads a V8 string pointer and dereferences it.
-func (i *v8Instance) getStringPtr(ptr libpf.Address) (string, error) {
+func (i *v8Instance) getStringPtr(ptr libpf.Address) (unique.Handle[string], error) {
 	return i.getString(i.rm.Ptr(ptr), 0)
 }
 
 // analyzeScopeInfo reads and heuristically analyzes V8 ScopeInfo data. It tries to
 // extract the function name, and its start and end line.
-func (i *v8Instance) analyzeScopeInfo(ptr libpf.Address) (name string,
+func (i *v8Instance) analyzeScopeInfo(ptr libpf.Address) (name unique.Handle[string],
 	startPos, endPos int, err error) {
 	vms := &i.d.vmStructs
 	var data libpf.Address
@@ -959,7 +962,7 @@ func (i *v8Instance) analyzeScopeInfo(ptr libpf.Address) (name string,
 	const slotSize = pointerSize
 	slotData := make([]byte, numSlots*slotSize)
 	if err = i.rm.Read(data, slotData); err != nil {
-		return "", 0, 0, nil
+		return unique.Make(""), 0, 0, nil
 	}
 
 	// Skip reserved slots and the context locals
@@ -967,10 +970,11 @@ func (i *v8Instance) analyzeScopeInfo(ptr libpf.Address) (name string,
 	ndx += 2 * int(decodeSMI(npsr.Uint64(slotData,
 		uint(vms.ScopeInfoIndex.NContextLocals)*slotSize)))
 
+	name = unique.Make("")
 	prev := uint64(HeapObjectTag)
 	for ; ndx < numSlots; ndx++ {
 		cur := npsr.Uint64(slotData, uint(ndx*slotSize))
-		if name == "" && isHeapObject(libpf.Address(cur)) {
+		if name.Value() == "" && isHeapObject(libpf.Address(cur)) {
 			// Just try getting the string ignoring errors and
 			// assume that first valid string is the function name
 			name, _ = i.getString(libpf.Address(cur), 0)
@@ -1106,10 +1110,10 @@ func (i *v8Instance) getSFI(taggedPtr libpf.Address) (*v8SFI, error) {
 		sfi.funcName, err = i.getString(nosAddr, nosType)
 	}
 	if err != nil {
-		sfi.funcName = fmt.Sprintf("<%s>", err)
+		sfi.funcName = unique.Make(fmt.Sprintf("<%s>", err))
 	}
-	if sfi.funcName == "" {
-		sfi.funcName = "<anonymous>"
+	if sfi.funcName.Value() == "" {
+		sfi.funcName = unique.Make("<anonymous>")
 	}
 
 	// Function data
@@ -1159,8 +1163,8 @@ func (i *v8Instance) getSFI(taggedPtr libpf.Address) (*v8SFI, error) {
 
 	// Synthesize function ID hash
 	h := fnv.New128a()
-	_, _ = h.Write([]byte(sfi.source.fileName))
-	_, _ = h.Write([]byte(sfi.funcName))
+	_, _ = h.Write([]byte(sfi.source.fileName.Value()))
+	_, _ = h.Write([]byte(sfi.funcName.Value()))
 	_, _ = h.Write(sfi.bytecode)
 	_, _ = h.Write(sfi.bytecodePositionTable)
 	sfi.funcID, err = libpf.FileIDFromBytes(h.Sum(nil))
@@ -1528,9 +1532,9 @@ func (i *v8Instance) symbolize(symbolReporter reporter.SymbolReporter, frameID l
 	})
 }
 
-const externalFunctionTag = "<external-file>"
+var externalFunctionTag = unique.Make("<external-file>")
 
-var externalStubID = calculateStubID(externalFunctionTag)
+var externalStubID = calculateStubID(externalFunctionTag.Value())
 
 // generateNativeFrame and conditionally symbolizes a native frame.
 func (i *v8Instance) generateNativeFrame(symbolReporter reporter.SymbolReporter,
@@ -1541,6 +1545,7 @@ func (i *v8Instance) generateNativeFrame(symbolReporter reporter.SymbolReporter,
 		symbolReporter.FrameMetadata(&reporter.FrameMetadataArgs{
 			FrameID:      frameID,
 			FunctionName: externalFunctionTag,
+			SourceFile:   unique.Make(""),
 		})
 		return
 	}
@@ -1842,8 +1847,8 @@ func (d *v8Data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, _ libpf.Add
 		return nil, err
 	}
 
-	addrToString, err := freelru.New[libpf.Address, string](interpreter.LruFunctionCacheSize,
-		libpf.Address.Hash32)
+	addrToString, err := freelru.New[libpf.Address, unique.Handle[string]](
+		interpreter.LruFunctionCacheSize, libpf.Address.Hash32)
 	if err != nil {
 		return nil, err
 	}

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -6,6 +6,7 @@ package perl // import "go.opentelemetry.io/ebpf-profiler/interpreter/perl"
 import (
 	"fmt"
 	"sync"
+	"unique"
 
 	"github.com/elastic/go-freelru"
 	log "github.com/sirupsen/logrus"
@@ -137,8 +138,8 @@ func (d *perlData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Add
 		return nil, err
 	}
 
-	addrToGV, err := freelru.New[libpf.Address, string](interpreter.LruFunctionCacheSize,
-		libpf.Address.Hash32)
+	addrToGV, err := freelru.New[libpf.Address, unique.Handle[string]](
+		interpreter.LruFunctionCacheSize, libpf.Address.Hash32)
 	if err != nil {
 		return nil, err
 	}

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"sync"
 	"sync/atomic"
+	"unique"
 	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
@@ -48,7 +49,7 @@ type perlInstance struct {
 	addrToCOP *freelru.LRU[copKey, *perlCOP]
 
 	// addrToGV maps a PERL Glob Value (GV) aka "symbol" to its name string
-	addrToGV *freelru.LRU[libpf.Address, string]
+	addrToGV *freelru.LRU[libpf.Address, unique.Handle[string]]
 
 	// memPool provides pointers to byte arrays for efficient memory reuse.
 	memPool sync.Pool
@@ -64,21 +65,21 @@ type perlInstance struct {
 // perlCOP contains information about Perl Control OPS structure
 type perlCOP struct {
 	fileID         libpf.FileID
-	sourceFileName string
+	sourceFileName unique.Handle[string]
 	line           libpf.AddressOrLineno
 }
 
 // copKey is used as cache key for Perl Control OPS structures.
 type copKey struct {
 	copAddr  libpf.Address
-	funcName string
+	funcName unique.Handle[string]
 }
 
 // hashCopKey returns a 32 bits hash of the input.
 // It's main purpose is to hash keys for caching perlCOP values.
 func hashCOPKey(k copKey) uint32 {
 	h := k.copAddr.Hash()
-	return uint32(h ^ xxhash.Sum64String(k.funcName))
+	return uint32(h ^ xxhash.Sum64String(k.funcName.Value()))
 }
 
 func (i *perlInstance) UpdateTSDInfo(ebpf interpreter.EbpfHandler, pid libpf.PID,
@@ -324,9 +325,9 @@ func (i *perlInstance) getHVName(hvAddr libpf.Address) (string, error) {
 	return i.getHEK(hekAddr)
 }
 
-func (i *perlInstance) getGV(gvAddr libpf.Address, nameOnly bool) (string, error) {
+func (i *perlInstance) getGV(gvAddr libpf.Address, nameOnly bool) (unique.Handle[string], error) {
 	if gvAddr == 0 {
-		return "", nil
+		return unique.Make(""), nil
 	}
 	if value, ok := i.addrToGV.Get(gvAddr); ok {
 		return value, nil
@@ -339,14 +340,14 @@ func (i *perlInstance) getGV(gvAddr libpf.Address, nameOnly bool) (string, error
 	hekAddr := i.rm.Ptr(xpvgvAddr + libpf.Address(vms.xpvgv.xivu_namehek))
 	gvName, err := i.getHEK(hekAddr)
 	if err != nil {
-		return "", err
+		return unique.Make(""), err
 	}
 
 	if !nameOnly && gvName != "" {
 		stashAddr := i.rm.Ptr(xpvgvAddr + libpf.Address(vms.xpvgv.xgv_stash))
 		packageName, err := i.getHVName(stashAddr)
 		if err != nil {
-			return "", err
+			return unique.Make(""), err
 		}
 
 		// Build the qualified name
@@ -357,14 +358,15 @@ func (i *perlInstance) getGV(gvAddr libpf.Address, nameOnly bool) (string, error
 		gvName = packageName + "::" + gvName
 	}
 
-	i.addrToGV.Add(gvAddr, gvName)
-
-	return gvName, nil
+	value := unique.Make(gvName)
+	i.addrToGV.Add(gvAddr, value)
+	return value, nil
 }
 
 // getCOP reads and caches a Control OP from remote interpreter.
 // On success, the COP is returned. On error, the error.
-func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP, error) {
+func (i *perlInstance) getCOP(copAddr libpf.Address, funcName unique.Handle[string]) (
+	*perlCOP, error) {
 	key := copKey{
 		copAddr:  copAddr,
 		funcName: funcName,
@@ -387,15 +389,14 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP,
 	} else {
 		// cop_file is a pointer to GV
 		sourceFileGVAddr := npsr.Ptr(cop, vms.cop.cop_file)
-		var err error
-		sourceFileName, err = i.getGV(sourceFileGVAddr, true)
-		if err == nil && len(sourceFileName) <= 2 {
-			err = fmt.Errorf("sourcefile gv length too small (%d)", len(sourceFileName))
+		gvName, err := i.getGV(sourceFileGVAddr, true)
+		if err == nil && len(gvName.Value()) <= 2 {
+			err = fmt.Errorf("sourcefile gv length too small (%d)", len(gvName.Value()))
 		}
 		if err != nil {
 			return nil, err
 		}
-		sourceFileName = sourceFileName[2:]
+		sourceFileName = gvName.Value()[2:]
 	}
 	if !util.IsValidString(sourceFileName) {
 		log.Debugf("Extracted invalid source file name '%v'", []byte(sourceFileName))
@@ -411,14 +412,14 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName string) (*perlCOP,
 	_, _ = h.Write([]byte(sourceFileName))
 	// Unfortunately there is very little information to extract for each function
 	// from the GV. Use just the function name at this time.
-	_, _ = h.Write([]byte(funcName))
+	_, _ = h.Write([]byte(funcName.Value()))
 	fileID, err := libpf.FileIDFromBytes(h.Sum(nil))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a file ID: %v", err)
 	}
 
 	c := &perlCOP{
-		sourceFileName: sourceFileName,
+		sourceFileName: unique.Make(sourceFileName),
 		fileID:         fileID,
 		line:           libpf.AddressOrLineno(line),
 	}
@@ -444,8 +445,8 @@ func (i *perlInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	// This can only happen if gvAddr is 0,
 	// which we use to denote code at the top level (e.g
 	// code in the file not inside a function).
-	if functionName == "" {
-		functionName = interpreter.TopLevelFunctionName
+	if functionName.Value() == "" {
+		functionName = unique.Make(interpreter.TopLevelFunctionName)
 	}
 	copAddr := libpf.Address(frame.Lineno)
 	cop, err := i.getCOP(copAddr, functionName)

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sync/atomic"
+	"unique"
 
 	log "github.com/sirupsen/logrus"
 
@@ -39,10 +40,10 @@ const (
 // PHP interpreter's zend_function structure.
 type phpFunction struct {
 	// name is the extracted name
-	name string
+	name unique.Handle[string]
 
 	// sourceFileName is the extracted filename field
-	sourceFileName string
+	sourceFileName unique.Handle[string]
 
 	// fileID is the synthesized methodID
 	fileID libpf.FileID
@@ -177,8 +178,8 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 	}
 
 	pf := &phpFunction{
-		name:           fname,
-		sourceFileName: sourceFileName,
+		name:           unique.Make(fname),
+		sourceFileName: unique.Make(sourceFileName),
 		fileID:         fileID,
 		lineStart:      lineStart,
 	}

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"unique"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
@@ -160,10 +161,10 @@ type pythonCodeObject struct {
 	version uint16
 
 	// name is the extracted co_name (the unqualified method or function name)
-	name string
+	name unique.Handle[string]
 
 	// sourceFileName is the extracted co_filename field
-	sourceFileName string
+	sourceFileName unique.Handle[string]
 
 	// For Python version < 3.10 lineTable is the extracted co_lnotab, and contains the
 	// "bytecode index" to "line number" mapping data.
@@ -567,8 +568,8 @@ func (p *pythonInstance) getCodeObject(addr libpf.Address,
 
 	pco := &pythonCodeObject{
 		version:        p.d.version,
-		name:           name,
-		sourceFileName: sourceFileName,
+		name:           unique.Make(name),
+		sourceFileName: unique.Make(sourceFileName),
 		firstLineNo:    firstLineNo,
 		lineTable:      lineTable,
 		ebpfChecksum:   ebpfChecksum,

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unique"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
@@ -212,7 +213,7 @@ func (r *rubyData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libp
 		return nil, err
 	}
 
-	addrToString, err := freelru.New[libpf.Address, string](addrToStringSize,
+	addrToString, err := freelru.New[libpf.Address, unique.Handle[string]](addrToStringSize,
 		libpf.Address.Hash32)
 	if err != nil {
 		return nil, err
@@ -251,7 +252,7 @@ func hashRubyIseqBodyPC(iseq rubyIseqBodyPC) uint32 {
 // rubyIseq stores information extracted from a iseq_constant_body struct.
 type rubyIseq struct {
 	// sourceFileName is the extracted filename field
-	sourceFileName string
+	sourceFileName unique.Handle[string]
 
 	// fileID is the synthesized methodID
 	fileID libpf.FileID
@@ -275,7 +276,7 @@ type rubyInstance struct {
 	iseqBodyPCToFunction *freelru.LRU[rubyIseqBodyPC, *rubyIseq]
 
 	// addrToString maps an address to an extracted Ruby String from this address.
-	addrToString *freelru.LRU[libpf.Address, string]
+	addrToString *freelru.LRU[libpf.Address, unique.Handle[string]]
 
 	// memPool provides pointers to byte arrays for efficient memory reuse.
 	memPool sync.Pool
@@ -362,25 +363,31 @@ func (r *rubyInstance) readRubyString(addr libpf.Address) (string, error) {
 		str = r.rm.String(addr + libpf.Address(vms.rstring_struct.as_ary))
 	}
 
-	r.addrToString.Add(addr, str)
+	r.addrToString.Add(addr, unique.Make(str))
 	return str, nil
 }
 
 type StringReader = func(address libpf.Address) (string, error)
 
 // getStringCached retrieves a string from cache or reads and inserts it if it's missing.
-func (r *rubyInstance) getStringCached(addr libpf.Address, reader StringReader) (string, error) {
+func (r *rubyInstance) getStringCached(addr libpf.Address, reader StringReader) (
+	unique.Handle[string], error) {
 	if value, ok := r.addrToString.Get(addr); ok {
 		return value, nil
 	}
 
 	str, err := reader(addr)
 	if err != nil {
-		return "", err
+		return unique.Make(""), err
+	}
+	if !util.IsValidString(str) {
+		log.Debugf("Extracted invalid string from Ruby at 0x%x '%v'", addr, libpf.SliceFrom(str))
+		return unique.Make(""), fmt.Errorf("extracted invalid Ruby string from address 0x%x", addr)
 	}
 
-	r.addrToString.Add(addr, str)
-	return str, err
+	val := unique.Make(str)
+	r.addrToString.Add(addr, val)
+	return val, err
 }
 
 // rubyPopcount64 is a helper macro.
@@ -675,12 +682,6 @@ func (r *rubyInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	if err != nil {
 		return err
 	}
-	if !util.IsValidString(sourceFileName) {
-		log.Debugf("Extracted invalid Ruby source file name at 0x%x '%v'",
-			iseqBody, []byte(sourceFileName))
-		return fmt.Errorf("extracted invalid Ruby source file name from address 0x%x",
-			iseqBody)
-	}
 
 	funcNamePtr := r.rm.Ptr(iseqBody +
 		libpf.Address(vms.iseq_constant_body.location+vms.iseq_location_struct.base_label))
@@ -688,20 +689,14 @@ func (r *rubyInstance) Symbolize(symbolReporter reporter.SymbolReporter,
 	if err != nil {
 		return err
 	}
-	if !util.IsValidString(functionName) {
-		log.Debugf("Extracted invalid Ruby method name at 0x%x '%v'",
-			iseqBody, []byte(functionName))
-		return fmt.Errorf("extracted invalid Ruby method name from address 0x%x",
-			iseqBody)
-	}
 
 	pcBytes := uint64ToBytes(uint64(pc))
 	iseqBodyBytes := uint64ToBytes(uint64(iseqBody))
 
 	// The fnv hash Write() method calls cannot fail, so it's safe to ignore the errors.
 	h := fnv.New128a()
-	_, _ = h.Write([]byte(sourceFileName))
-	_, _ = h.Write([]byte(functionName))
+	_, _ = h.Write([]byte(sourceFileName.Value()))
+	_, _ = h.Write([]byte(functionName.Value()))
 	_, _ = h.Write(pcBytes)
 	_, _ = h.Write(iseqBodyBytes)
 	fileID, err := libpf.FileIDFromBytes(h.Sum(nil))

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -149,15 +149,15 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 
 func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
 	log.Debugf("FrameMetadata [%x] %v+%v at %v:%v",
-		args.FrameID.FileID(), args.FunctionName, args.FunctionOffset,
-		args.SourceFile, args.SourceLine)
+		args.FrameID.FileID(), args.FunctionName.Value(), args.FunctionOffset,
+		args.SourceFile.Value(), args.SourceLine)
 	si := samples.SourceInfo{
 		LineNumber:     args.SourceLine,
 		FilePath:       args.SourceFile,
 		FunctionOffset: args.FunctionOffset,
 		FunctionName:   args.FunctionName,
 	}
-	if si.FilePath == "" {
+	if si.FilePath.Value() == "" {
 		if oldsi, exists := b.pdata.Frames.Get(args.FrameID); exists {
 			si.FilePath = oldsi.FilePath
 		}

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -6,6 +6,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"context"
 	"time"
+	"unique"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/process"
@@ -65,9 +66,9 @@ type FrameMetadataArgs struct {
 	// FrameID is a unique identifier for the frame.
 	FrameID libpf.FrameID
 	// FunctionName is the name of the function for the frame.
-	FunctionName string
+	FunctionName unique.Handle[string]
 	// SourceFile is the source code file name for the frame.
-	SourceFile string
+	SourceFile unique.Handle[string]
 	// SourceLine is the source code level line number of this frame.
 	SourceLine libpf.SourceLineno
 	// FunctionOffset is the line offset from function start line for the frame.

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -197,8 +197,8 @@ func (p *Pdata) setProfile(
 					FramesCacheLifetime); exists {
 					locInfo.lineNumber = int64(si.LineNumber)
 					fi := funcInfo{
-						nameIdx:     stringSet.Add(si.FunctionName),
-						fileNameIdx: stringSet.Add(si.FilePath),
+						nameIdx:     stringSet.Add(si.FunctionName.Value()),
+						fileNameIdx: stringSet.Add(si.FilePath.Value()),
 					}
 					locInfo.functionIndex = funcSet.Add(fi)
 				} else {

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -2,6 +2,7 @@ package pdata
 
 import (
 	"testing"
+	"unique"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,7 @@ func TestGetDummyMappingIndex(t *testing.T) {
 
 //nolint:lll
 func TestFunctionTableOrder(t *testing.T) {
+	none := unique.Make("")
 	for _, tt := range []struct {
 		name        string
 		executables map[libpf.FileID]samples.ExecInfo
@@ -119,11 +121,11 @@ func TestFunctionTableOrder(t *testing.T) {
 			},
 			frames: map[libpf.FileID]map[libpf.AddressOrLineno]samples.SourceInfo{
 				libpf.NewFileID(2, 3): {
-					libpf.AddressOrLineno(0xef):  {FunctionName: "func1"},
-					libpf.AddressOrLineno(0x1ef): {FunctionName: "func2"},
-					libpf.AddressOrLineno(0x2ef): {FunctionName: "func3"},
-					libpf.AddressOrLineno(0x3ef): {FunctionName: "func4"},
-					libpf.AddressOrLineno(0x4ef): {FunctionName: "func5"},
+					libpf.AddressOrLineno(0xef):  {FunctionName: unique.Make("func1"), FilePath: none},
+					libpf.AddressOrLineno(0x1ef): {FunctionName: unique.Make("func2"), FilePath: none},
+					libpf.AddressOrLineno(0x2ef): {FunctionName: unique.Make("func3"), FilePath: none},
+					libpf.AddressOrLineno(0x3ef): {FunctionName: unique.Make("func4"), FilePath: none},
+					libpf.AddressOrLineno(0x4ef): {FunctionName: unique.Make("func5"), FilePath: none},
 				},
 			},
 			events: map[libpf.Origin]samples.KeyToEventMapping{

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -3,7 +3,11 @@
 
 package samples // import "go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
-import "go.opentelemetry.io/ebpf-profiler/libpf"
+import (
+	"unique"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
 
 type TraceEventMeta struct {
 	Timestamp      libpf.UnixTime64
@@ -81,6 +85,6 @@ type ExecInfo struct {
 type SourceInfo struct {
 	LineNumber     libpf.SourceLineno
 	FunctionOffset uint32
-	FunctionName   string
-	FilePath       string
+	FunctionName   unique.Handle[string]
+	FilePath       unique.Handle[string]
 }

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -115,8 +115,8 @@ func (c *symbolizationCache) symbolize(ty libpf.FrameType, fileID libpf.FileID,
 
 	if data, ok := c.symbols[libpf.NewFrameID(fileID, lineNumber)]; ok {
 		return fmt.Sprintf("%s+%d in %s:%d",
-			data.FunctionName, data.FunctionOffset,
-			data.SourceFile, data.SourceLine), nil
+			data.FunctionName.Value(), data.FunctionOffset,
+			data.SourceFile.Value(), data.SourceLine), nil
 	}
 
 	sourceFile, ok := c.files[fileID]

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unique"
 	"unsafe"
 
 	cebpf "github.com/cilium/ebpf"
@@ -702,7 +703,8 @@ func (t *Tracer) insertKernelFrames(trace *host.Trace, ustackLen uint32,
 		if funcName, _, err := kmod.LookupSymbolByAddress(libpf.Address(kstackVal[i])); err == nil {
 			t.reporter.FrameMetadata(&reporter.FrameMetadataArgs{
 				FrameID:      frameID,
-				FunctionName: funcName,
+				FunctionName: unique.Make(funcName),
+				SourceFile:   unique.Make(""),
 			})
 			t.reporter.ExecutableMetadata(&reporter.ExecutableMetadataArgs{
 				FileID:     kmod.FileID(),


### PR DESCRIPTION
Use the interned unique.Handle[string] for strings in symbolization. This reduced memory usage and allows the string interning to work better when we pass the Handle to the reporter LRUs.

DRAFT:
- maybe the `unique.Handle[string]` should be a `type` in `libpf` or somewhere?
- should also define `EmptyString` or similar to contain the empty string handle
- possibly also allow using uninitialized handle, how over that requires always checking the value before using `.Value()` because dereferencing `nil' string pointer will panic
