### PR TITLE
use userns and mark mount as shared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,12 @@ docker-image:
 	docker build -t otel/opentelemetry-ebpf-profiler-dev -f Dockerfile .
 
 agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
+	@echo $$PWD
+	docker run -v "$$PWD":/agent:z -it --rm --userns=keep-id otel/opentelemetry-ebpf-profiler-dev:latest \
 	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
 
 debug-agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
+	docker run -v "$$PWD":/agent:z -it --rm --userns=keep-id otel/opentelemetry-ebpf-profiler-dev:latest \
 	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) debug"
 
 legal:


### PR DESCRIPTION
Made a change to the docker command in the makefile to make it work rootlessly with podman. 

May want to run to confirm it still works with docker. 95% sure the behavior should be the same for both.