### PR TITLE
reporter: set SchemaURL

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -52,6 +52,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 		rp := profiles.ResourceProfiles().AppendEmpty()
 		rp.Resource().Attributes().PutStr(string(semconv.ContainerIDKey),
 			string(containerID))
+		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
 		sp.Scope().SetName(agentName)


### PR DESCRIPTION
As things are moving constantly it is important to let the backend know the version of the schema used to name attributes.