### PR TITLE
ci: fix cron job for auto tagging

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,5 +1,6 @@
 name: Monthly Tagging
 on:
+  workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
     # Run every month on the 3rd day at 08:15 AM.
     - cron: '15 8 3 * *'

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,8 +1,8 @@
 name: Monthly Tagging
 on:
   schedule:
-    # Run every month on the 1st day at 08:15 AM.
-    - cron: '15 8 1 * *'
+    # Run every month on the 3rd day at 08:15 AM.
+    - cron: '15 8 3 * *'
 
 jobs:
   create-monthly-tag:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -2,7 +2,7 @@ name: Monthly Tagging
 on:
   schedule:
     # Run every month on the 1st day at 08:15 AM.
-    - cron: '15 8 * 1 *'
+    - cron: '15 8 1 * *'
 
 jobs:
   create-monthly-tag:


### PR DESCRIPTION
Fix the trigger for the auto tagging job. At the moment it would run on every day of January instead of every 1st of each month.

Here is the format:

```
┌───────────── minute (0 - 59)
│ ┌───────────── hour (0 - 23)
│ │ ┌───────────── day of the month (1 - 31)
│ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
│ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
│ │ │ │ │
* * * * *
```