### PR TITLE
[ci/codeql] adapt permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,7 @@ on:
   schedule:
     - cron: "21 6 * * 1"
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   analyze:


### PR DESCRIPTION
Since the merge of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/commit/e04411c941e658d7229c8022fea4fe842ef149a4 the [CodeQL GH jobs are failing](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/workflows/codeql.yml). It seems like, the job requires more read permissions, than just to the [content](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).

As this GH job is working in other OTel repositores with `read-all` [set](https://github.com/open-telemetry/opentelemetry-go/blob/0f7f1d0bad21aba18feaadc0171c53705fbda419/.github/workflows/codeql-analysis.yml#L21), also use `read-all`.