### PR TITLE
fix(tracemgmt): remove unnecessary errno check in rate limit reset condition

### DIFF
--- a/support/ebpf/tracemgmt.h
+++ b/support/ebpf/tracemgmt.h
@@ -173,7 +173,7 @@ static inline EBPF_INLINE bool report_pid(void *ctx, u64 pid_tgid, int ratelimit
     increment_metric(metricID_PIDEventsErr);
     return false;
   }
-  if (ratelimit_action == RATELIMIT_ACTION_RESET || errNo != 0) {
+  if (ratelimit_action == RATELIMIT_ACTION_RESET) {
     bpf_map_delete_elem(&reported_pids, &pid);
   }
 


### PR DESCRIPTION
condition `errNo != 0` is always false here