### PR TITLE
reporter: Do not generate unique dummy mappings

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -45,7 +45,6 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 
 	// By specification, the first element should be empty.
 	stringSet.Add("")
-	funcSet.Add(funcInfo{nameIdx: stringSet.Add(""), fileNameIdx: stringSet.Add("")})
 	mappingSet.Add(dummyFileID)
 	dic.MappingTable().AppendEmpty()
 

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -27,6 +27,9 @@ const (
 	FrameMapLifetime        = 1 * time.Hour
 )
 
+// DummyFileID is used as the FileID for a dummy mapping
+var dummyFileID = libpf.NewFileID(0, 0)
+
 // Generate generates a pdata request out of internal profiles data, to be
 // exported.
 func (p *Pdata) Generate(tree samples.TraceEventsTree,
@@ -43,6 +46,8 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 	// By specification, the first element should be empty.
 	stringSet.Add("")
 	funcSet.Add(funcInfo{nameIdx: stringSet.Add(""), fileNameIdx: stringSet.Add("")})
+	mappingSet.Add(dummyFileID)
+	dic.MappingTable().AppendEmpty()
 
 	for containerID, originToEvents := range tree {
 		if len(originToEvents) == 0 {
@@ -216,17 +221,8 @@ func (p *Pdata) setProfile(
 					}
 					locInfo.functionIndex = funcSet.Add(fi)
 				}
-
-				idx, exists := mappingSet.AddWithCheck(traceInfo.Files[i])
-				locInfo.mappingIndex = idx
-				if !exists {
-					// To be compliant with the protocol, generate a dummy mapping entry.
-					mapping := dic.MappingTable().AppendEmpty()
-					mapping.SetFilenameStrindex(stringSet.Add(""))
-					attrMgr.AppendOptionalString(mapping.AttributeIndices(),
-						semconv.ProcessExecutableBuildIDHtlhashKey,
-						traceInfo.Files[i].StringNoQuotes())
-				}
+				// mapping_table[0] is always the dummy mapping
+				locInfo.mappingIndex = 0
 			} // End frame type switch
 
 			idx, exists := locationSet.AddWithCheck(locInfo)

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -110,7 +110,7 @@ func TestFunctionTableOrder(t *testing.T) {
 			executables:              map[libpf.FileID]samples.ExecInfo{},
 			frames:                   map[libpf.FileID]map[libpf.AddressOrLineno]samples.SourceInfo{},
 			events:                   map[libpf.Origin]samples.KeyToEventMapping{},
-			wantFunctionTable:        []string{""},
+			wantFunctionTable:        []string{},
 			expectedResourceProfiles: 0,
 		}, {
 			name:                     "single executable",
@@ -177,7 +177,7 @@ func TestFunctionTableOrder(t *testing.T) {
 				},
 			},
 			wantFunctionTable: []string{
-				"", "func1", "func2", "func3", "func4", "func5",
+				"func1", "func2", "func3", "func4", "func5",
 			},
 		},
 	} {


### PR DESCRIPTION
### Summary

mapping_table[0] should now be the only dummy mapping. Previously, the agent generated a unique dummy mapping per frame.

**Also see:**
- #597 

**NOTE**: Devfiler needs to be updated to account for dummy mappings.