### PR TITLE
Use Time/SetTime rather than SetTime/SetStartTime

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -33,7 +33,8 @@ var dummyFileID = libpf.NewFileID(0, 0)
 // Generate generates a pdata request out of internal profiles data, to be
 // exported.
 func (p *Pdata) Generate(tree samples.TraceEventsTree,
-	agentName, agentVersion string) (pprofile.Profiles, error) {
+	agentName, agentVersion string,
+) (pprofile.Profiles, error) {
 	profiles := pprofile.NewProfiles()
 	dic := profiles.ProfilesDictionary()
 
@@ -280,7 +281,7 @@ func (p *Pdata) setProfile(
 	log.Debugf("Reporting OTLP profile with %d samples", profile.Sample().Len())
 
 	profile.SetDuration(pcommon.Timestamp(endTS - startTS))
-	profile.SetStartTime(pcommon.Timestamp(startTS))
+	profile.SetTime(pcommon.Timestamp(startTS))
 
 	return nil
 }

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -249,7 +249,7 @@ func TestProfileDuration(t *testing.T) {
 
 			profile := res.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0)
 			require.Equal(t, pcommon.Timestamp(7), profile.Duration())
-			require.Equal(t, pcommon.Timestamp(1), profile.StartTime())
+			require.Equal(t, pcommon.Timestamp(1), profile.Time())
 		})
 	}
 }


### PR DESCRIPTION
This method was removed in the latest collector, and using it here prevents the release of collector-releases.

See https://github.com/open-telemetry/opentelemetry-collector/pull/13315