### PR TITLE
remotememory: allow compiling on non linux systems

### DIFF
--- a/remotememory/remotememory.go
+++ b/remotememory/remotememory.go
@@ -9,10 +9,7 @@ package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
-
-	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
@@ -122,30 +119,13 @@ func (rm RemoteMemory) StringPtr(addr libpf.Address) string {
 	return rm.String(addr)
 }
 
-// ProcessVirtualMemory implements RemoteMemory by using process_vm_readv syscalls
+// ProcessVirtualMemory implements ReaderAt by using process_vm_readv syscalls
 // to read the remote memory.
 type ProcessVirtualMemory struct {
 	pid libpf.PID
 }
 
-func (vm ProcessVirtualMemory) ReadAt(p []byte, off int64) (int, error) {
-	numBytesWanted := len(p)
-	if numBytesWanted == 0 {
-		return 0, nil
-	}
-	localIov := []unix.Iovec{{Base: &p[0], Len: uint64(numBytesWanted)}}
-	remoteIov := []unix.RemoteIovec{{Base: uintptr(off), Len: numBytesWanted}}
-	numBytesRead, err := unix.ProcessVMReadv(int(vm.pid), localIov, remoteIov, 0)
-	if err != nil {
-		err = fmt.Errorf("failed to read PID %v at 0x%x: %w", vm.pid, off, err)
-	} else if numBytesRead != numBytesWanted {
-		err = fmt.Errorf("failed to read PID %v at 0x%x: got only %d of %d",
-			vm.pid, off, numBytesRead, numBytesWanted)
-	}
-	return numBytesRead, err
-}
-
-// NewRemoteMemory returns ProcessVirtualMemory implementation of RemoteMemory.
+// NewProcessVirtualMemory returns RemoteMemory with ProcessVirtualMemory as the underlying reader
 func NewProcessVirtualMemory(pid libpf.PID) RemoteMemory {
 	return RemoteMemory{ReaderAt: ProcessVirtualMemory{pid}}
 }

--- a/remotememory/remotememory_linux.go
+++ b/remotememory/remotememory_linux.go
@@ -1,12 +1,13 @@
 //go:build linux
 
-//Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"
 
 import (
 	"fmt"
+
 	"golang.org/x/sys/unix"
 )
 

--- a/remotememory/remotememory_linux.go
+++ b/remotememory/remotememory_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+//Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+func (vm ProcessVirtualMemory) ReadAt(p []byte, off int64) (int, error) {
+	numBytesWanted := len(p)
+	if numBytesWanted == 0 {
+		return 0, nil
+	}
+	localIov := []unix.Iovec{{Base: &p[0], Len: uint64(numBytesWanted)}}
+	remoteIov := []unix.RemoteIovec{{Base: uintptr(off), Len: numBytesWanted}}
+	numBytesRead, err := unix.ProcessVMReadv(int(vm.pid), localIov, remoteIov, 0)
+	if err != nil {
+		err = fmt.Errorf("failed to read PID %v at 0x%x: %w", vm.pid, off, err)
+	} else if numBytesRead != numBytesWanted {
+		err = fmt.Errorf("failed to read PID %v at 0x%x: got only %d of %d",
+			vm.pid, off, numBytesRead, numBytesWanted)
+	}
+	return numBytesRead, err
+}

--- a/remotememory/remotememory_other.go
+++ b/remotememory/remotememory_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+//Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// ReadAt is the stub implementation, allowing to compile the remotememory
+// package on non linux systems, always failing at runtime with an error if used.
+func (vm ProcessVirtualMemory) ReadAt(_ []byte, _ int64) (int, error) {
+	return 0, fmt.Errorf("unsupported os %s", runtime.GOOS)
+}

--- a/remotememory/remotememory_other.go
+++ b/remotememory/remotememory_other.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-//Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"


### PR DESCRIPTION
This will eventually help allowing running some unit tests (for example coredump tests) without spawning a full linux OS on non linux systems (at least darwin, maybe windows)