### PR TITLE
ebpf: update Makefile to add header dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.d
 *.pb.go
 .cache
 /.idea

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -60,8 +60,9 @@ amd64:
 arm64:
 	$(MAKE) TARGET_ARCH=arm64
 
-errors.h: ../../tools/errors-codegen/errors.json
+errors.h: ../../tools/errors-codegen/errors.json ../../tools/errors-codegen/main.go
 	go run ../../tools/errors-codegen/main.go bpf $@
+	$(CLANG_FORMAT) -i -Werror -style=file errors.h
 
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c errors.h
 	$(BPF_CLANG) $(FLAGS) -MMD -MP -o $@

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -63,7 +63,7 @@ arm64:
 errors.h: ../../tools/errors-codegen/errors.json
 	go run ../../tools/errors-codegen/main.go bpf $@
 
-%.ebpf.$(TARGET_ARCH).o: %.ebpf.c
+%.ebpf.$(TARGET_ARCH).o: %.ebpf.c errors.h
 	$(BPF_CLANG) $(FLAGS) -MMD -MP -o $@
 
 $(TRACER_NAME): $(OBJS)

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -60,7 +60,7 @@ amd64:
 arm64:
 	$(MAKE) TARGET_ARCH=arm64
 
-errors.h: ../../tools/errors-codegen/errors.json ../../tools/errors-codegen/main.go
+errors.h: ../../tools/errors-codegen/errors.json
 	go run ../../tools/errors-codegen/main.go bpf $@
 
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c errors.h

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -64,7 +64,7 @@ errors.h: ../../tools/errors-codegen/errors.json
 	go run ../../tools/errors-codegen/main.go bpf $@
 
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c
-	$(BPF_CLANG) $(FLAGS) -MMD -MF $(@:.o=.d) -o $@
+	$(BPF_CLANG) $(FLAGS) -MMD -MP -o $@
 
 $(TRACER_NAME): $(OBJS)
 	$(BPF_LINK) $^ -o - | $(LLC) -march=bpf -mcpu=v2 -filetype=obj -o $@

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -62,7 +62,6 @@ arm64:
 
 errors.h: ../../tools/errors-codegen/errors.json ../../tools/errors-codegen/main.go
 	go run ../../tools/errors-codegen/main.go bpf $@
-	$(CLANG_FORMAT) -i -Werror -style=file errors.h
 
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c errors.h
 	$(BPF_CLANG) $(FLAGS) -MMD -MP -o $@

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -48,6 +48,7 @@ FLAGS=$(TARGET_FLAGS) -g \
 
 SRCS := $(wildcard *.ebpf.c)
 OBJS := $(SRCS:.c=.$(TARGET_ARCH).o)
+DEPS := $(OBJS:.o=.d)
 
 .DEFAULT_GOAL := all
 
@@ -62,10 +63,8 @@ arm64:
 errors.h: ../../tools/errors-codegen/errors.json
 	go run ../../tools/errors-codegen/main.go bpf $@
 
-%.ebpf.c: errors.h ;
-
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c
-	$(BPF_CLANG) $(FLAGS) -o $@
+	$(BPF_CLANG) $(FLAGS) -MMD -MF $(@:.o=.d) -o $@
 
 $(TRACER_NAME): $(OBJS)
 	$(BPF_LINK) $^ -o - | $(LLC) -march=bpf -mcpu=v2 -filetype=obj -o $@
@@ -88,4 +87,6 @@ format:
 	$(CLANG_FORMAT) -i -style=file *.[ch]
 
 clean:
-	rm -f *.o
+	rm -f *.o *.d
+
+-include $(DEPS)


### PR DESCRIPTION
I noticed when I change a header, the ebpf program is not recompiled and requires a manual clean.

This change should force recompilation if any dependent header changed