### PR TITLE
Dockerfile: add clang-format-17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64
     cross_pkg_arch=$(uname -m | sed -e 's/aarch64/x86-64/' -e 's/x86_64/aarch64/'); \
     apt-get update -y && \
     apt-get dist-upgrade -y && \
-    apt-get install -y curl wget make git cmake clang-17 unzip libc6-dev g++ gcc pkgconf \
+    apt-get install -y curl wget make git cmake unzip libc6-dev g++ gcc pkgconf \
+        clang-17 clang-format-17 \
         gcc-${cross_pkg_arch}-linux-gnu libc6-${cross_debian_arch}-cross \
         musl-dev:amd64 musl-dev:arm64 && \
     apt-get clean autoclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64
     cross_pkg_arch=$(uname -m | sed -e 's/aarch64/x86-64/' -e 's/x86_64/aarch64/'); \
     apt-get update -y && \
     apt-get dist-upgrade -y && \
-    apt-get install -y curl wget make git cmake unzip libc6-dev g++ gcc pkgconf \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        curl wget make git cmake unzip libc6-dev g++ gcc pkgconf \
         clang-17 clang-format-17 \
         gcc-${cross_pkg_arch}-linux-gnu libc6-${cross_debian_arch}-cross \
         musl-dev:amd64 musl-dev:arm64 && \


### PR DESCRIPTION
The image may be handy to format/lint C code
```
root@7b6151a22a97:/agent/support/ebpf# make lint
clang-format-17 -Werror --dry-run -style=file *.[ch]
/bin/sh: 1: clang-format-17: not found
make: *** [Makefile:84: lint] Error 127
```