### PR TITLE
ebpf: use features.BPF_F_NO_PREALLOC constant

### DIFF
--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -12,10 +12,8 @@ import (
 	"unsafe"
 
 	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/exp/constraints"
-	"golang.org/x/sys/unix"
-
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -25,6 +23,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/rlimit"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/util"
+	"golang.org/x/exp/constraints"
 )
 
 /*
@@ -495,7 +494,7 @@ func probeBatchOperations(mapType cebpf.MapType) error {
 		KeySize:    8,
 		ValueSize:  8,
 		MaxEntries: uint32(updates),
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      features.BPF_F_NO_PREALLOC,
 	}
 
 	var keys any


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/612

This PR allows compiling the `processmanager/ebpf` package on `darwin`
This will eventually help allowing running some unit tests (for example coredump tests) without spawning a full linux OS 