### PR TITLE
rlimit: allow compiling rlimit on non-linux systems

### DIFF
--- a/rlimit/rlimit_linux.go
+++ b/rlimit/rlimit_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/rlimit/rlimit_other.go
+++ b/rlimit/rlimit_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rlimit // import "go.opentelemetry.io/ebpf-profiler/rlimit"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// MaximizeMemlock is the stub implementation, allowing to compile the rlimit
+// package on non-linux systems, always failing at runtime with an error if used.
+func MaximizeMemlock() (func(), error) {
+	return nil, fmt.Errorf("unsupported os %s", runtime.GOOS)
+}


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/612

This will eventually help allowing running some unit tests (for example coredump tests) without spawning a full linux OS on non linux systems (at least darwin)