### PR TITLE
php: recognize apache2 libphp.so as loader

### DIFF
--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -41,7 +41,8 @@ var (
 	evalCodeFunctionName = libpf.Intern("<eval'd code>")
 
 	// regex for the interpreter executable
-	phpRegex     = regexp.MustCompile(".*/php(-cgi|-fpm)?[0-9.]*$|^php(-cgi|-fpm)?[0-9.]*$")
+	phpRegex = regexp.MustCompile(`.*/php(-cgi|-fpm)?[0-9.]*$|^php(-cgi|-fpm)?[0-9.]*$` +
+		`|.*/libphp.*\.so$`)
 	versionMatch = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)`)
 
 	// compiler check to make sure the needed interfaces are satisfied

--- a/interpreter/php/php_test.go
+++ b/interpreter/php/php_test.go
@@ -10,13 +10,17 @@ import (
 )
 
 func TestPHPRegexs(t *testing.T) {
-	shouldMatch := []string{"php", "./php", "/foo/bar/php", "./foo/bar/php", "php-fpm", "php-cgi7"}
+	shouldMatch := []string{"php", "./php", "/foo/bar/php", "./foo/bar/php", "php-fpm", "php-cgi7",
+		"/usr/lib/apache2/modules/libphp.so", "/libphp.so",
+		"/usr/lib/apache2/modules/libphp5.so", "/libphp5.so",
+		"/usr/lib/apache2/modules/libphp8.1.so", "/libphp8.1.so"}
 	for _, s := range shouldMatch {
 		assert.True(t, phpRegex.MatchString(s), "PHP regex %s should match %s",
 			phpRegex.String(), s)
 	}
 
-	shouldNotMatch := []string{"foophp", "ph p", "ph/p", "php-bar"}
+	shouldNotMatch := []string{"foophp", "ph p", "ph/p", "php-bar",
+		"/usr/lib/apache2/modules/libphp8.1-so", "libphp-so", "/libphp.soap"}
 	for _, s := range shouldNotMatch {
 		assert.False(t, phpRegex.MatchString(s), "PHP regex %s should not match %s",
 			phpRegex.String(), s)


### PR DESCRIPTION
To symbolize PHP interpreted stack frames on apache2 we must recognize
libphp.so paths (e.g. /usr/lib/apache2/modules/libphp8.1.so) as PHP loader.

Resolves: #610