### PR TITLE
process: replace strconv.ParseUint in parseMappings

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -122,3 +122,13 @@ func TestNewPIDOfSelf(t *testing.T) {
 	require.Equal(t, uint32(0), numParseErrors)
 	assert.NotEmpty(t, mappings)
 }
+
+func BenchmarkParseMappings(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		reader := strings.NewReader(testMappings)
+		_, _, err := parseMappings(reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Profiling ebpf-profiler shows, that a significant part of `process.parseMappings` is spent in `strconv.ParseUint`.

<img width="1191" height="529" alt="2025-07-21_14-59" src="https://github.com/user-attachments/assets/49da504d-c9de-41ca-ac47-6c048e25528e" />


Replace strconv.PareseUint with specialized functions.

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/ebpf-profiler/process
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
                 │   old.txt   │               new.txt               │
                 │   sec/op    │   sec/op     vs base                │
ParseMappings-20   2.202µ ± 5%   1.837µ ± 4%  -16.60% (p=0.000 n=10)

                 │   old.txt    │             new.txt              │
                 │     B/op     │     B/op      vs base            │
ParseMappings-20   2.032Ki ± 0%   2.032Ki ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                 │  old.txt   │            new.txt             │
                 │ allocs/op  │ allocs/op   vs base            │
ParseMappings-20   2.000 ± 0%   2.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

