### PR TITLE
Dockerfile: add ${GOPATH}/bin to $PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN GO_VERSION=$(grep -oPm1 '^go \K([[:digit:].]+)' /tmp/go.mod) && \
 # Set Go environment variables
 ENV GOPATH="/agent/go"
 ENV GOCACHE="/agent/.cache"
-ENV PATH="/usr/local/go/bin:$PATH"
+ENV PATH="/usr/local/go/bin:/agent/go/bin:$PATH"
 
 # gRPC dependencies
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN GO_VERSION=$(grep -oPm1 '^go \K([[:digit:].]+)' /tmp/go.mod) && \
 # Set Go environment variables
 ENV GOPATH="/agent/go"
 ENV GOCACHE="/agent/.cache"
-ENV PATH="/usr/local/go/bin:/agent/go/bin:$PATH"
+ENV PATH="/usr/local/go/bin:$PATH"
 
 # gRPC dependencies
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
@@ -47,6 +47,7 @@ RUN                                                                             
 
 # Append to /etc/profile for login shells
 RUN echo 'export PATH="/usr/local/go/bin:$PATH"' >> /etc/profile
+RUN echo 'export PATH="/agent/go/bin:$PATH"' >> /etc/profile
 
 # Create rust related directories in /usr/local
 RUN mkdir -p /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
This allows using the installed tools, such as porto in the docker dev container
```
root@3f484fa80ce1:/agent/src# make lint
GOARCH=arm64 go generate ./...
(cd support && ./generate.sh)
go: downloading github.com/jcchavezs/porto v0.7.0
types_gen.go
go: downloading golang.org/x/mod v0.21.0
bash: line 1: porto: command not found
(run: make vanity-import-fix)
make: *** [Makefile:100: vanity-import-check] Error 1
```