### PR TITLE
Dockerfile: install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64
     apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         curl wget make git cmake unzip libc6-dev g++ gcc pkgconf \
-        clang-17 clang-format-17 \
+        clang-17 clang-format-17 ca-certificates\
         gcc-${cross_pkg_arch}-linux-gnu libc6-${cross_debian_arch}-cross \
         musl-dev:amd64 musl-dev:arm64 && \
     apt-get clean autoclean && \


### PR DESCRIPTION
When building the docker image, sometimes the download of artifacts fails because of certificate issues. E.g.:
```
Resolving golang.org (golang.org)... 172.217.168.49, 2a00:1450:400a:802::2011
Connecting to golang.org (golang.org)|172.217.168.49|:443... connected.
ERROR: The certificate of 'golang.org' is not trusted.
ERROR: The certificate of 'golang.org' doesn't have a known issuer.
```