### PR TITLE
processmanager: reduce allocations for errors

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -56,6 +56,8 @@ var (
 	errUnknownMapping = errors.New("unknown memory mapping")
 	// errUnknownPID indicates that the process is not known to the process manager.
 	errUnknownPID = errors.New("unknown process")
+	// errPIDGone indicates that a process is no longer managed by the process manager.
+	errPIDGone = errors.New("interpreter process gone")
 )
 
 // New creates a new ProcessManager which is responsible for keeping track of loading
@@ -196,7 +198,7 @@ func (pm *ProcessManager) symbolizeFrame(frame int, trace *host.Trace,
 	defer pm.mu.Unlock()
 
 	if len(pm.interpreters[trace.PID]) == 0 {
-		return errors.New("interpreter process gone")
+		return errPIDGone
 	}
 
 	for _, instance := range pm.interpreters[trace.PID] {
@@ -206,7 +208,7 @@ func (pm *ProcessManager) symbolizeFrame(frame int, trace *host.Trace,
 				// So continue with the next interpreter instance for this PID.
 				continue
 			}
-			return fmt.Errorf("symbolization failed: %w", err)
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
While looking at uprobes attached to ebpf-profiler:runtime.mallocgc I noticed, that the error path of processmanager accounts for a significant amount of allocations.

<img width="3454" height="948" alt="20250723-154749" src="https://github.com/user-attachments/assets/ef6e66e1-f07a-4b31-a8da-aa7af90e2a1b" />

Reduce allocations by moving reusing common errors and drop prosa around errors.

Update: The screenshot does **not** include the start time of ebpf-profiler.

To quantify and visualize the impact:

<img width="1838" height="159" alt="2025-07-23_16-01" src="https://github.com/user-attachments/assets/1ab16326-617c-488f-99b5-5d99e56717fd" />
