### PR TITLE
CI: fix script path

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -37,7 +37,7 @@ jobs:
           git clone --depth=1 https://github.com/open-telemetry/opentelemetry-collector.git $collector_path
       - name: Setup replace statement
         run: |
-          COLLECTOR_PATH=/tmp/opentelemetry-collector ./scripts/local-collector
+          COLLECTOR_PATH=/tmp/opentelemetry-collector ./scripts/local-collector.sh
           go mod tidy
       - name: Tests
         run: make test-junit


### PR DESCRIPTION
CI [failed](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/16612963509/job/46999600022#step:6:6) with this error:
```
/home/runner/work/_temp/f0dfe594-8d5a-4bf0-bedc-302e04114782.sh: line 1: ./scripts/local-collector: No such file or directory
```