### PR TITLE
Fix local collector path

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -37,7 +37,7 @@ jobs:
           git clone --depth=1 https://github.com/open-telemetry/opentelemetry-collector.git $collector_path
       - name: Setup replace statement
         run: |
-          COLLECTOR_PATH=/tmp/opentelemetry-collector ./scripts/local-collector
+          COLLECTOR_PATH=/tmp/opentelemetry-collector ./scripts/local-collector.sh
           go mod tidy
       - name: Tests
         run: make test-junit


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/630
This typo happened when the script was moved from a Makefile command to a sh script.