### PR TITLE
Remove host.FileID from StackDeltaProvider interface

### DIFF
--- a/nativeunwind/elfunwindinfo/stackdeltaprovider.go
+++ b/nativeunwind/elfunwindinfo/stackdeltaprovider.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"sync/atomic"
 
-	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/nativeunwind"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
@@ -32,8 +31,8 @@ func NewStackDeltaProvider() nativeunwind.StackDeltaProvider {
 }
 
 // GetIntervalStructuresForFile builds the stack delta information for a single executable.
-func (provider *ELFStackDeltaProvider) GetIntervalStructuresForFile(_ host.FileID,
-	elfRef *pfelf.Reference, interval *sdtypes.IntervalData) error {
+func (provider *ELFStackDeltaProvider) GetIntervalStructuresForFile(elfRef *pfelf.Reference,
+	interval *sdtypes.IntervalData) error {
 	err := ExtractELF(elfRef, interval)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/nativeunwind/stackdeltaprovider.go
+++ b/nativeunwind/stackdeltaprovider.go
@@ -4,7 +4,6 @@
 package nativeunwind // import "go.opentelemetry.io/ebpf-profiler/nativeunwind"
 
 import (
-	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
 )
@@ -22,8 +21,7 @@ type Statistics struct {
 type StackDeltaProvider interface {
 	// GetIntervalStructuresForFile inspects a single executable and extracts data that is needed
 	// to rebuild the stack for traces of this executable.
-	GetIntervalStructuresForFile(fileID host.FileID, elfRef *pfelf.Reference,
-		interval *sdtypes.IntervalData) error
+	GetIntervalStructuresForFile(elfRef *pfelf.Reference, interval *sdtypes.IntervalData) error
 
 	// GetAndResetStatistics returns the internal statistics for this provider and resets all
 	// values to 0.

--- a/processmanager/execinfomanager/manager.go
+++ b/processmanager/execinfomanager/manager.go
@@ -185,7 +185,7 @@ func (mgr *ExecutableInfoManager) AddOrIncRef(fileID host.FileID,
 	// so we release the lock before doing this.
 	mgr.state.WUnlock(&state)
 
-	if err = mgr.sdp.GetIntervalStructuresForFile(fileID, elfRef, &intervalData); err != nil {
+	if err = mgr.sdp.GetIntervalStructuresForFile(elfRef, &intervalData); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			mgr.deferredFileIDs.Add(fileID, libpf.Void{})
 		}

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -94,8 +94,8 @@ func newTestProcess(pid libpf.PID) process.Process {
 type dummyStackDeltaProvider struct{}
 
 // GetIntervalStructuresForFile fills in the expected data structure with semi random data.
-func (d *dummyStackDeltaProvider) GetIntervalStructuresForFile(_ host.FileID,
-	_ *pfelf.Reference, result *sdtypes.IntervalData) error {
+func (d *dummyStackDeltaProvider) GetIntervalStructuresForFile(_ *pfelf.Reference,
+	result *sdtypes.IntervalData) error {
 	r := rand.New(rand.NewPCG(42, 42)) //nolint:gosec
 	addr := 0x10
 	for i := 0; i < r.IntN(42); i++ {


### PR DESCRIPTION
No one uses this. It was originally envisioned to be used for possibly implementing alternative provider to fetch the deltas from remove server using the host.FileID. But this is now superceded by the fact that pfelf.Reference is passed and the GnuBuildID or other checksums can be calculated if needed.