### PR TITLE
interpreter: reduce GC stress by interning and using unsafe.String

### DIFF
--- a/interpreter/apmint/apmint.go
+++ b/interpreter/apmint/apmint.go
@@ -207,7 +207,7 @@ func nextString(rm remotememory.RemoteMemory, addr *libpf.Address, maxLen int) (
 	}
 
 	*addr += libpf.Address(length)
-	return string(raw), nil
+	return unsafe.String(unsafe.SliceData(raw), len(raw)), nil
 }
 
 // readProcStorage reads the APM process storage from memory.

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -204,9 +204,9 @@ func (d *hotspotInstance) getSymbol(addr libpf.Address) libpf.String {
 			return libpf.NullString
 		}
 	}
-	s := string(tmp)
+	s := unsafe.String(unsafe.SliceData(tmp), len(tmp))
 	if !util.IsValidString(s) {
-		log.Debugf("Extracted Hotspot symbol is invalid at 0x%x '%v'", addr, []byte(s))
+		log.Debugf("Extracted Hotspot symbol is invalid at 0x%x '%v'", addr, tmp)
 		return libpf.NullString
 	}
 	value := libpf.Intern(s)

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -842,7 +842,7 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 				if err != nil {
 					return err
 				}
-				if err = cb(string(buf)); err != nil {
+				if err = cb(unsafe.String(unsafe.SliceData(buf), len(buf))); err != nil {
 					return err
 				}
 			}

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -5,7 +5,6 @@ package perl // import "go.opentelemetry.io/ebpf-profiler/interpreter/perl"
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/elastic/go-freelru"
 	log "github.com/sirupsen/logrus"
@@ -122,7 +121,7 @@ func (d *perlData) String() string {
 
 func (d *perlData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory) (interpreter.Instance, error) {
-	addrToHEK, err := freelru.New[libpf.Address, string](interpreter.LruFunctionCacheSize,
+	addrToHEK, err := freelru.New[libpf.Address, libpf.String](interpreter.LruFunctionCacheSize,
 		libpf.Address.Hash32)
 	if err != nil {
 		return nil, err
@@ -147,14 +146,6 @@ func (d *perlData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Add
 		addrToHEK: addrToHEK,
 		addrToCOP: addrToCOP,
 		addrToGV:  addrToGV,
-		memPool: sync.Pool{
-			New: func() any {
-				// To avoid resizing of the returned byte slize we size new
-				// allocations to hekLenLimit.
-				buf := make([]byte, hekLenLimit)
-				return &buf
-			},
-		},
 	}, nil
 }
 

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -180,7 +180,7 @@ func determinePHPVersion(ef *pfelf.File) (uint, error) {
 		if zeroIdx < 0 {
 			continue
 		}
-		version, err := versionExtract(string(rodata[idx : idx+zeroIdx]))
+		version, err := versionExtract(unsafe.String(unsafe.SliceData(rodata[idx:]), zeroIdx))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Where possible avoid string casts to reduce GC pressure.