### PR TITLE
tracer: fix capacity issue

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -678,7 +678,7 @@ func (t *Tracer) readKernelFrames(kstackID int32) (libpf.Frames, error) {
 		kstackLen++
 	}
 
-	frames := make(libpf.Frames, kstackLen)
+	frames := make(libpf.Frames, 0, kstackLen)
 	for i := uint32(0); i < kstackLen; i++ {
 		address := libpf.Address(kstackVal[i])
 		frame := libpf.Frame{


### PR DESCRIPTION
When allocating the memory for the kernel frames, set the capacity instead of the size. 

This fixes the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc502cd]

goroutine 39 [running]:
unique.Handle[...].Value(...)
	/usr/local/go/src/unique/handle.go:27
go.opentelemetry.io/ebpf-profiler/traceutil.HashTrace(0xc0011a14a0?)
	/agent/traceutil/traceutil.go:20 +0x8d
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).ConvertTrace(0xc0012f8000, 0xc000335110)
	/agent/processmanager/manager.go:303 +0x75c
go.opentelemetry.io/ebpf-profiler/tracehandler.(*traceHandler).HandleTrace(0xc0012300f0, 0xc000335110)
	/agent/tracehandler/tracehandler.go:147 +0x370
go.opentelemetry.io/ebpf-profiler/tracehandler.Start.func1()
	/agent/tracehandler/tracehandler.go:182 +0x173
created by go.opentelemetry.io/ebpf-profiler/tracehandler.Start in goroutine 1
	/agent/tracehandler/tracehandler.go:171 +0x179
```