### PR TITLE
[chore] drop debug and DebugTracer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all all-common clean ebpf generate test test-deps \
 	test-junit protobuf docker-image agent legal integration-test-binaries \
-	codespell lint linter-version debug debug-agent ebpf-profiler format-ebpf \
+	codespell lint linter-version ebpf-profiler format-ebpf \
 	rust-components rust-targets rust-tests vanity-import-check vanity-import-fix
 
 SHELL := /usr/bin/env bash
@@ -53,10 +53,6 @@ MAKEFLAGS += -j$(shell nproc)
 JUNIT_OUT_DIR ?= /tmp/testresults
 
 all: ebpf-profiler
-
-debug: GO_TAGS := $(GO_TAGS),debugtracer
-debug: EBPF_FLAGS += debug
-debug: all
 
 # Removes the go build cache and binaries in the current project
 clean:
@@ -155,10 +151,6 @@ docker-image:
 agent:
 	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
 	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
-
-debug-agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) otel/opentelemetry-ebpf-profiler-dev:latest \
-	   "make TARGET_ARCH=$(TARGET_ARCH) VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) debug"
 
 legal:
 	@go install github.com/google/go-licenses@latest

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -92,7 +92,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		SamplesPerSecond:       c.config.SamplesPerSecond,
 		MapScaleFactor:         int(c.config.MapScaleFactor),
 		KernelVersionCheck:     !c.config.NoKernelVersionCheck,
-		DebugTracer:            c.config.VerboseMode,
+		VerboseMode:            c.config.VerboseMode,
 		BPFVerifierLogLevel:    uint32(c.config.BpfVerifierLogLevel),
 		ProbabilisticInterval:  c.config.ProbabilisticInterval,
 		ProbabilisticThreshold: c.config.ProbabilisticThreshold,

--- a/interpreter/golabels/test/main_test.go
+++ b/interpreter/golabels/test/main_test.go
@@ -51,7 +51,7 @@ func TestGoLabels(t *testing.T) {
 		ProbabilisticInterval:  100,
 		ProbabilisticThreshold: 100,
 		OffCPUThreshold:        uint32(math.MaxUint32 / 100),
-		DebugTracer:            true,
+		VerboseMode:            true,
 	})
 	require.NoError(t, err)
 

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -127,7 +127,7 @@ func TestTraceTransmissionAndParsing(t *testing.T) {
 		ProbabilisticInterval:  100,
 		ProbabilisticThreshold: 100,
 		OffCPUThreshold:        1 * math.MaxUint32,
-		DebugTracer:            true,
+		VerboseMode:            true,
 	})
 	require.NoError(t, err)
 
@@ -247,7 +247,7 @@ func TestAllTracers(t *testing.T) {
 		ProbabilisticInterval:  100,
 		ProbabilisticThreshold: 100,
 		OffCPUThreshold:        uint32(math.MaxUint32 / 100),
-		DebugTracer:            true,
+		VerboseMode:            true,
 	})
 	require.NoError(t, err)
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -128,8 +128,8 @@ type Config struct {
 	FilterErrorFrames bool
 	// KernelVersionCheck indicates whether the kernel version should be checked.
 	KernelVersionCheck bool
-	// DebugTracer indicates whether to load the debug version of eBPF tracers.
-	DebugTracer bool
+	// VerboseMode indicates whether to enable verbose output of eBPF tracers.
+	VerboseMode bool
 	// BPFVerifierLogLevel is the log level of the eBPF verifier output.
 	BPFVerifierLogLevel uint32
 	// ProbabilisticInterval is the time interval for which probabilistic profiling will be enabled.
@@ -283,7 +283,7 @@ func initializeMapsAndPrograms(kmod *kallsyms.Module, cfg *Config) (
 		return nil, nil, fmt.Errorf("failed to load specification for tracers: %v", err)
 	}
 
-	if cfg.DebugTracer {
+	if cfg.VerboseMode {
 		if err = coll.Variables["with_debug_output"].Set(uint32(1)); err != nil {
 			return nil, nil, fmt.Errorf("failed to set debug output: %v", err)
 		}


### PR DESCRIPTION
With the merge of #560 the dedicated debug eBPF binary blobs got removed. Cleanup remaining bits and unify the handling.