### PR TITLE
ruby interpreter: add latest offsets and fallback to symtab for symbol discovery

### DIFF
--- a/interpreter/loaderinfo.go
+++ b/interpreter/loaderinfo.go
@@ -48,11 +48,15 @@ func (i *LoaderInfo) GetSymbolAsRanges(symbol libpf.SymbolName) ([]util.Range, e
 	if err != nil {
 		return nil, fmt.Errorf("symbol '%v' not found: %w", symbol, err)
 	}
-	start := uint64(sym.Address)
+	return i.SymbolAsRanges(sym), nil
+}
+
+// SymbolAsRanges returns the normalized virtual address ranges for the named symbol
+func (i *LoaderInfo) SymbolAsRanges(symbol *libpf.Symbol) []util.Range {
 	return []util.Range{{
-		Start: start,
-		End:   start + sym.Size},
-	}, nil
+		Start: uint64(symbol.Address),
+		End:   uint64(symbol.Address) + symbol.Size,
+	}}
 }
 
 // FileID returns the fileID  element of the LoaderInfo struct.

--- a/tools/coredump/testdata/amd64/ruby-3.3.9-loop.json
+++ b/tools/coredump/testdata/amd64/ruby-3.3.9-loop.json
@@ -1,0 +1,87 @@
+{
+  "coredump-ref": "b30adc830b2f54cb27f8f35a1ac20c7c5b4fb6a81c9c272d62368f5194b3162e",
+  "threads": [
+    {
+      "lwp": 7397,
+      "frames": [
+        "is_prime+0 in /app/loop.rb:10",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "<main>+0 in /app/loop.rb:30",
+        "libruby.so.3.3.9+0x31ba80",
+        "libruby.so.3.3.9+0x321007",
+        "libruby.so.3.3.9+0x22912d",
+        "libruby.so.3.3.9+0x303ada",
+        "libruby.so.3.3.9+0x30a691",
+        "libruby.so.3.3.9+0x317d3f",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.3.9+0x31bde5",
+        "libruby.so.3.3.9+0x321007",
+        "libruby.so.3.3.9+0x22946d",
+        "libruby.so.3.3.9+0x303e48",
+        "libruby.so.3.3.9+0x30a691",
+        "libruby.so.3.3.9+0x317d3f",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.3.9+0x31bce8",
+        "libruby.so.3.3.9+0x120238",
+        "libruby.so.3.3.9+0x1267aa",
+        "ruby+0x110f",
+        "libc.so.6+0x29ca7",
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    },
+    {
+      "lwp": 7424,
+      "frames": [
+        "libc.so.6+0x9a9ee",
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "33c913cea616d1881350ee6d3ef784eda4b2f1de3036c4a437b4b612a121cf13",
+      "local-path": "/usr/local/lib/ruby/3.3.0/x86_64-linux/monitor.so"
+    },
+    {
+      "ref": "a778cb0514fb431a6ef92ad1f02318aa8c3b6218e9b8dd6acb9544ec10f91269",
+      "local-path": "/usr/local/lib/libruby.so.3.3.9"
+    },
+    {
+      "ref": "1d25fd63234b59e4c581564c7a6d8f5c6cf36eee757e3d26f4b0808dd36a4896",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "2bd1552c47799ef67e701e81d4383061fd76059868e446e63560f0dd0d5ec14e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "067650d84b8f554cedf0b9ff26137bdd10cd03d4bbcdba1029a543c59d1798e5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "c608c52e4edb3886910125a89beba619c3211b27affd7db1140da29c5a485aaf",
+      "local-path": "/usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "582f2d3d4edab86d601c54b37f04bd18fa2cda28be30e9f8c87df73c1c581354",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "5db18e8a8894ef4746eb8230855b638a5e52e782b2f10deede5f1dad846178bb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "72733e395b91ba6c86adb6d1e711059b422752d7c2ef64e55d8286c011f866a5",
+      "local-path": "/usr/local/bin/ruby"
+    },
+    {
+      "ref": "8e3f1eb7bab7921c8dec8c86fcbea681d33f3b269647be8c358e331f4d8e75db",
+      "local-path": "/usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/ruby-3.4.5-loop.json
+++ b/tools/coredump/testdata/amd64/ruby-3.4.5-loop.json
@@ -1,0 +1,52 @@
+{
+  "coredump-ref": "96e1cb7a34e425c67af9067bfb7d0b82abd6f5f5df5042bd54587080ae96f71b",
+  "threads": [
+    {
+      "lwp": 35312,
+      "frames": [
+        "is_prime+0 in /app/loop.rb:10",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "libruby.so.3.4.5+0x346a40",
+        "libruby.so.3.4.5+0x34bb17",
+        "libruby.so.3.4.5+0x24a095",
+        "libruby.so.3.4.5+0x32ae6a",
+        "libruby.so.3.4.5+0x331df0",
+        "libruby.so.3.4.5+0x3409bc",
+        "00000000000000000+0x0",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "00000000000000000+0x0",
+        "libruby.so.3.4.5+0x346da5",
+        "libruby.so.3.4.5+0x34bb17",
+        "libruby.so.3.4.5+0x24a2dd",
+        "libruby.so.3.4.5+0x329a00",
+        "libruby.so.3.4.5+0x331df0",
+        "libruby.so.3.4.5+0x3409bc",
+        "00000000000000000+0x0",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "00000000000000000+0x0",
+        "libruby.so.3.4.5+0x346ca8",
+        "libruby.so.3.4.5+0x13d25a",
+        "libruby.so.3.4.5+0x1434fa",
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    },
+    {
+      "lwp": 35338,
+      "frames": [
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "582f2d3d4edab86d601c54b37f04bd18fa2cda28be30e9f8c87df73c1c581354",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "1cc1af955ac32bfbfb6368a9af8eb0c4972cff323ae9b0e42f66a9723f780595",
+      "local-path": "/usr/local/lib/libruby.so.3.4.5"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/ruby-3.5.0-loop.json
+++ b/tools/coredump/testdata/amd64/ruby-3.5.0-loop.json
@@ -1,0 +1,52 @@
+{
+  "coredump-ref": "9e9725ed6dab4301d72783cff4616690cc1dd1273f6b5679e667a58282b094b5",
+  "threads": [
+    {
+      "lwp": 39303,
+      "frames": [
+        "is_prime+0 in /app/loop.rb:10",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "libruby.so.3.5.0+0x3399b0",
+        "libruby.so.3.5.0+0x33e9d7",
+        "libruby.so.3.5.0+0x23e175",
+        "libruby.so.3.5.0+0x31e2ea",
+        "libruby.so.3.5.0+0x325240",
+        "libruby.so.3.5.0+0x333b86",
+        "00000000000000000+0x0",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "00000000000000000+0x0",
+        "libruby.so.3.5.0+0x339d65",
+        "libruby.so.3.5.0+0x33e9d7",
+        "libruby.so.3.5.0+0x23e3bd",
+        "libruby.so.3.5.0+0x31ce80",
+        "libruby.so.3.5.0+0x325240",
+        "libruby.so.3.5.0+0x333b86",
+        "00000000000000000+0x0",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "00000000000000000+0x0",
+        "libruby.so.3.5.0+0x339be9",
+        "libruby.so.3.5.0+0x135c5a",
+        "libruby.so.3.5.0+0x13befa",
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    },
+    {
+      "lwp": 39330,
+      "frames": [
+        "<unwinding aborted due to error native_no_pid_page_mapping>"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "b95d95d7acb8885a9a7fa1266d15e8d1bd35166023143ad7545a45c3ab5e7b0d",
+      "local-path": "/usr/local/lib/libruby.so.3.5.0"
+    },
+    {
+      "ref": "582f2d3d4edab86d601c54b37f04bd18fa2cda28be30e9f8c87df73c1c581354",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/ruby-3.3.9-loop.json
+++ b/tools/coredump/testdata/arm64/ruby-3.3.9-loop.json
@@ -1,0 +1,103 @@
+{
+  "coredump-ref": "9733f091c2e586f0fffd4203e8e7f5508cd8986b5bc34fc7e1ae89b70395baf2",
+  "threads": [
+    {
+      "lwp": 1317239,
+      "frames": [
+        "libruby.so.3.3.9+0x2faf44",
+        "is_prime+0 in /app/loop.rb:11",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "<main>+0 in /app/loop.rb:30",
+        "libruby.so.3.3.9+0x2feedb",
+        "libruby.so.3.3.9+0x30f0ff",
+        "libruby.so.3.3.9+0x214a5b",
+        "libruby.so.3.3.9+0x2ea1e7",
+        "libruby.so.3.3.9+0x2efa4f",
+        "libruby.so.3.3.9+0x2f97af",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.3.9+0x2fef9f",
+        "libruby.so.3.3.9+0x30f0ff",
+        "libruby.so.3.3.9+0x214db7",
+        "libruby.so.3.3.9+0x2eb4bf",
+        "libruby.so.3.3.9+0x2efa4f",
+        "libruby.so.3.3.9+0x2f97af",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.3.9+0x2feedb",
+        "libruby.so.3.3.9+0x10faab",
+        "libruby.so.3.3.9+0x11628f",
+        "ruby+0xbaf",
+        "libc.so.6+0x2229b",
+        "libc.so.6+0x2237b",
+        "ruby+0xc2f"
+      ]
+    },
+    {
+      "lwp": 1317260,
+      "frames": [
+        "libc.so.6+0x8efac",
+        "libc.so.6+0x82657",
+        "libc.so.6+0x8269b",
+        "libc.so.6+0xee143",
+        "libruby.so.3.3.9+0x2a78f3",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0xedc1b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "9a146967dc38c3820c5dc21c3209812655f66b6551264072b187bd0e787947e0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "0b6ffd0ad6851333bc20e4723d58e879b81b009a06e3df9f61f6dde6091cb901",
+      "local-path": "/usr/local/lib/ruby/3.3.0/aarch64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "cd5f308744716b6acb96c50f904fed47170601cbded03cc399e611221c89ce24",
+      "local-path": "/usr/local/lib/ruby/3.3.0/aarch64-linux/monitor.so"
+    },
+    {
+      "ref": "bcc27e0424977640c5647c34758bb443e99ea88edde45a0896a1dc5b7713cb0b",
+      "local-path": "/usr/local/lib/libruby.so.3.3.9"
+    },
+    {
+      "ref": "6025f191bab010ad585ca2044f0b3436a376572c0487bbd57848521f7669f46b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "c0c1ecaff337aea6062f616aa4a05520180201ef7b8ac9afb99bd133cd5feae7",
+      "local-path": "/usr/local/lib/ruby/3.3.0/aarch64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "aa58dc4b16a6f9aed418c8447fc5d36a68672c09fd1729361d1df37792ad7a03",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "8858b931d041b74a8ce9dcb16d9912eb431c4f55b97ca2e58646a1c1bd991852",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "a8afb2d1f4a0c5e14c0fc82f794ec839eafe29738907aa92895410f57630bbe2",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "fc0165e3cbff299baa266b5531ac9054fff35786bf3ffa46f6eae5650d9bd8c8",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "2dd059935f68b71efc53b6915cd77d12b1133af3d66d7872660b737e5f393015",
+      "local-path": "/usr/local/bin/ruby"
+    },
+    {
+      "ref": "6fe00acadf8119ff245855e5dcc7f26c6c0ffaf4bfa2baa88feab58f23727d65",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3.1"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/ruby-3.4.5-loop.json
+++ b/tools/coredump/testdata/arm64/ruby-3.4.5-loop.json
@@ -1,0 +1,98 @@
+{
+  "coredump-ref": "70001cca90745b1c61352eb18371dbd64d87f8356a1c441f2a80c71315d65381",
+  "threads": [
+    {
+      "lwp": 1271670,
+      "frames": [
+        "libruby.so.3.4.5+0x30b4d4",
+        "libruby.so.3.4.5+0x32a8db",
+        "libruby.so.3.4.5+0x2326b7",
+        "libruby.so.3.4.5+0x30eac7",
+        "libruby.so.3.4.5+0x313c07",
+        "libruby.so.3.4.5+0x31fe1b",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "<main>+0 in /app/loop.rb:30",
+        "libruby.so.3.4.5+0x3261bb",
+        "libruby.so.3.4.5+0x32a937",
+        "libruby.so.3.4.5+0x2328cb",
+        "libruby.so.3.4.5+0x30d193",
+        "libruby.so.3.4.5+0x313c07",
+        "libruby.so.3.4.5+0x31fe1b",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.4.5+0x325fd3",
+        "libruby.so.3.4.5+0x12b4ff",
+        "libruby.so.3.4.5+0x12f1db",
+        "ruby+0xbaf",
+        "libc.so.6+0x2229b",
+        "libc.so.6+0x2237b",
+        "ruby+0xc2f"
+      ]
+    },
+    {
+      "lwp": 1271706,
+      "frames": [
+        "libc.so.6+0x8efac",
+        "libc.so.6+0x82657",
+        "libc.so.6+0x8269b",
+        "libc.so.6+0xee143",
+        "libruby.so.3.4.5+0x2ca01b",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0xedc1b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "8858b931d041b74a8ce9dcb16d9912eb431c4f55b97ca2e58646a1c1bd991852",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "196abe31779d5aac82a95d641bc95a784944f02d36f068ae06965af393eb965a",
+      "local-path": "/usr/local/lib/ruby/3.4.0/aarch64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "6cec8ec1e84e82980bd5aecba5940b7b77ba971570c5ee9f53299436eb550b4f",
+      "local-path": "/usr/local/lib/ruby/3.4.0/aarch64-linux/monitor.so"
+    },
+    {
+      "ref": "a8afb2d1f4a0c5e14c0fc82f794ec839eafe29738907aa92895410f57630bbe2",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "aa58dc4b16a6f9aed418c8447fc5d36a68672c09fd1729361d1df37792ad7a03",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "6fe00acadf8119ff245855e5dcc7f26c6c0ffaf4bfa2baa88feab58f23727d65",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "fc0165e3cbff299baa266b5531ac9054fff35786bf3ffa46f6eae5650d9bd8c8",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "dc29fcc8450d5fb9cf621d9f7244593a365984af78d1eb102e84828807026305",
+      "local-path": "/usr/local/bin/ruby"
+    },
+    {
+      "ref": "9a146967dc38c3820c5dc21c3209812655f66b6551264072b187bd0e787947e0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "79bbc4b50cfc5bbd6646c6c2a44762ecba6e03907d2d75026707b04041aada6b",
+      "local-path": "/usr/local/lib/libruby.so.3.4.5"
+    },
+    {
+      "ref": "a81171bc355b613ad0504086c1eb9a4ff14c8c6fdd7fc7e49cb5e6eebed830d9",
+      "local-path": "/usr/local/lib/ruby/3.4.0/aarch64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "6025f191bab010ad585ca2044f0b3436a376572c0487bbd57848521f7669f46b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/ruby-3.5.0-loop.json
+++ b/tools/coredump/testdata/arm64/ruby-3.5.0-loop.json
@@ -1,0 +1,96 @@
+{
+  "coredump-ref": "79af6a47057064c87397a21c23307556a9c617e8ac82cc5fb62f3f86f713aa14",
+  "threads": [
+    {
+      "lwp": 1317941,
+      "frames": [
+        "libruby.so.3.5.0+0x301cc8",
+        "libruby.so.3.5.0+0x1c7313",
+        "libruby.so.3.5.0+0x22b18f",
+        "libruby.so.3.5.0+0x31709b",
+        "is_prime+0 in /app/loop.rb:10",
+        "sum_of_primes+0 in /app/loop.rb:20",
+        "<main>+0 in /app/loop.rb:30",
+        "libruby.so.3.5.0+0x31c73f",
+        "libruby.so.3.5.0+0x320eb7",
+        "libruby.so.3.5.0+0x22aa2b",
+        "libruby.so.3.5.0+0x304373",
+        "libruby.so.3.5.0+0x30a927",
+        "libruby.so.3.5.0+0x316b6b",
+        "<main>+0 in /app/loop.rb:29",
+        "ffffffffffffffffffffffffffffffff+0x0",
+        "<main>+0 in /app/loop.rb:28",
+        "libruby.so.3.5.0+0x31c543",
+        "libruby.so.3.5.0+0x127b5f",
+        "libruby.so.3.5.0+0x12b83b",
+        "ruby+0xbef",
+        "libc.so.6+0x2229b",
+        "libc.so.6+0x2237b",
+        "ruby+0xc6f"
+      ]
+    },
+    {
+      "lwp": 1317962,
+      "frames": [
+        "libc.so.6+0x8efac",
+        "libc.so.6+0x82657",
+        "libc.so.6+0x8269b",
+        "libc.so.6+0xee143",
+        "libruby.so.3.5.0+0x2c205b",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0x85f77",
+        "libc.so.6+0xedc1b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "8858b931d041b74a8ce9dcb16d9912eb431c4f55b97ca2e58646a1c1bd991852",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "6025f191bab010ad585ca2044f0b3436a376572c0487bbd57848521f7669f46b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "fc0165e3cbff299baa266b5531ac9054fff35786bf3ffa46f6eae5650d9bd8c8",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "aa2c5f3345202f71a94e5581af00143f38b23aeaf4d2b56c66ef51ad06a51d4e",
+      "local-path": "/usr/local/lib/libruby.so.3.5.0"
+    },
+    {
+      "ref": "eba6caaa74483187d03b249c19e4bfaf78308d4030d717f3208924da5151bd58",
+      "local-path": "/usr/local/lib/ruby/3.5.0+0/aarch64-linux/monitor.so"
+    },
+    {
+      "ref": "fab5778c75462a5e4baa7d1b27651074f2f7d114358340d814f0a097367bd088",
+      "local-path": "/usr/local/bin/ruby"
+    },
+    {
+      "ref": "6fe00acadf8119ff245855e5dcc7f26c6c0ffaf4bfa2baa88feab58f23727d65",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "a8afb2d1f4a0c5e14c0fc82f794ec839eafe29738907aa92895410f57630bbe2",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "9a146967dc38c3820c5dc21c3209812655f66b6551264072b187bd0e787947e0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "aa58dc4b16a6f9aed418c8447fc5d36a68672c09fd1729361d1df37792ad7a03",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "bd00785d3997760250481db9d9ba873319405923cad2d8be43a205c17de60e66",
+      "local-path": "/usr/local/lib/ruby/3.5.0+0/aarch64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "1cbcf3a9eba60e5a1dcde48e530345063626ee8e8ad4206190024b6d05329b7b",
+      "local-path": "/usr/local/lib/ruby/3.5.0+0/aarch64-linux/enc/trans/transdb.so"
+    }
+  ]
+}


### PR DESCRIPTION
Extends the Ruby interpreter support in the eBPF profiler to include Ruby versions 3.3.x, 3.4.x, and 3.5.x. The changes address structural changes in Ruby's internal data structures and symbol visibility changes introduced in these newer versions.

### Changes

#### 1. Extended Version Support
- Added version-specific handling for Ruby 3.3+, 3.4, and 3.5


#### 2. Symbol Resolution Improvements
- Added fallback mechanism to read symbols from the symbol table when `ruby_single_main_ractor` is hidden (Ruby 3.3+)
- Introduced `SymbolAsRanges` helper method in `LoaderInfo` to convert symbols to address ranges

Went back and forth here. Decide to try, as a first step, to attempt to fallback to read the whole symtab, similarly to how is happens today for the [`golabels` interpreter](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/1f99142ab554a909455d6c6b00880466f6cf4a97/interpreter/golabels/tls_amd64.go#L18-L19). 


#### 5. Test Coverage
- Added test data for Ruby 3.3.9, 3.4.5, and 3.5.0-preview1 coredumps with stack traces showing proper resolution of Ruby method names and line numbers
- `arm64` files were capture just fine using the suggested `coredump new -pid $(pgrep ruby) -name the-name-of-the-test.json`
- `amd64` come from a core captured from gdb after setting a breakpoint in the rb_vm_exec function. Couldn't get `coredump new -pid` to work.


### Compatibility
- Maintains backward compatibility with Ruby 2.5 through 3.2
- No breaking changes to existing functionality

### Related Issues

https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/202