### PR TITLE
tools/zstpak: name file in error message

### DIFF
--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -138,7 +138,7 @@ func (store *Store) OpenReadAt(id ID) (*ModuleReader, error) {
 
 	file, err := zstpak.Open(localPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open local file: %w", err)
+		return nil, fmt.Errorf("failed to open local file %s: %w", localPath, err)
 	}
 
 	reader := &ModuleReader{

--- a/tools/zstpak/lib/zstpak.go
+++ b/tools/zstpak/lib/zstpak.go
@@ -183,7 +183,7 @@ func Open(path string) (*Reader, error) {
 
 	hdr, err := readFooter(file, uint64(fileInfo.Size()))
 	if err != nil {
-		return nil, fmt.Errorf("%s: %v,", path, err)
+		return nil, err
 	}
 
 	return &Reader{


### PR DESCRIPTION
If coredump tests fail because of a file with an unexected format, we get the following error:
```
failed to open coredump file reader: failed to open local file: file doesn't appear to be in zstpak format (bad magic)
```
Enrich the returned error message with the file name, to help debug this issue. Now it looks like this:
```
failed to open coredump file reader: failed to open local file: modulecache/09d5bc25045e77dd69e76304b8babc5b0bc85abda959a8c65cd3a3d9b471bdd0: file doesn't appear to be in zstpak format (bad magic)
```