### PR TITLE
Reduce memory consumption of systemProcess.getmappings

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -263,7 +263,7 @@ func (sp *systemProcess) GetMappings() ([]Mapping, uint32, error) {
 		}
 	}
 
-	sp.fileToMapping = make(map[string]*Mapping)
+	fileToMapping := make(map[string]*Mapping)
 	for idx, m := range mappings {
 		path := m.Path.String()
 		if path != "" {


### PR DESCRIPTION
1. `fileToMappings` were allocated with more entries than required.
2. The `mappings` array can now be collected by the GC. Previously, there were references to it and prevented timely GC'ing.

```
$ benchstat old.txt new.txt 
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/ebpf-profiler/process
cpu: AMD Ryzen 7 8845HS w/ Radeon 780M Graphics
                             │   old.txt   │              new.txt               │
                             │   sec/op    │   sec/op     vs base               │
SystemProcess_GetMappings-16   50.42µ ± 7%   46.34µ ± 2%  -8.10% (p=0.000 n=10)

                             │   old.txt    │               new.txt                │
                             │     B/op     │     B/op      vs base                │
SystemProcess_GetMappings-16   9.619Ki ± 1%   6.826Ki ± 0%  -29.04% (p=0.000 n=10)

                             │   old.txt   │              new.txt               │
                             │  allocs/op  │ allocs/op   vs base                │
SystemProcess_GetMappings-16   11.000 ± 0%   9.000 ± 0%  -18.18% (p=0.000 n=10)
```

The quick&dirty benchmark code
```Go
func BenchmarkSystemProcess_GetMappings(b *testing.B) {
       pid := libpf.PID(os.Getpid())
       pr := New(pid, pid)

       b.ReportAllocs()
       b.ResetTimer()

       for b.Loop() {
               _, _, err := pr.GetMappings()
               if err != nil {
                       b.Fatal(err)
               }
       }
}
```