### PR TITLE
reporter: drop HostMetadataReporter

### DIFF
--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -6,7 +6,6 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"context"
 
-	lru "github.com/elastic/go-freelru"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 
@@ -28,14 +27,6 @@ type CollectorReporter struct {
 
 // NewCollector builds a new CollectorReporter
 func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorReporter, error) {
-	// Next step: Dynamically configure the size of this LRU.
-	// Currently, we use the length of the JSON array in
-	// hostmetadata/hostmetadata.json.
-	hostmetadata, err := lru.NewSynced[string, string](115, hashString)
-	if err != nil {
-		return nil, err
-	}
-
 	data, err := pdata.New(
 		cfg.SamplesPerSecond,
 		cfg.ExecutablesCacheElements,
@@ -49,12 +40,11 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 
 	return &CollectorReporter{
 		baseReporter: &baseReporter{
-			cfg:          cfg,
-			name:         cfg.Name,
-			version:      cfg.Version,
-			pdata:        data,
-			traceEvents:  xsync.NewRWMutex(tree),
-			hostmetadata: hostmetadata,
+			cfg:         cfg,
+			name:        cfg.Name,
+			version:     cfg.Version,
+			pdata:       data,
+			traceEvents: xsync.NewRWMutex(tree),
 			runLoop: &runLoop{
 				stopSignal: make(chan libpf.Void),
 			},

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -5,7 +5,6 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/process"
@@ -16,7 +15,6 @@ import (
 type Reporter interface {
 	TraceReporter
 	SymbolReporter
-	HostMetadataReporter
 
 	// Start starts the reporter in the background.
 	//
@@ -76,13 +74,4 @@ type SymbolReporter interface {
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
 	ExecutableMetadata(args *ExecutableMetadataArgs)
-}
-
-type HostMetadataReporter interface {
-	// ReportHostMetadata enqueues host metadata for sending (to the collection agent).
-	ReportHostMetadata(metadataMap map[string]string)
-
-	// ReportHostMetadataBlocking sends host metadata to the collection agent.
-	ReportHostMetadataBlocking(ctx context.Context, metadataMap map[string]string,
-		maxRetries int, waitRetry time.Duration) error
 }


### PR DESCRIPTION
With HostMetadataReporter host specific attributes were reported in the past. Remove this interface, as this is no longer the case and the interface just allocates memory without using it.