### PR TITLE
CI: add manual trigger for docker image

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,6 +1,7 @@
 name: "Update builder docker image"
 
 on:
+  workflow_dispatch: # Allows manual triggering of the workflow
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
Allow users with write permission to manually trigger this workflow.

Currently, the docker build image is only updated, if `Dockerfile` changes. As the Go version was bumped with a recent change, the Go version used in the generate Docker image is not up to date. As a consequence, when the current docker image is used it first has to update its Go version before being able to build everything. Depending on the network connection and processing power, this additional step can introduce noticeable delays.

The suggestion is to allow users with write permission to trigger the generation of new images instead of triggering new images based on changes in `go.mod`, as dependencies are constantly updated and therefore would generate significant noise if with every dependency update also the builder image was updated.