### PR TITLE
Make Go label collection work for stripped binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-deps:
 
 TEST_INTEGRATION_BINARY_DIRS := tracer processmanager/ebpf support interpreter/golabels/integrationtests
 
-pprof-execs: pprof_1_23 pprof_1_24 pprof_1_24_cgo
+pprof-execs: pprof_1_23 pprof_1_24 pprof_1_24_cgo pprof_1_24_cgo_stripped
 
 pprof_1_23:
 	CGO_ENABLED=0 GOTOOLCHAIN=go1.23.7 go test -C ./interpreter/golabels/integrationtests/pprof -c -trimpath -tags $(GO_TAGS),nocgo,integration -o ./../$@
@@ -132,6 +132,9 @@ pprof_1_24:
 
 pprof_1_24_cgo:
 	CGO_ENABLED=1 GOTOOLCHAIN=go1.24.6 go test -C ./interpreter/golabels/integrationtests/pprof -c -ldflags '-extldflags "-static"' -trimpath -tags $(GO_TAGS),withcgo,integration -o ./../$@
+
+pprof_1_24_cgo_stripped:
+	CGO_ENABLED=1 GOTOOLCHAIN=go1.24.6 go test -C ./interpreter/golabels/integrationtests/pprof -c -trimpath -ldflags='-s -w' -tags $(GO_TAGS),withcgo,integration -o ./../$@
 
 integration-test-binaries: generate ebpf pprof-execs
 	$(foreach test_name, $(TEST_INTEGRATION_BINARY_DIRS), \

--- a/interpreter/golabels/integrationtests/golabels_integration_test.go
+++ b/interpreter/golabels/integrationtests/golabels_integration_test.go
@@ -33,6 +33,9 @@ var (
 
 	//go:embed pprof_1_24_cgo
 	pprof_1_24_cgo []byte
+
+	//go:embed pprof_1_24_cgo_stripped
+	pprof_1_24_cgo_stripped []byte
 )
 
 type mockIntervals struct{}
@@ -58,9 +61,10 @@ func Test_Golabels(t *testing.T) {
 	tests := map[string]struct {
 		bin []byte
 	}{
-		"pprof_1_23":     {bin: pprof_1_23},
-		"pprof_1_24":     {bin: pprof_1_24},
-		"pprof_1_24_cgo": {bin: pprof_1_24_cgo},
+		"pprof_1_23":              {bin: pprof_1_23},
+		"pprof_1_24":              {bin: pprof_1_24},
+		"pprof_1_24_cgo":          {bin: pprof_1_24_cgo},
+		"pprof_1_24_cgo_stripped": {bin: pprof_1_24_cgo_stripped},
 	}
 
 	for name, tc := range tests {

--- a/interpreter/golabels/tls_amd64.go
+++ b/interpreter/golabels/tls_amd64.go
@@ -8,6 +8,7 @@ package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabe
 import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/nativeunwind/elfunwindinfo"
 	"golang.org/x/arch/x86/x86asm"
 )
 
@@ -16,19 +17,32 @@ import (
 // may be dynamic relocating going on so just read it from a known
 // symbol if possible.
 func extractTLSGOffset(f *pfelf.File) (int32, error) {
-	syms, err := f.ReadSymbols()
-	if err != nil {
-		return 0, err
+	var funcAddr int64
+
+	if syms, err := f.ReadSymbols(); err != nil {
+		gopclntab, err := elfunwindinfo.NewGopclntab(f)
+		if err != nil {
+			return 0, err
+		}
+		defer gopclntab.Close()
+		funcPc, err := gopclntab.LookupFunction("runtime.stackcheck")
+		if err != nil {
+			return 0, err
+		}
+		funcAddr = int64(funcPc)
+	} else {
+		sym, err := syms.LookupSymbol("runtime.stackcheck.abi0")
+		if err != nil {
+			// Binary must be stripped, hope default is correct and warn.
+			log.Warnf("Failed to find stackcheck symbol, Go labels might not work: %v", err)
+			return -8, err
+		}
+		funcAddr = int64(sym.Address)
 	}
+
 	// Dump of assembler code for function runtime.stackcheck:
 	// 0x0000000000470080 <+0>:     mov    %fs:0xfffffffffffffff8,%rax
-	sym, err := syms.LookupSymbol("runtime.stackcheck.abi0")
-	if err != nil {
-		// Binary must be stripped, hope default is correct and warn.
-		log.Warnf("Failed to find stackcheck symbol, Go labels might not work: %v", err)
-		return -8, nil
-	}
-	b, err := f.VirtualMemory(int64(sym.Address), 10, 10)
+	b, err := f.VirtualMemory(funcAddr, 10, 10)
 	if err != nil {
 		return 0, err
 	}

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -10,6 +10,7 @@ package elfunwindinfo // import "go.opentelemetry.io/ebpf-profiler/nativeunwind/
 import (
 	"bytes"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"go/version"
 	"io"
@@ -496,6 +497,17 @@ func (g *Gopclntab) mapPcval(offs int32, startPc, pc uint) (int32, bool) {
 		}
 	}
 	return p.val, true
+}
+
+func (g *Gopclntab) LookupFunction(funcName string) (uintptr, error) {
+	for i := 0; i < g.numFuncs; i++ {
+		mapPc, funcOff := g.getFuncMapEntry(i)
+		funcPc, fun := g.getFunc(funcOff)
+		if fun != nil && mapPc == funcPc && getString(g.funcnametab, int(fun.nameOff)) == funcName {
+			return funcPc, nil
+		}
+	}
+	return 0, errors.New("function not found")
 }
 
 // Symbolize returns the file, line and function information for given PC


### PR DESCRIPTION
Use gopclntab to retrieve the runtime.stackcheck / runtime.load_g symbol address when the binary is stripped.

Symbol lookup is currently implemented inefficiently by iterating over the gopclntab functions.