### PR TITLE
golabels: fix race condition

### DIFF
--- a/interpreter/golabels/integrationtests/golabels_integration_test.go
+++ b/interpreter/golabels/integrationtests/golabels_integration_test.go
@@ -113,7 +113,12 @@ func Test_Golabels(t *testing.T) {
 
 			go func() {
 				if err := exec.CommandContext(ctx, exe.Name()).Run(); err != nil {
-					t.Log(err)
+					select {
+					case <-ctx.Done():
+						// Context is canceled, meaning the test is done.
+					default:
+						t.Log(err)
+					}
 				}
 			}()
 


### PR DESCRIPTION
In the integration tests for golabels, we do see sporatic race conditions:

```
panic: Log in goroutine after Test_Golabels/pprof_1_24_cgo has completed: signal: killed

goroutine 88 [running]:
testing.(*common).logDepth(0xc0010cf340, {0xc002073570, 0xf}, 0x3)
	testing/testing.go:1064 +0x4b4
testing.(*common).log(...)
	testing/testing.go:1046
testing.(*common).Log(0xc0010cf340, {0xc000083fc0?, 0xc000013f90?, 0x0?})
	testing/testing.go:1087 +0x4a
go.opentelemetry.io/ebpf-profiler/interpreter/golabels/integrationtests.Test_Golabels.func1.1()
	go.opentelemetry.io/ebpf-profiler/interpreter/golabels/integrationtests/golabels_integration_test.go:116 +0x79
created by go.opentelemetry.io/ebpf-profiler/interpreter/golabels/integrationtests.Test_Golabels.func1 in goroutine 63
	go.opentelemetry.io/ebpf-profiler/interpreter/golabels/integrationtests/golabels_integration_test.go:114 +0x4f9
```

To avoid these panics, stop calling t.Log() if the context was canceled.