### PR TITLE
proposal: FileOpener interface in executable metadata

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -604,7 +604,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 
 		exeReporter.ReportExecutable(&reporter.ExecutableMetadata{
 			MappingFile: info.file,
-			Process:     pr,
+			Opener:      pr,
 			Mapping:     m,
 		})
 

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -161,6 +162,20 @@ type Section struct {
 
 	// elfReader is the same ReadAt as used for the File
 	elfReader io.ReaderAt
+}
+
+func OpenFromFile(osFile *os.File) (*File, error) {
+	f, err := mmap.OpenFromFile(osFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ff, err := newFile(f, f, 0, false)
+	if err != nil {
+		_ = ff.Close()
+		return nil, err
+	}
+	return ff, nil
 }
 
 // Open opens the named file using os.Open and prepares it for use as an ELF binary.

--- a/libpf/pfelf/internal/mmap/mmap.go
+++ b/libpf/pfelf/internal/mmap/mmap.go
@@ -83,13 +83,17 @@ func (r *ReaderAt) Subslice(offset, length int) ([]byte, error) {
 	return unsafe.Slice((*byte)(unsafe.Pointer(&r.data[offset])), length), nil
 }
 
-// Open memory-maps the named file for reading.
 func Open(filename string) (*ReaderAt, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
+	return OpenFromFile(f)
+}
+
+// Open memory-maps the named file for reading.
+func OpenFromFile(f *os.File) (*ReaderAt, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err
@@ -107,10 +111,10 @@ func Open(filename string) (*ReaderAt, error) {
 		}, nil
 	}
 	if size < 0 {
-		return nil, fmt.Errorf("mmap: file %q has negative size", filename)
+		return nil, fmt.Errorf("mmap: file %q has negative size", f.Name())
 	}
 	if size != int64(int(size)) {
-		return nil, fmt.Errorf("mmap: file %q is too large", filename)
+		return nil, fmt.Errorf("mmap: file %q is too large", f.Name())
 	}
 
 	data, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -317,6 +317,11 @@ func (cd *CoredumpProcess) ExtractAsFile(_ string) (string, error) {
 	return "", errors.New("coredump does not support opening backing file")
 }
 
+// OpenFile implements the Process interface.
+func (cf *CoredumpProcess) OpenFile(file string) (ProcessFile, error) {
+	return nil, errors.New("coredump does not support opening file")
+}
+
 // getFile returns (creating if needed) a matching CoredumpFile for given file name.
 func (cd *CoredumpProcess) getFile(name string) *CoredumpFile {
 	if cf, ok := cd.files[name]; ok {

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -79,6 +79,10 @@ func (d *dummyProcess) ExtractAsFile(name string) (string, error) {
 	return name, nil
 }
 
+func (d *dummyProcess) OpenFile(file string) (process.ProcessFile, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (d *dummyProcess) Close() error {
 	return nil
 }

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -372,7 +372,7 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 
 	pm.exeReporter.ReportExecutable(&reporter.ExecutableMetadata{
 		MappingFile:       info.mappingFile,
-		Process:           pr,
+		Opener:            pr,
 		Mapping:           mapping,
 		DebuglinkFileName: ef.DebuglinkFileName(elfRef.FileName(), elfRef),
 	})

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -33,12 +33,17 @@ type TraceReporter interface {
 	ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceEventMeta) error
 }
 
+type FileOpener interface {
+	// OpenFile opens the given file from the process namespace.
+	OpenFile(file string) (process.ProcessFile, error)
+}
+
 type ExecutableMetadata struct {
 	// MappingFile is the reference to mapping file data.
 	MappingFile libpf.FrameMappingFile
 
 	// Process is the interface to the process holding the file.
-	Process process.Process
+	Opener FileOpener
 
 	// Mapping is the process.Mapping file. Process.OpenMappingFile can be used
 	// to open the file if needed.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/periodiccaller"
 	pm "go.opentelemetry.io/ebpf-profiler/processmanager"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpf"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/rlimit"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -114,6 +115,8 @@ type Config struct {
 	Intervals Intervals
 	// IncludeTracers holds information about which tracers are enabled.
 	IncludeTracers types.IncludedTracers
+	// Reporter provides a way to report executable metadata to the reporter.
+	Reporter reporter.ExecutableReporter
 	// SamplesPerSecond holds the number of samples per second.
 	SamplesPerSecond int
 	// MapScaleFactor is the scaling factor for eBPF map sizes.
@@ -195,7 +198,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	hasBatchOperations := ebpfHandler.SupportsGenericBatchOperations()
 
 	processManager, err := pm.New(ctx, cfg.IncludeTracers, cfg.Intervals.MonitorInterval(),
-		ebpfHandler, nil, nil, elfunwindinfo.NewStackDeltaProvider(),
+		ebpfHandler, nil, cfg.Reporter, elfunwindinfo.NewStackDeltaProvider(),
 		cfg.FilterErrorFrames, cfg.IncludeEnvVars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)


### PR DESCRIPTION
This change introduces `FileOpener` interface allows to open any file in the target process namespace.

The goal is to provide the necessary API to easily find and upload (separate) symbol files.

It returns a `ProcessFile` interface that provides:
    - a ReadAtCloser interface to access raw file data
    - an openable path that remains valid even after process exit
    - an `*os.File` that allows to open a `pfelf.File` with mmap

For vdso, openable path / os.File are not provided.
