### PR TITLE
CI: update renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
   "postUpdateOptions" : [
     "gomodTidy"
   ],
+  "ignorePaths": ["LICENSES/**"],
   "packageRules": [
     {
       "groupName": "Go dependencies",
@@ -24,7 +25,6 @@
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "schedule": ["before 8am every weekday"],
-      "ignorePaths": ["**/LICENSES/**"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Unfortunately #753 shows that this new instruction is not followed by renovate. Therefore, promote `ignorePaths` to a higher level.