### PR TITLE
feat: add Go buildID to profile attributes

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -190,6 +190,9 @@ func (p *Pdata) setProfile(
 						semconv.ProcessExecutableBuildIDGNUKey,
 						mf.GnuBuildID)
 					attrMgr.AppendOptionalString(mapping.AttributeIndices(),
+						semconv.ProcessExecutableBuildIDGoKey,
+						mf.GoBuildID)
+					attrMgr.AppendOptionalString(mapping.AttributeIndices(),
 						semconv.ProcessExecutableBuildIDHtlhashKey,
 						mf.FileID.StringNoQuotes())
 				}


### PR DESCRIPTION
Followup to https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/731