### PR TITLE
go: open executable for symbolization on demand

### DIFF
--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -647,6 +647,12 @@ const (
 	// Number of failures reading Go custom labels
 	IDUnwindGoLabelsFailures = 279
 
+	// Number of cache hits for Go symbols
+	IDGoSymbolCacheHit = 280
+
+	// Number of cache misses for Go symbols
+	IDGoSymbolCacheMiss = 281
+
 	// max number of ID values, keep this as *last entry*
-	IDMax = 280
+	IDMax = 282
 )

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -2015,5 +2015,19 @@
     "name": "UnwindGoLabelsFailures",
     "field": "bpf.golabels.errors",
     "id": 279
+  },
+  {
+   "description": "Number of cache hits for Go symbols",
+   "type": "counter",
+   "name": "GoSymbolCacheHit",
+   "field": "agent.go.symbol_cache.hits",
+   "id": 280
+  },
+  {
+   "description": "Number of cache misses for Go symbols",
+   "type": "counter",
+   "name": "GoSymbolCacheMiss",
+   "field": "agent.go.symbol_cache.misses",
+   "id": 281
   }
 ]


### PR DESCRIPTION
Go executables, when memory-mapped, contribute to a notable increase in Resident Set Size (RSS) values. This can lead to significant memory consumption, posing challenges with Kubernetes' maximum memory limits and potentially causing Out Of Memory (OOM) errors, especially with a growing number and size of these executables.