### PR TITLE
ebpf-profiler: use noop.meter

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,9 +16,11 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
+	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/vc"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -100,6 +102,8 @@ func mainWithExitCode() exitCode {
 
 	intervals := times.New(cfg.ReporterInterval,
 		cfg.MonitorInterval, cfg.ProbabilisticInterval)
+
+	metrics.Start(noop.Meter{})
 
 	rep, err := reporter.NewOTLP(&reporter.Config{
 		Name:                   os.Args[0],


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/758 started to expose internal metrics via the telemetry settings of the OTel collector.

When using the binary ebpf-profiler, use a noop.meter to avoid verbose logging of the metrics package.