### PR TITLE
Deduplicate Stack messages

### DIFF
--- a/reporter/internal/pdata/helper.go
+++ b/reporter/internal/pdata/helper.go
@@ -10,8 +10,13 @@ type locationInfo struct {
 	functionIndex int32
 }
 
-// funcInfo is a helper to construct profile.Function messages.
+// funcInfo is a helper used to deduplicate Functions.
 type funcInfo struct {
 	nameIdx     int32
 	fileNameIdx int32
+}
+
+// stackInfo is a helper used to deduplicate Stacks.
+type stackInfo struct {
+	locationIndices string
 }


### PR DESCRIPTION
Protocol v1.8.0 introduces a new `Stack` message. This PR adds deduplication for such messages.

Fixes: #808

**TODO:**
- ~Add some tests~
