### PR TITLE
Custom executable reporter

### DIFF
--- a/collector/factory.go
+++ b/collector/factory.go
@@ -4,23 +4,16 @@
 package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 
 import (
-	"context"
-	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
-
-	"go.opentelemetry.io/ebpf-profiler/collector/internal"
-	"go.opentelemetry.io/ebpf-profiler/internal/controller"
+	"go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
 )
 
 var (
 	typeStr = component.MustNewType("profiling")
-
-	errInvalidConfig = errors.New("invalid config")
 )
 
 // NewFactory creates a factory for the receiver.
@@ -28,24 +21,11 @@ func NewFactory() receiver.Factory {
 	return xreceiver.NewFactory(
 		typeStr,
 		defaultConfig,
-		xreceiver.WithProfiles(createProfilesReceiver, component.StabilityLevelAlpha))
-}
-
-func createProfilesReceiver(
-	_ context.Context,
-	rs receiver.Settings,
-	baseCfg component.Config,
-	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
-	cfg, ok := baseCfg.(*controller.Config)
-	if !ok {
-		return nil, errInvalidConfig
-	}
-
-	return internal.NewController(cfg, rs, nextConsumer)
+		xreceiver.WithProfiles(receiverhelper.CreateProfilesReceiver, component.StabilityLevelAlpha))
 }
 
 func defaultConfig() component.Config {
-	return &controller.Config{
+	return &receiverhelper.Config{
 		ReporterInterval:       5 * time.Second,
 		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -4,9 +4,11 @@
 package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 
 import (
+	"context"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
 	"go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
@@ -21,7 +23,20 @@ func NewFactory() receiver.Factory {
 	return xreceiver.NewFactory(
 		typeStr,
 		defaultConfig,
-		xreceiver.WithProfiles(receiverhelper.CreateProfilesReceiver, component.StabilityLevelAlpha))
+		xreceiver.WithProfiles(createProfilesReceiver, component.StabilityLevelAlpha))
+}
+
+func createProfilesReceiver(
+	ctx context.Context,
+	rs receiver.Settings,
+	baseCfg component.Config,
+	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
+	return receiverhelper.BuildProfilesReceiver(
+		ctx,
+		rs,
+		baseCfg,
+		nextConsumer,
+	)
 }
 
 func defaultConfig() component.Config {

--- a/collector/factory_test.go
+++ b/collector/factory_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
 )
 
 func TestNewFactory(t *testing.T) {
@@ -30,7 +31,7 @@ func TestCreateProfilesReceiver(t *testing.T) {
 		},
 		{
 			name:      "Nil config",
-			wantError: errInvalidConfig,
+			wantError: receiverhelper.ErrInvalidConfig,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -27,8 +27,20 @@ type Controller struct {
 	ctlr *controller.Controller
 }
 
+// Option is a function that allows to configure a ControllerOption.
+type Option func(*ControllerOption)
+
+// ControllerOption is the extra configuration for the controller.
+type ControllerOption struct {
+	ExecutableReporter reporter.ExecutableReporter
+}
+
 func NewController(cfg *controller.Config, rs receiver.Settings,
-	nextConsumer xconsumer.Profiles) (*Controller, error) {
+	nextConsumer xconsumer.Profiles, opts ...Option) (*Controller, error) {
+	controllerOption := ControllerOption{}
+	for _, opt := range opts {
+		opt(&controllerOption)
+	}
 	intervals := times.New(cfg.ReporterInterval,
 		cfg.MonitorInterval, cfg.ProbabilisticInterval)
 
@@ -47,6 +59,7 @@ func NewController(cfg *controller.Config, rs receiver.Settings,
 		return nil, err
 	}
 	cfg.Reporter = rep
+	cfg.ExecutableReporter = controllerOption.ExecutableReporter
 
 	// Provide internal metrics via the collectors telemetry.
 	meter := rs.MeterProvider.Meter(ctrlName)

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -24,8 +24,7 @@ const (
 // Controller is a bridge between the Collector's [receiverprofiles.Profiles]
 // interface and our [internal.Controller]
 type Controller struct {
-	ctlr       *controller.Controller
-	onShutdown func()
+	ctlr *controller.Controller
 }
 
 // Option is a function that allows to configure a ControllerOption.
@@ -36,7 +35,6 @@ type Option interface {
 // ControllerOption is the extra configuration for the controller.
 type ControllerOption struct {
 	ExecutableReporter reporter.ExecutableReporter
-	OnShutdown         func()
 	ReporterFactory    func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)
 }
 
@@ -76,8 +74,7 @@ func NewController(cfg *controller.Config, rs receiver.Settings,
 	metrics.Start(meter)
 
 	return &Controller{
-		ctlr:       controller.New(cfg),
-		onShutdown: controllerOption.OnShutdown,
+		ctlr: controller.New(cfg),
 	}, nil
 }
 
@@ -88,9 +85,6 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 
 // Shutdown stops the receiver.
 func (c *Controller) Shutdown(_ context.Context) error {
-	if c.onShutdown != nil {
-		c.onShutdown()
-	}
 	c.ctlr.Shutdown()
 	return nil
 }

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -29,7 +29,9 @@ type Controller struct {
 }
 
 // Option is a function that allows to configure a ControllerOption.
-type Option func(*ControllerOption)
+type Option interface {
+	Apply(*ControllerOption) *ControllerOption
+}
 
 // ControllerOption is the extra configuration for the controller.
 type ControllerOption struct {
@@ -40,12 +42,12 @@ type ControllerOption struct {
 
 func NewController(cfg *controller.Config, rs receiver.Settings,
 	nextConsumer xconsumer.Profiles, opts ...Option) (*Controller, error) {
-	controllerOption := ControllerOption{}
+	controllerOption := &ControllerOption{}
 	controllerOption.ReporterFactory = func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error) {
 		return reporter.NewCollector(cfg, nextConsumer)
 	}
 	for _, opt := range opts {
-		opt(&controllerOption)
+		controllerOption = opt.Apply(controllerOption)
 	}
 	intervals := times.New(cfg.ReporterInterval,
 		cfg.MonitorInterval, cfg.ProbabilisticInterval)

--- a/collector/receiverhelper/options.go
+++ b/collector/receiverhelper/options.go
@@ -14,3 +14,10 @@ func WithExecutableReporter(executableReporter reporter.ExecutableReporter) inte
 		option.ExecutableReporter = executableReporter
 	}
 }
+
+// WithOnShutdown is a function that allows to define a callback to be called when the controller is shutdown.
+func WithOnShutdown(onShutdown func()) internal.Option {
+	return func(option *internal.ControllerOption) {
+		option.OnShutdown = onShutdown
+	}
+}

--- a/collector/receiverhelper/options.go
+++ b/collector/receiverhelper/options.go
@@ -9,23 +9,30 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
 
+type optFunc func(*internal.ControllerOption) *internal.ControllerOption
+
+func (f optFunc) Apply(c *internal.ControllerOption) *internal.ControllerOption { return f(c) }
+
 // WithExecutableReporter is a function that allows to configure a ExecutableReporter.
 func WithExecutableReporter(executableReporter reporter.ExecutableReporter) internal.Option {
-	return func(option *internal.ControllerOption) {
+	return optFunc(func(option *internal.ControllerOption) *internal.ControllerOption {
 		option.ExecutableReporter = executableReporter
-	}
+		return option
+	})
 }
 
 // WithOnShutdown is a function that allows to define a callback to be called when the controller is shutdown.
 func WithOnShutdown(onShutdown func()) internal.Option {
-	return func(option *internal.ControllerOption) {
+	return optFunc(func(option *internal.ControllerOption) *internal.ControllerOption {
 		option.OnShutdown = onShutdown
-	}
+		return option
+	})
 }
 
 // WithReporterFactory is a function that allows to define a custom collector reporter factory.
 func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)) internal.Option {
-	return func(option *internal.ControllerOption) {
+	return optFunc(func(option *internal.ControllerOption) *internal.ControllerOption {
 		option.ReporterFactory = reporterFactory
-	}
+		return option
+	})
 }

--- a/collector/receiverhelper/options.go
+++ b/collector/receiverhelper/options.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receiverhelper // import "go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
+
+import (
+	"go.opentelemetry.io/ebpf-profiler/collector/internal"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+)
+
+// WithExecutableReporter is a function that allows to configure a ExecutableReporter.
+func WithExecutableReporter(executableReporter reporter.ExecutableReporter) internal.Option {
+	return func(option *internal.ControllerOption) {
+		option.ExecutableReporter = executableReporter
+	}
+}

--- a/collector/receiverhelper/options.go
+++ b/collector/receiverhelper/options.go
@@ -21,14 +21,6 @@ func WithExecutableReporter(executableReporter reporter.ExecutableReporter) inte
 	})
 }
 
-// WithOnShutdown is a function that allows to define a callback to be called when the controller is shutdown.
-func WithOnShutdown(onShutdown func()) internal.Option {
-	return optFunc(func(option *internal.ControllerOption) *internal.ControllerOption {
-		option.OnShutdown = onShutdown
-		return option
-	})
-}
-
 // WithReporterFactory is a function that allows to define a custom collector reporter factory.
 func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)) internal.Option {
 	return optFunc(func(option *internal.ControllerOption) *internal.ControllerOption {

--- a/collector/receiverhelper/options.go
+++ b/collector/receiverhelper/options.go
@@ -4,6 +4,7 @@
 package receiverhelper // import "go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
 
 import (
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/collector/internal"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
@@ -19,5 +20,12 @@ func WithExecutableReporter(executableReporter reporter.ExecutableReporter) inte
 func WithOnShutdown(onShutdown func()) internal.Option {
 	return func(option *internal.ControllerOption) {
 		option.OnShutdown = onShutdown
+	}
+}
+
+// WithReporterFactory is a function that allows to define a custom collector reporter factory.
+func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)) internal.Option {
+	return func(option *internal.ControllerOption) {
+		option.ReporterFactory = reporterFactory
 	}
 }

--- a/collector/receiverhelper/options_test.go
+++ b/collector/receiverhelper/options_test.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receiverhelper // import "go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
+	"go.opentelemetry.io/ebpf-profiler/collector/internal"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
+)
+
+func TestWithExecutableReporter(t *testing.T) {
+	executableReporter := &executableReporterTest{}
+	option := WithExecutableReporter(executableReporter)
+	require.Equal(t, executableReporter, option.Apply(&internal.ControllerOption{}).ExecutableReporter)
+}
+
+func TestWithReporterFactory(t *testing.T) {
+	reporterFactory := func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error) {
+		return &reporterTest{}, nil
+	}
+	option := WithReporterFactory(reporterFactory)
+	returnedFactory := option.Apply(&internal.ControllerOption{}).ReporterFactory
+	require.Equal(t, reflect.ValueOf(reporterFactory).Pointer(), reflect.ValueOf(returnedFactory).Pointer())
+}
+
+// empty struct that implements the ExecutableReporter interface
+type executableReporterTest struct{}
+
+func (e *executableReporterTest) ReportExecutable(args *reporter.ExecutableMetadata) {}
+
+// empty struct that implements the Reporter interface
+type reporterTest struct{}
+
+func (r *reporterTest) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceEventMeta) error {
+	return nil
+}
+
+func (r *reporterTest) Start(ctx context.Context) error {
+	return nil
+}
+
+func (r *reporterTest) Stop() {}

--- a/collector/receiverhelper/receiverhelper.go
+++ b/collector/receiverhelper/receiverhelper.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receiverhelper // import "go.opentelemetry.io/ebpf-profiler/collector/receiverhelper"
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
+
+	"go.opentelemetry.io/ebpf-profiler/collector/internal"
+	"go.opentelemetry.io/ebpf-profiler/internal/controller"
+)
+
+var (
+	errInvalidConfig = errors.New("invalid config")
+)
+
+func CreateProfilesReceiver(
+	_ context.Context,
+	rs receiver.Settings,
+	baseCfg component.Config,
+	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
+	cfg, ok := baseCfg.(*Config)
+	if !ok {
+		return nil, errInvalidConfig
+	}
+
+	controlerCfg := controller.Config{
+		ReporterInterval:       cfg.ReporterInterval,
+		MonitorInterval:        cfg.MonitorInterval,
+		SamplesPerSecond:       cfg.SamplesPerSecond,
+		ProbabilisticInterval:  cfg.ProbabilisticInterval,
+		ProbabilisticThreshold: cfg.ProbabilisticThreshold,
+		Tracers:                cfg.Tracers,
+		ClockSyncInterval:      cfg.ClockSyncInterval,
+		SendErrorFrames:        cfg.SendErrorFrames,
+		VerboseMode:            cfg.VerboseMode,
+		OffCPUThreshold:        cfg.OffCPUThreshold,
+		IncludeEnvVars:         cfg.IncludeEnvVars,
+	}
+	return internal.NewController(&controlerCfg, rs, nextConsumer)
+}
+
+type Config struct {
+	ReporterInterval       time.Duration `mapstructure:"reporter_interval"`
+	MonitorInterval        time.Duration `mapstructure:"monitor_interval"`
+	SamplesPerSecond       int           `mapstructure:"samples_per_second"`
+	ProbabilisticInterval  time.Duration `mapstructure:"probabilistic_interval"`
+	ProbabilisticThreshold uint          `mapstructure:"probabilistic_threshold"`
+	Tracers                string        `mapstructure:"tracers"`
+	ClockSyncInterval      time.Duration `mapstructure:"clock_sync_interval"`
+	SendErrorFrames        bool          `mapstructure:"send_error_frames"`
+	VerboseMode            bool          `mapstructure:"verbose_mode"`
+	OffCPUThreshold        float64       `mapstructure:"off_cpu_threshold"`
+	IncludeEnvVars         string        `mapstructure:"include_env_vars"`
+}

--- a/collector/receiverhelper/receiverhelper.go
+++ b/collector/receiverhelper/receiverhelper.go
@@ -18,17 +18,21 @@ import (
 )
 
 var (
-	errInvalidConfig = errors.New("invalid config")
+	// ErrInvalidConfig is returned when the config is invalid.
+	ErrInvalidConfig = errors.New("invalid config")
 )
 
-func CreateProfilesReceiver(
+// BuildProfilesReceiver builds a profiles receiver.
+// It creates a controller with the provided config and options.
+func BuildProfilesReceiver(
 	_ context.Context,
 	rs receiver.Settings,
 	baseCfg component.Config,
-	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
+	nextConsumer xconsumer.Profiles,
+	opts ...internal.Option) (xreceiver.Profiles, error) {
 	cfg, ok := baseCfg.(*Config)
 	if !ok {
-		return nil, errInvalidConfig
+		return nil, ErrInvalidConfig
 	}
 
 	controlerCfg := controller.Config{
@@ -44,9 +48,10 @@ func CreateProfilesReceiver(
 		OffCPUThreshold:        cfg.OffCPUThreshold,
 		IncludeEnvVars:         cfg.IncludeEnvVars,
 	}
-	return internal.NewController(&controlerCfg, rs, nextConsumer)
+	return internal.NewController(&controlerCfg, rs, nextConsumer, opts...)
 }
 
+// Config is the configuration for the profiles receiver.
 type Config struct {
 	ReporterInterval       time.Duration `mapstructure:"reporter_interval"`
 	MonitorInterval        time.Duration `mapstructure:"monitor_interval"`

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -35,7 +35,8 @@ type Config struct {
 	UProbeLinks            []string
 	LoadProbe              bool
 
-	Reporter reporter.Reporter
+	Reporter           reporter.Reporter
+	ExecutableReporter reporter.ExecutableReporter
 
 	Fs *flag.FlagSet
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -99,6 +99,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		IncludeEnvVars:         envVars,
 		UProbeLinks:            c.config.UProbeLinks,
 		LoadProbe:              c.config.LoadProbe,
+		ExecutableReporter:     c.config.ExecutableReporter,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load eBPF tracer: %w", err)


### PR DESCRIPTION
# Description

This PR introduces several improvements to the OpenTelemetry eBPF profiler's collector and reporter system:
- Executable Reporter configuration: Added support for configuring an Executable Reporter
- OTEL config integration: Made receiver configuration configurable directly from OpenTelemetry configuration files
- Configurable CollectorReporter: Added configuration options for the CollectorReporter to allow more flexible setup

Note: 
 - reviewing commit by commit is recommended.
 - This PR replace https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/769

# Usage
```go
func NewFactory() receiver.Factory {
	return xreceiver.NewFactory(
		typeStr,
		defaultConfig,
		xreceiver.WithProfiles(createProfilesReceiver, component.StabilityLevelAlpha))
}

func createProfilesReceiver(
	ctx context.Context,
	rs receiver.Settings,
	baseCfg component.Config,
	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
	config, ok := baseCfg.(Config)
	if !ok {
		return nil, errors.New("invalid config type")
	}
	
	executableReporter := &CustomExecutableReporter{
		ExtraFields: config.ExtraFields,
	}

	return receiverhelper.BuildProfilesReceiver(
		ctx,
		rs,
		config.Config,
		nextConsumer,
		receiverhelper.WithExecutableReporter(executableReporter),
		receiverhelper.WithOnShutdown(func() {
			executableReporter.Stop()
		}),
		receiverhelper.WithReporterFactory(func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error) {
			return reporter.NewCollector(cfg, nextConsumer)
		}),
	)
}

// Custom configuration with extra field to configure the executable reporter
type Config struct {
	*receiverhelper.Config `mapstructure:",squash"`
	ExtraFields             string `mapstructure:"extra_field"`
}

func defaultConfig() component.Config {
	cfg := ebpfcollector.NewFactory().CreateDefaultConfig().(*receiverhelper.Config)

	return Config{
		Config:     cfg,
		ExtraFields: "extra_field",
	}
}


// Custom executable reporter
type CustomExecutableReporter struct {
	ExtraFields string
}

func (m *CustomExecutableReporter) ReportExecutable(args *reporter.ExecutableMetadata) {
	fmt.Println("ReportExecutable", args)
}

func (m *CustomExecutableReporter) Stop() {
	fmt.Println("Stop")
}
```