### PR TITLE
Allow user-defined configuration of MaxGRPCRetries and MaxRPCMsgSize

### DIFF
--- a/collector/factory.go
+++ b/collector/factory.go
@@ -35,7 +35,8 @@ func createProfilesReceiver(
 	_ context.Context,
 	rs receiver.Settings,
 	baseCfg component.Config,
-	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
+	nextConsumer xconsumer.Profiles,
+) (xreceiver.Profiles, error) {
 	cfg, ok := baseCfg.(*controller.Config)
 	if !ok {
 		return nil, errInvalidConfig
@@ -53,5 +54,7 @@ func defaultConfig() component.Config {
 		ProbabilisticThreshold: 100,
 		Tracers:                "all",
 		ClockSyncInterval:      3 * time.Minute,
+		MaxGRPCRetries:         5,
+		MaxRPCMsgSize:          32 << 20, // 32 MiB,
 	}
 }

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -28,15 +28,16 @@ type Controller struct {
 }
 
 func NewController(cfg *controller.Config, rs receiver.Settings,
-	nextConsumer xconsumer.Profiles) (*Controller, error) {
+	nextConsumer xconsumer.Profiles,
+) (*Controller, error) {
 	intervals := times.New(cfg.ReporterInterval,
 		cfg.MonitorInterval, cfg.ProbabilisticInterval)
 
 	rep, err := reporter.NewCollector(&reporter.Config{
 		Name:                   ctrlName,
 		Version:                vc.Version(),
-		MaxRPCMsgSize:          32 << 20, // 32 MiB
-		MaxGRPCRetries:         5,
+		MaxRPCMsgSize:          cfg.MaxRPCMsgSize,
+		MaxGRPCRetries:         cfg.MaxGRPCRetries,
 		GRPCOperationTimeout:   intervals.GRPCOperationTimeout(),
 		GRPCStartupBackoffTime: intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:  intervals.GRPCConnectionTimeout(),

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	OffCPUThreshold        float64
 	UProbeLinks            []string
 	LoadProbe              bool
+	MaxGRPCRetries         uint32
+	MaxRPCMsgSize          int
 
 	Reporter reporter.Reporter
 


### PR DESCRIPTION
This allows user-defined configuration of the currently static configurations in the receiver's controller, as mentioned in #817.
cc @Gandem @ogaca-dd