### PR TITLE
Export the Collector Config

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	LoadProbe              bool          `mapstructure:"load_probe"`
 	MapScaleFactor         uint          `mapstructure:"map_scale_factor"`
 	BPFVerifierLogLevel    uint          `mapstructure:"bpf_verifier_log_level"`
-	KernelVersionCheck     bool          `mapstructure:"kernel_version_check"`
+	NoKernelVersionCheck   bool          `mapstructure:"no_kernel_version_check"`
 	MaxGRPCRetries         uint32        `mapstructure:"max_grpc_retries"`
 	MaxRPCMsgSize          int           `mapstructure:"max_rpc_msg_size"`
 }

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -58,7 +58,7 @@ func createProfilesReceiver(
 		LoadProbe:              cfg.LoadProbe,
 		MapScaleFactor:         cfg.MapScaleFactor,
 		BpfVerifierLogLevel:    cfg.BPFVerifierLogLevel,
-		NoKernelVersionCheck:   !cfg.KernelVersionCheck,
+		NoKernelVersionCheck:   cfg.NoKernelVersionCheck,
 		MaxGRPCRetries:         cfg.MaxGRPCRetries,
 		MaxRPCMsgSize:          cfg.MaxRPCMsgSize,
 	}
@@ -75,7 +75,6 @@ func defaultConfig() component.Config {
 		ProbabilisticThreshold: 100,
 		Tracers:                "all",
 		ClockSyncInterval:      3 * time.Minute,
-		KernelVersionCheck:     true,
 		MaxGRPCRetries:         5,
 		MaxRPCMsgSize:          32 << 20, // 32 MiB,
 	}


### PR DESCRIPTION
# Description 
This PR exports the Collector Config to allow user to create their custom receiver.

See this [document](https://docs.google.com/document/d/1QGRCABBgA-eJ3BXe0k0oM6MNGdVXvHmgDT675KxCVZo/edit?tab=t.0#heading=h.f2fxlsoa2dqh) for additional requirements.

This PR is part of a serie of PRs that replaces https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/811 

# Implementation Note
Instead of having this code
```go
	controlerCfg := &controller.Config{
		ReporterInterval:       cfg.ReporterInterval,
		MonitorInterval:        cfg.MonitorInterval,
		SamplesPerSecond:       cfg.SamplesPerSecond,
		ProbabilisticInterval:  cfg.ProbabilisticInterval,
		ProbabilisticThreshold: cfg.ProbabilisticThreshold,
		Tracers:                cfg.Tracers,
		ClockSyncInterval:      cfg.ClockSyncInterval,
		SendErrorFrames:        cfg.SendErrorFrames,
		VerboseMode:            cfg.VerboseMode,
		OffCPUThreshold:        cfg.OffCPUThreshold,
		IncludeEnvVars:         cfg.IncludeEnvVars,
	}
```

it is possible to embed `Config` inside  `controller.Config` and so results in the following code:
```go
controlerCfg := &controller.Config{ Config:  cfg}

// controller.Config definition
type Config struct {
   collector.Config
  // Other fields
}
```
To avoid cycle this require `collector.Config` to be located in its own package, that is why this solution was not used.