### PR TITLE
tracer: load uprobe program in integration tests

### DIFF
--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -239,6 +239,7 @@ func TestAllTracers(t *testing.T) {
 		ProbabilisticThreshold: 100,
 		OffCPUThreshold:        uint32(math.MaxUint32 / 100),
 		VerboseMode:            true,
+		LoadProbe:              true,
 	})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
CI tests are expected to fail in https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/824 because of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/824#discussion_r2372637327.

But as the uprobe program is not loaded, it passes. Fix this by adding the uprobe to `TestAllTracers` config.