### PR TITLE
reporter: Rename off_cpu sample type

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -144,7 +144,7 @@ func (p *Pdata) setProfile(
 		st.SetTypeStrindex(stringSet.Add("samples"))
 		st.SetUnitStrindex(stringSet.Add("count"))
 	case support.TraceOriginOffCPU:
-		st.SetTypeStrindex(stringSet.Add("events"))
+		st.SetTypeStrindex(stringSet.Add("off_cpu"))
 		st.SetUnitStrindex(stringSet.Add("nanoseconds"))
 	case support.TraceOriginUProbe:
 		st.SetTypeStrindex(stringSet.Add("events"))


### PR DESCRIPTION
This example is explicitly mentioned in the [spec], so we should follow that.

 This will require changes in e.g. [devfiler]

[devfiler]:https://github.com/elastic/devfiler/blob/ae6ec150adf10c0f2e8cc5e32556f62df0092917/src/collector/otlp/service.rs#L385-L387

[spec]:https://github.com/open-telemetry/opentelemetry-proto/blob/0d02f212598f3ec1dda35274e87f59351f619058/opentelemetry/proto/profiles/v1development/profiles.proto#L267-L271
