### PR TITLE
Go: set patch version to 0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module go.opentelemetry.io/ebpf-profiler
 
+// NOTE:
+// This go.mod is NOT used to build any official binary.
+// To see the builder manifests used for official binaries,
+// check https://github.com/open-telemetry/opentelemetry-collector-releases
+//
+// For the OpenTelemetry eBPF Profiler distribution specifically, see
+// https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler
+
 go 1.24.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/ebpf-profiler
 
-go 1.24.6
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.1


### PR DESCRIPTION
Specifying a higher minor version of Go blocks OTel ebpf profiler components to be updated in other OTel components - e.g. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42590/files#r2333188175. Therefore set the patch version to 0.