### PR TITLE
Add a callback when the controller is shutting down.

### DIFF
--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -13,6 +13,7 @@ type option interface {
 
 type controllerOption struct {
 	executableReporter reporter.ExecutableReporter
+	onShutdown         func()
 }
 
 type optFunc func(*controllerOption) *controllerOption
@@ -23,6 +24,14 @@ func (f optFunc) apply(c *controllerOption) *controllerOption { return f(c) }
 func WithExecutableReporter(executableReporter reporter.ExecutableReporter) option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.executableReporter = executableReporter
+		return option
+	})
+}
+
+// WithOnShutdown is a function that allows to configure a function to be called when the controller is shutdown.
+func WithOnShutdown(onShutdown func()) option {
+	return optFunc(func(option *controllerOption) *controllerOption {
+		option.onShutdown = onShutdown
 		return option
 	})
 }

--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -13,7 +13,7 @@ type option interface {
 
 type controllerOption struct {
 	executableReporter reporter.ExecutableReporter
-	onShutdown         func()
+	onShutdown         func() error
 }
 
 type optFunc func(*controllerOption) *controllerOption
@@ -29,7 +29,7 @@ func WithExecutableReporter(executableReporter reporter.ExecutableReporter) opti
 }
 
 // WithOnShutdown is a function that allows to configure a function to be called when the controller is shutdown.
-func WithOnShutdown(onShutdown func()) option {
+func WithOnShutdown(onShutdown func() error) option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.onShutdown = onShutdown
 		return option

--- a/collector/controller_options_test.go
+++ b/collector/controller_options_test.go
@@ -23,7 +23,7 @@ type executableReporterTest struct{}
 func (e *executableReporterTest) ReportExecutable(args *reporter.ExecutableMetadata) {}
 
 func TestWithOnShutdown(t *testing.T) {
-	onShutdown := func() {}
+	onShutdown := func() error { return nil }
 	option := WithOnShutdown(onShutdown)
 	require.Equal(
 		t,

--- a/collector/controller_options_test.go
+++ b/collector/controller_options_test.go
@@ -4,6 +4,7 @@
 package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,3 +21,12 @@ func TestWithExecutableReporter(t *testing.T) {
 type executableReporterTest struct{}
 
 func (e *executableReporterTest) ReportExecutable(args *reporter.ExecutableMetadata) {}
+
+func TestWithOnShutdown(t *testing.T) {
+	onShutdown := func() {}
+	option := WithOnShutdown(onShutdown)
+	require.Equal(
+		t,
+		reflect.ValueOf(onShutdown).Pointer(),
+		reflect.ValueOf(option.apply(&controllerOption{}).onShutdown).Pointer())
+}

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -67,6 +67,7 @@ func BuildProfilesReceiver(options ...option) xreceiver.CreateProfilesFunc {
 			MaxGRPCRetries:         cfg.MaxGRPCRetries,
 			MaxRPCMsgSize:          cfg.MaxRPCMsgSize,
 			ExecutableReporter:     controllerOption.executableReporter,
+			OnShutdown:             controllerOption.onShutdown,
 		}
 
 		return internal.NewController(controlerCfg, rs, nextConsumer)

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -24,7 +24,8 @@ const (
 // Controller is a bridge between the Collector's [receiverprofiles.Profiles]
 // interface and our [internal.Controller]
 type Controller struct {
-	ctlr *controller.Controller
+	ctlr       *controller.Controller
+	onShutdown func()
 }
 
 func NewController(cfg *controller.Config, rs receiver.Settings,
@@ -54,7 +55,8 @@ func NewController(cfg *controller.Config, rs receiver.Settings,
 	metrics.Start(meter)
 
 	return &Controller{
-		ctlr: controller.New(cfg),
+		onShutdown: cfg.OnShutdown,
+		ctlr:       controller.New(cfg),
 	}, nil
 }
 
@@ -66,5 +68,8 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 // Shutdown stops the receiver.
 func (c *Controller) Shutdown(_ context.Context) error {
 	c.ctlr.Shutdown()
+	if c.onShutdown != nil {
+		c.onShutdown()
+	}
 	return nil
 }

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -25,7 +25,7 @@ const (
 // interface and our [internal.Controller]
 type Controller struct {
 	ctlr       *controller.Controller
-	onShutdown func()
+	onShutdown func() error
 }
 
 func NewController(cfg *controller.Config, rs receiver.Settings,
@@ -69,7 +69,7 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 func (c *Controller) Shutdown(_ context.Context) error {
 	c.ctlr.Shutdown()
 	if c.onShutdown != nil {
-		c.onShutdown()
+		return c.onShutdown()
 	}
 	return nil
 }

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Fs *flag.FlagSet
 
 	IncludeEnvVars string
+	OnShutdown     func()
 }
 
 const (

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	Fs *flag.FlagSet
 
 	IncludeEnvVars string
-	OnShutdown     func()
+	OnShutdown     func() error
 }
 
 const (


### PR DESCRIPTION
This PR adds a callback when the controller is shutting down.

See this [document](https://docs.google.com/document/d/1QGRCABBgA-eJ3BXe0k0oM6MNGdVXvHmgDT675KxCVZo/edit?tab=t.0#heading=h.f2fxlsoa2dqh) for additional requirements.

This PR is part of a series of PRs that replaces https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/811 :
- https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/834
- https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/825

This [PR](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/834) adds a way to configure the ExecutableReporter but our implementation uses life cycle (Start and Stop methods). The callback when the controller is shutting down can be used to call the Stop method of an executable reporter.
Note: I named it `onShutdown` because it can serve other purposes.
