### PR TITLE
golabels: unify error handling

### DIFF
--- a/interpreter/golabels/golabels.go
+++ b/interpreter/golabels/golabels.go
@@ -4,6 +4,7 @@
 package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabels"
 
 import (
+	"errors"
 	"fmt"
 	"go/version"
 	"unsafe"
@@ -21,6 +22,8 @@ type data struct {
 	offsets   support.GoLabelsOffsets
 	interpreter.InstanceStubs
 }
+
+var errDecodeSymbol = errors.New("failed to decode symbol")
 
 func (d *data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID,
 	_ libpf.Address, _ remotememory.RemoteMemory) (interpreter.Instance, error) {
@@ -59,7 +62,14 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 
 	offsets := getOffsets(goVersion)
 	tlsOffset, err := extractTLSGOffset(file)
-	if err != nil {
+	switch err {
+	case libpf.ErrSymbolNotFound:
+		return nil, fmt.Errorf("failed to lookup symbol in %s: %v", info.FileName(), err)
+	case errDecodeSymbol:
+		log.Warnf("Failed to decode symbol in %s for Go label extraction", info.FileName())
+	case nil:
+		// Nothing to do - just continue
+	default:
 		return nil, fmt.Errorf("failed to extract TLS offset: %w", err)
 	}
 	offsets.Tls_offset = tlsOffset

--- a/interpreter/golabels/tls_amd64.go
+++ b/interpreter/golabels/tls_amd64.go
@@ -6,7 +6,6 @@
 package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabels"
 
 import (
-	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/asm/amd"
 	e "go.opentelemetry.io/ebpf-profiler/asm/expression"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
@@ -70,6 +69,5 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 			return int32(offset.CapturedValue()), nil
 		}
 	}
-	log.Warnf("Failed to decode stackcheck symbol, Go label collection might not work")
-	return -8, nil
+	return -8, errDecodeSymbol
 }

--- a/interpreter/golabels/tls_arm64.go
+++ b/interpreter/golabels/tls_arm64.go
@@ -6,7 +6,6 @@
 package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabels"
 
 import (
-	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/armhelpers"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"golang.org/x/arch/arm64/arm64asm"
@@ -45,10 +44,7 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 	}
 	sym, err := syms.LookupSymbol("runtime.load_g.abi0")
 	if err != nil {
-		// Binary must be stripped, just warn and return 0 and we'll rely on r28.
-		log.Warnf("Failed to find load_g symbol in cgo enabled Go binary "+
-			"label collection in CGO frames may not work: %v", err)
-		return 0, nil
+		return 0, err
 	}
 	b, err := f.VirtualMemory(int64(sym.Address), 32, 32)
 	if err != nil {
@@ -78,6 +74,5 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 			}
 		}
 	}
-	log.Warnf("Failed to decode load_g symbol, Go label collection might not work with CGO frames")
-	return 0, nil
+	return 0, errDecodeSymbol
 }


### PR DESCRIPTION
If symbol extraction fails for golabels, either

```
Failed to decode stackcheck symbol, Go label collection might not work
```

or
```
Failed to decode load_g symbol, Go label collection might not work with CGO frames
```

is printed. These generic messages make it hard to pin point the related Go executable. Therefore unify error handling for this case and name the affected Go executable.