### PR TITLE
interpreter/ruby: remove redundant LRU

### DIFF
--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -212,12 +212,6 @@ const (
 	// Number of unwound Ruby frames
 	IDUnwindRubyFrames = 109
 
-	// Number of cache hits for Ruby IseqBodyPCToFunction
-	IDRubyIseqBodyPCHit = 110
-
-	// Number of cache misses for Ruby IseqBodyPCToFunction
-	IDRubyIseqBodyPCMiss = 111
-
 	// Number of cache hits for Ruby AddrToString
 	IDRubyAddrToStringHit = 112
 
@@ -388,12 +382,6 @@ const (
 
 	// Number of deleted cache elements for Python AddrToCodeObject
 	IDPythonAddrToCodeObjectDel = 178
-
-	// Number of added cache elements for Ruby IseqBodyPCToFunction
-	IDRubyIseqBodyPCAdd = 179
-
-	// Number of deleted cache elements for Ruby IseqBodyPCToFunction
-	IDRubyIseqBodyPCDel = 180
 
 	// Number of added cache elements for Ruby AddrToString
 	IDRubyAddrToStringAdd = 181

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -805,6 +805,7 @@
     "id": 109
   },
   {
+    "obsolete": true,
     "description": "Number of cache hits for Ruby IseqBodyPCToFunction",
     "type": "counter",
     "name": "RubyIseqBodyPCHit",
@@ -812,6 +813,7 @@
     "id": 110
   },
   {
+    "obsolete": true,
     "description": "Number of cache misses for Ruby IseqBodyPCToFunction",
     "type": "counter",
     "name": "RubyIseqBodyPCMiss",
@@ -1297,6 +1299,7 @@
     "id": 178
   },
   {
+    "obsolete": true,
     "description": "Number of added cache elements for Ruby IseqBodyPCToFunction",
     "type": "counter",
     "name": "RubyIseqBodyPCAdd",
@@ -1304,6 +1307,7 @@
     "id": 179
   },
   {
+    "obsolete": true,
     "description": "Number of deleted cache elements for Ruby IseqBodyPCToFunction",
     "type": "counter",
     "name": "RubyIseqBodyPCDel",


### PR DESCRIPTION
now that the core caches frames, the top level iseqBodyPCToFunction LRU is redundant.

Remove it to reduce memory overhead.