### PR TITLE
processmanager: update process metadata alongside process synchroniza…

### DIFF
--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -106,6 +106,47 @@ func (pm *ProcessManager) getTSDInfo(pid libpf.PID) *tpbase.TSDInfo {
 	return nil
 }
 
+// fetchProcessMeta returns metadata related to the PID.
+func (pm *ProcessManager) fetchProcessMeta(pid libpf.PID) ProcessMeta {
+	var processName string
+	exePath, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if name, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err == nil {
+		processName = string(name)
+	}
+
+	envVarMap := make(map[string]string, len(pm.includeEnvVars))
+	if len(pm.includeEnvVars) > 0 {
+		if envVars, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid)); err == nil {
+			// environ has environment variables separated by a null byte (hex: 00)
+			splittedVars := strings.Split(string(envVars), "\000")
+			for _, envVar := range splittedVars {
+				keyValuePair := strings.SplitN(envVar, "=", 2)
+
+				// If the entry could not be split at a '=', ignore it
+				// (last entry of environ might be empty)
+				if len(keyValuePair) != 2 {
+					continue
+				}
+
+				if _, ok := pm.includeEnvVars[keyValuePair[0]]; ok {
+					envVarMap[keyValuePair[0]] = keyValuePair[1]
+				}
+			}
+		}
+	}
+
+	containerID, err := extractContainerID(pid)
+	if err != nil {
+		log.Debugf("Failed extracting containerID for %d: %v", pid, err)
+	}
+	return ProcessMeta{
+		Name:         processName,
+		Executable:   exePath,
+		ContainerID:  containerID,
+		EnvVariables: envVarMap,
+	}
+}
+
 // updatePidInformation updates pidToProcessInfo with the new information about
 // vaddr, offset, fileID and length for the given pid. If we don't know about the pid yet, it also
 // allocates the embedded map. If the mapping for pid at vaddr with requestedLength and fileID
@@ -117,44 +158,8 @@ func (pm *ProcessManager) updatePidInformation(pid libpf.PID, m *Mapping) (bool,
 	if !ok {
 		// We don't have information for this pid, so we first need to
 		// allocate the embedded map for this process.
-		var processName string
-		exePath, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
-		if name, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err == nil {
-			processName = string(name)
-		}
-
-		envVarMap := make(map[string]string, len(pm.includeEnvVars))
-		if len(pm.includeEnvVars) > 0 {
-			if envVars, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid)); err == nil {
-				// environ has environment variables separated by a null byte (hex: 00)
-				splittedVars := strings.Split(string(envVars), "\000")
-				for _, envVar := range splittedVars {
-					keyValuePair := strings.SplitN(envVar, "=", 2)
-
-					// If the entry could not be split at a '=', ignore it
-					// (last entry of environ might be empty)
-					if len(keyValuePair) != 2 {
-						continue
-					}
-
-					if _, ok := pm.includeEnvVars[keyValuePair[0]]; ok {
-						envVarMap[keyValuePair[0]] = keyValuePair[1]
-					}
-				}
-			}
-		}
-
-		containerID, err := extractContainerID(pid)
-		if err != nil {
-			log.Debugf("Failed extracting containerID for %d: %v", pid, err)
-		}
-
 		info = &processInfo{
-			meta: ProcessMeta{
-				Name:         processName,
-				Executable:   exePath,
-				ContainerID:  containerID,
-				EnvVariables: envVarMap},
+			meta:             pm.fetchProcessMeta(pid),
 			mappings:         make(map[libpf.Address]*Mapping),
 			mappingsByFileID: make(map[host.FileID]map[libpf.Address]*Mapping),
 			tsdInfo:          nil,
@@ -507,6 +512,9 @@ func (pm *ProcessManager) synchronizeMappings(pr process.Process,
 	// Generate the list of added and removed mappings.
 	pm.mu.RLock()
 	if info, ok := pm.pidToProcessInfo[pid]; ok {
+		// Update metadata of the process.
+		info.meta = pm.fetchProcessMeta(pid)
+
 		// Iterate over cached executable mappings, if any, and collect mappings
 		// that have changed so that they are later batch-removed.
 		for addr, existingMapping := range info.mappings {


### PR DESCRIPTION
…tion

So far process metadata is fetched only when the process is handled for the first time. Use the process synchronization mechanism to update metadata alongside mapping information.

Fixes 835