### PR TITLE
Export Option

### DIFF
--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -7,7 +7,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
 
-type option interface {
+type Option interface {
 	apply(*controllerOption) *controllerOption
 }
 
@@ -21,7 +21,7 @@ type optFunc func(*controllerOption) *controllerOption
 func (f optFunc) apply(c *controllerOption) *controllerOption { return f(c) }
 
 // WithExecutableReporter is a function that allows to configure a ExecutableReporter.
-func WithExecutableReporter(executableReporter reporter.ExecutableReporter) option {
+func WithExecutableReporter(executableReporter reporter.ExecutableReporter) Option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.executableReporter = executableReporter
 		return option
@@ -29,7 +29,7 @@ func WithExecutableReporter(executableReporter reporter.ExecutableReporter) opti
 }
 
 // WithOnShutdown is a function that allows to configure a function to be called when the controller is shutdown.
-func WithOnShutdown(onShutdown func() error) option {
+func WithOnShutdown(onShutdown func() error) Option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.onShutdown = onShutdown
 		return option

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -31,7 +31,7 @@ func NewFactory() receiver.Factory {
 		xreceiver.WithProfiles(BuildProfilesReceiver(), component.StabilityLevelAlpha))
 }
 
-func BuildProfilesReceiver(options ...option) xreceiver.CreateProfilesFunc {
+func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 	return func(ctx context.Context,
 		rs receiver.Settings,
 		baseCfg component.Config,


### PR DESCRIPTION
### Description

This PR exports `Option`.

### Motivations

In the current implementation you cannot write the following code as `options` is not exported.
```go
options := []ebpfcollector.options{} // Doesn't compile
if Enabled {
  options = append(options, ebpfcollector.WithExecutableReporter(executableReporter))
  options = append(options, ebpfcollector.WithOnShutdown(executableReporter.Stop))
} else {
  options = append(options, ebpfcollector.WithOnShutdown(func() error { 
	// Some code
	return nil 
}))
}

createProfiles = ebpfcollector.BuildProfilesReceiver(options...)

```
Instead you have to use:
```go
var receiverFunc xreceiver.CreateProfilesFunc

if IsEnabled() {
  receiverFunc = ebpfcollector.BuildProfilesReceiver(ebpfcollector.WithExecutableReporter(executableReporter),
	ebpfcollector.WithOnShutdown(executableReporter.Stop))
} else {
  receiverFunc = ebpfcollector.BuildProfilesReceiver(ebpfcollector.WithOnShutdown(func() error {
  // Some code
  return nil
}))
}
```

If there’s only a single condition, this is fine. However, if there are multiple cases, you’ll need to call BuildProfilesReceiver once for each combination of conditions.

