### PR TITLE
Move collector.Config to its own package.

### DIFF
--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
+package config // import "go.opentelemetry.io/ebpf-profiler/collector/config"
 
 import "time"
 

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
 
+	"go.opentelemetry.io/ebpf-profiler/collector/config"
 	"go.opentelemetry.io/ebpf-profiler/collector/internal"
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
 )
@@ -37,7 +38,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 		baseCfg component.Config,
 		nextConsumer xconsumer.Profiles,
 	) (xreceiver.Profiles, error) {
-		cfg, ok := baseCfg.(*Config)
+		cfg, ok := baseCfg.(*config.Config)
 		if !ok {
 			return nil, errInvalidConfig
 		}
@@ -76,7 +77,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 }
 
 func defaultConfig() component.Config {
-	return &Config{
+	return &config.Config{
 		ReporterInterval:       5 * time.Second,
 		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,


### PR DESCRIPTION
This PR moves `collector.Config` to its own package `config`.
This is a split of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/859 where the goal is to implement `Validate` on the config without code duplication. See [here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/849#issuecomment-3376648588) for more context.