### PR TITLE
reporter: Remove outdated comment

### DIFF
--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -190,9 +190,6 @@ func (p *Pdata) setProfile(
 					mapping.SetFileOffset(frame.MappingFileOffset)
 					mapping.SetFilenameStrindex(stringSet.Add(mf.FileName.String()))
 
-					// Once SemConv and its Go package is released with the new
-					// semantic convention for build_id, replace these hard coded
-					// strings.
 					attrMgr.AppendOptionalString(mapping.AttributeIndices(),
 						semconv.ProcessExecutableBuildIDGNUKey,
 						mf.GnuBuildID)


### PR DESCRIPTION
The hard coded strings were removed in f944d4609e8e ("Go: update to go.opentelemetry.io/otel@v1.35.0 (#383)")

Fixes: f944d4609e8e ("Go: update to go.opentelemetry.io/otel@v1.35.0 (#383)")