### PR TITLE
Embed config.Config to controller.Config

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -84,7 +84,7 @@ func parseArgs() (*controller.Config, error) {
 	fs := flag.NewFlagSet("ebpf-profiler", flag.ExitOnError)
 
 	// Please keep the parameters ordered alphabetically in the source-code.
-	fs.UintVar(&args.BpfVerifierLogLevel, "bpf-log-level", 0, bpfVerifierLogLevelHelp)
+	fs.UintVar(&args.BPFVerifierLogLevel, "bpf-log-level", 0, bpfVerifierLogLevelHelp)
 
 	fs.StringVar(&args.CollAgentAddr, "collection-agent", "", collAgentAddrHelp)
 	fs.BoolVar(&args.Copyright, "copyright", false, copyrightHelp)

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -49,27 +49,10 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 		}
 
 		controlerCfg := &controller.Config{
-			ReporterInterval:       cfg.ReporterInterval,
-			MonitorInterval:        cfg.MonitorInterval,
-			SamplesPerSecond:       cfg.SamplesPerSecond,
-			ProbabilisticInterval:  cfg.ProbabilisticInterval,
-			ProbabilisticThreshold: cfg.ProbabilisticThreshold,
-			Tracers:                cfg.Tracers,
-			ClockSyncInterval:      cfg.ClockSyncInterval,
-			SendErrorFrames:        cfg.SendErrorFrames,
-			VerboseMode:            cfg.VerboseMode,
-			OffCPUThreshold:        cfg.OffCPUThreshold,
-			IncludeEnvVars:         cfg.IncludeEnvVars,
-			UProbeLinks:            cfg.UProbeLinks,
-			LoadProbe:              cfg.LoadProbe,
-			MapScaleFactor:         cfg.MapScaleFactor,
-			BpfVerifierLogLevel:    cfg.BPFVerifierLogLevel,
-			NoKernelVersionCheck:   cfg.NoKernelVersionCheck,
-			MaxGRPCRetries:         cfg.MaxGRPCRetries,
-			MaxRPCMsgSize:          cfg.MaxRPCMsgSize,
-			ExecutableReporter:     controllerOption.executableReporter,
-			ReporterFactory:        controllerOption.reporterFactory,
-			OnShutdown:             controllerOption.onShutdown,
+			Config:             *cfg,
+			ExecutableReporter: controllerOption.executableReporter,
+			ReporterFactory:    controllerOption.reporterFactory,
+			OnShutdown:         controllerOption.onShutdown,
 		}
 
 		return internal.NewController(controlerCfg, rs, nextConsumer)

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -10,33 +10,18 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
+	"go.opentelemetry.io/ebpf-profiler/collector/config"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/tracer"
 )
 
 type Config struct {
-	BpfVerifierLogLevel    uint
-	CollAgentAddr          string
-	Copyright              bool
-	DisableTLS             bool
-	MapScaleFactor         uint
-	MonitorInterval        time.Duration
-	ClockSyncInterval      time.Duration
-	NoKernelVersionCheck   bool
-	PprofAddr              string
-	ProbabilisticInterval  time.Duration
-	ProbabilisticThreshold uint
-	ReporterInterval       time.Duration
-	SamplesPerSecond       int
-	SendErrorFrames        bool
-	Tracers                string
-	VerboseMode            bool
-	Version                bool
-	OffCPUThreshold        float64
-	UProbeLinks            []string
-	LoadProbe              bool
-	MaxGRPCRetries         uint32
-	MaxRPCMsgSize          int
+	config.Config
+	CollAgentAddr string
+	Copyright     bool
+	DisableTLS    bool
+	PprofAddr     string
+	Version       bool
 
 	ExecutableReporter reporter.ExecutableReporter
 	OnShutdown         func() error
@@ -47,8 +32,6 @@ type Config struct {
 	Reporter        reporter.Reporter
 
 	Fs *flag.FlagSet
-
-	IncludeEnvVars string
 }
 
 const (
@@ -79,8 +62,8 @@ func (cfg *Config) Validate() error {
 		)
 	}
 
-	if cfg.BpfVerifierLogLevel > 2 {
-		return fmt.Errorf("invalid eBPF verifier log level: %d", cfg.BpfVerifierLogLevel)
+	if cfg.BPFVerifierLogLevel > 2 {
+		return fmt.Errorf("invalid eBPF verifier log level: %d", cfg.BPFVerifierLogLevel)
 	}
 
 	if cfg.ProbabilisticInterval < 1*time.Minute || cfg.ProbabilisticInterval > 5*time.Minute {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -82,7 +82,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		MapScaleFactor:         int(c.config.MapScaleFactor),
 		KernelVersionCheck:     !c.config.NoKernelVersionCheck,
 		VerboseMode:            c.config.VerboseMode,
-		BPFVerifierLogLevel:    uint32(c.config.BpfVerifierLogLevel),
+		BPFVerifierLogLevel:    uint32(c.config.BPFVerifierLogLevel),
 		ProbabilisticInterval:  c.config.ProbabilisticInterval,
 		ProbabilisticThreshold: c.config.ProbabilisticThreshold,
 		OffCPUThreshold:        uint32(c.config.OffCPUThreshold * float64(math.MaxUint32)),


### PR DESCRIPTION
Embed config.Config to controller.Config.

This is a split of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/859 where the goal is to implement `Validate` on the config without code duplication. See [here](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/849#issuecomment-3376648588) for more context.