### PR TITLE
Fix toolchain paths on certain systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export TARGET_ARCH
 export CGO_ENABLED = 0
 export GOARCH = $(TARGET_ARCH)
 export CC = $(shell command -v $(ARCH_PREFIX)-linux-gnu-gcc || command -v $(ARCH_PREFIX)-unknown-linux-gnu-gcc)
-export OBJCOPY = $(shell command -v $(ARCH_PREFIX)-linux-gnu-objcopy || echo $(ARCH_PREFIX)-unknown-linux-gnu-objcopy)
+export OBJCOPY = $(shell command -v $(ARCH_PREFIX)-linux-gnu-objcopy || command -v $(ARCH_PREFIX)-unknown-linux-gnu-objcopy)
 
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD | tr -d '-' | tr '[:upper:]' '[:lower:]')
 COMMIT_SHORT_SHA = $(shell git rev-parse --short=8 HEAD)


### PR DESCRIPTION
Certain systems, e.g. Guix, have e.g. $ARCH-unknown-linux-gnu-gcc rather than $ARCH-linux-gnu-gcc.

Thus, use the former as a fallback if the latter isn't found.