### PR TITLE
gopclntab: skip small segments in search for gopclntab

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -261,7 +261,7 @@ func searchGoPclntab(ef *pfelf.File) ([]byte, error) {
 		}
 
 		// Skip segments that are too small anyway.
-		if p.Memsz < uint64(PclntabHeaderSize()) {
+		if p.Filesz < uint64(PclntabHeaderSize()) {
 			continue
 		}
 


### PR DESCRIPTION
Added a check to skip segments that are too small for gopclntab.