### PR TITLE
config: drop check for MaxRPCMsgSize

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -88,10 +88,6 @@ func (cfg *Config) Validate() error {
 				"should be in the range [0..1]. 0 disables off-cpu profiling")
 	}
 
-	if cfg.MaxRPCMsgSize <= 0 {
-		return fmt.Errorf("invalid max-rpc-msg-size: got %d, must be greater than 0", cfg.MaxRPCMsgSize)
-	}
-
 	if !cfg.NoKernelVersionCheck {
 		major, minor, patch, err := tracer.GetCurrentKernelVersion()
 		if err != nil {


### PR DESCRIPTION
Remove validation of MaxRPCMsgSize in config.

The merge of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/868 prevents eBPF profiler from starting:
```
ERRO[0000] invalid max-rpc-msg-size: got 0, must be greater than 0 
```

Therefore, revert this part of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/868.