### PR TITLE
Make tracer Close release all resources to prevent leaks

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -164,7 +164,7 @@ func startTraceHandling(ctx context.Context, trc *tracer.Tracer) error {
 	// Spawn monitors for the various result maps
 	traceCh := make(chan *host.Trace)
 
-	if err := trc.StartMapMonitors(ctx, traceCh); err != nil {
+	if err := trc.StartMapMonitors(traceCh); err != nil {
 		return fmt.Errorf("failed to start map monitors: %v", err)
 	}
 

--- a/interpreter/golabels/integrationtests/golabels_integration_test.go
+++ b/interpreter/golabels/integrationtests/golabels_integration_test.go
@@ -112,7 +112,7 @@ func Test_Golabels(t *testing.T) {
 
 			traceCh := make(chan *host.Trace)
 
-			err = trc.StartMapMonitors(ctx, traceCh)
+			err = trc.StartMapMonitors(traceCh)
 			require.NoError(t, err)
 
 			go func() {

--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -119,6 +119,14 @@ func LoadMaps(ctx context.Context, maps map[string]*cebpf.Map) (ebpfapi.EbpfHand
 	return impl, nil
 }
 
+// WaitAsyncUpdates waits for all background async map update workers to exit.
+// This should be called during shutdown before closing eBPF maps.
+func (impl *ebpfMapsImpl) WaitAsyncUpdates() {
+	if impl.updateWorkers != nil {
+		impl.updateWorkers.wg.Wait()
+	}
+}
+
 // UpdateInterpreterOffsets adds the given moduleRanges to the eBPF map interpreterOffsets.
 func (impl *ebpfMapsImpl) UpdateInterpreterOffsets(ebpfProgIndex uint16, fileID host.FileID,
 	offsetRanges []util.Range) error {

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -124,7 +124,7 @@ func TestTraceTransmissionAndParsing(t *testing.T) {
 	require.NoError(t, err)
 
 	traceChan := make(chan *host.Trace, 16)
-	err = tr.StartMapMonitors(ctx, traceChan)
+	err = tr.StartMapMonitors(traceChan)
 	require.NoError(t, err)
 
 	runKernelFrameProbe(t, tr)


### PR DESCRIPTION
I have been using Parca and made some modifications to allow it to stop and restart the tracer. After each restart, the number of open file descriptors increases. This commit aims to fix the resource leak issue that occurs when closing.