### PR TITLE
pfelf, interpreters, elfunwindinfo: refactor to not use mmap

### DIFF
--- a/asm/amd/tls.go
+++ b/asm/amd/tls.go
@@ -58,12 +58,12 @@ func ExtractTLSOffset(code []byte, codeAddress uint64, file *pfelf.File) (int32,
 		if file != nil {
 			addr := e.NewImmediateCapture("addr")
 			if actual.Match(e.Mem8(addr)) {
-				valueBytes, err := file.VirtualMemory(int64(addr.CapturedValue()), 8, 8)
-				if err != nil {
+				b := make([]byte, 8)
+				if _, err := file.ReadAt(b, int64(addr.CapturedValue())); err != nil {
 					continue
 				}
 				// Read the 8-byte value as int64 (little-endian)
-				value := int64(npsr.Uint64(valueBytes, 0))
+				value := int64(npsr.Uint64(b, 0))
 				return validateTLSOffset(int32(value))
 			}
 		}

--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -110,8 +110,8 @@ func (g *goInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, mapping
 	defer sfCounter.DefaultToFailure()
 
 	address := ef.Data()
-	sourceFile, lineNo, fn := g.d.pclntab.Symbolize(uintptr(address))
-	if fn == "" {
+	sourceFile, lineNo, fn := g.d.pclntab.Symbolize(uint64(address))
+	if fn == libpf.NullString {
 		return fmt.Errorf("failed to symbolize 0x%x", address)
 	}
 	// See comment about return address handling in ProcessManager.convertFrame
@@ -121,15 +121,11 @@ func (g *goInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, mapping
 	frames.Append(&libpf.Frame{
 		Type:            libpf.GoFrame,
 		AddressOrLineno: libpf.AddressOrLineno(address),
-		Mapping:         mapping,
-		FunctionName:    libpf.Intern(fn),
-		SourceFile:      libpf.Intern(sourceFile),
+		FunctionName:    fn,
+		SourceFile:      sourceFile,
 		SourceLine:      libpf.SourceLineno(lineNo),
+		Mapping:         mapping,
 	})
 	sfCounter.ReportSuccess()
 	return nil
-}
-
-func (g *goInstance) ReleaseResources() error {
-	return g.d.pclntab.SetDontNeed()
 }

--- a/interpreter/golabels/tls_amd64.go
+++ b/interpreter/golabels/tls_amd64.go
@@ -41,8 +41,8 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 	}
 
 	sz := int(min(sym.Size, 128))
-	code, err := f.VirtualMemory(int64(sym.Address), sz, sz)
-	if err != nil {
+	code := make([]byte, sz)
+	if _, err = f.ReadAt(code, int64(sym.Address)); err != nil {
 		return 0, err
 	}
 

--- a/interpreter/golabels/tls_arm64.go
+++ b/interpreter/golabels/tls_arm64.go
@@ -60,8 +60,9 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 			return 0, err
 		}
 	}
-	b, err := f.VirtualMemory(int64(sym.Address), 32, 32)
-	if err != nil {
+	sz := int(min(sym.Size, 32))
+	b := make([]byte, sz)
+	if _, err := f.ReadAt(b, int64(sym.Address)); err != nil {
 		return 0, err
 	}
 	for ; len(b) > 0; b = b[4:] {

--- a/interpreter/instancestubs.go
+++ b/interpreter/instancestubs.go
@@ -32,7 +32,3 @@ func (is *InstanceStubs) Symbolize(libpf.EbpfFrame, *libpf.Frames, libpf.FrameMa
 func (is *InstanceStubs) GetAndResetMetrics() ([]metrics.Metric, error) {
 	return []metrics.Metric{}, nil
 }
-
-func (is *InstanceStubs) ReleaseResources() error {
-	return nil
-}

--- a/interpreter/multi.go
+++ b/interpreter/multi.go
@@ -142,14 +142,3 @@ func (m *MultiInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
 
 	return allMetrics, errors.Join(errs...)
 }
-
-func (m *MultiInstance) ReleaseResources() error {
-	var errs []error
-	for _, instance := range m.instances {
-		err := instance.ReleaseResources()
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
-}

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -2122,7 +2122,7 @@ func locateSnapshotArea(ef *pfelf.File, syms relevantSymbols) util.Range {
 		return util.Range{}
 	}
 
-	for prevEnd := uintptr(addr); prevEnd-uintptr(addr) < 1024; ndx++ {
+	for prevEnd := uint64(addr); prevEnd-uint64(addr) < 1024; ndx++ {
 		fde, err := eft.DecodeIndex(ndx)
 		if err != nil {
 			return util.Range{}

--- a/interpreter/types.go
+++ b/interpreter/types.go
@@ -155,7 +155,4 @@ type Instance interface {
 	// GetAndResetMetrics collects the metrics from the Instance and resets
 	// the counters to their initial value.
 	GetAndResetMetrics() ([]metrics.Metric, error)
-
-	// Release resources that are used to symbolize a stack.
-	ReleaseResources() error
 }

--- a/libpf/pfatbuf/atbuf.go
+++ b/libpf/pfatbuf/atbuf.go
@@ -1,0 +1,370 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// pfatbuf providers wrappers adding caching to types that implement the `ReaderAt` interface.
+
+package pfatbuf // import "go.opentelemetry.io/ebpf-profiler/libpf/pfatbuf"
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"runtime/debug"
+	"strings"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
+)
+
+const debugEnabled = false
+const pageSize = 1024
+const numPages = 8
+
+// Cache implements buffering for random access reads via the `ReaderAt` interface.
+type Cache struct {
+	name  string
+	inner io.ReaderAt
+
+	data     [pageSize * numPages]byte
+	pageNum  [numPages]int64
+	pageSize [numPages]int
+	pageHit  [numPages]uint
+	hit      uint
+	lastIdx  int
+
+	loads map[int64]uint
+}
+
+func (c *Cache) Inner() io.ReaderAt {
+	return c.inner
+}
+
+func (c *Cache) InitName(name string, rd io.ReaderAt) {
+	c.name = name
+	c.inner = rd
+	c.InvalidateCache()
+}
+
+func (c *Cache) Init(rd io.ReaderAt) {
+	c.InitName("noname", rd)
+}
+
+func (c *Cache) InvalidateCache() {
+	for i := range numPages {
+		c.pageNum[i] = -1
+		c.pageSize[i] = 0
+		c.pageHit[i] = uint(i)
+	}
+	c.hit = numPages
+	c.lastIdx = 0
+	c.loads = make(map[int64]uint)
+}
+
+// findPage fins the page for given offset from cache. If present, the index
+// of the cached page along with ok is returned. If not present, the returned
+// index is the index which should be reused.
+func (c *Cache) getPage(pageNum int64) (int, bool) {
+	if c.pageNum[c.lastIdx] == pageNum {
+		return c.lastIdx, true
+	}
+	oldestHit := ^uint(0)
+	oldestIdx := 0
+	for i := range numPages {
+		if c.pageNum[i] == pageNum {
+			c.lastIdx = i
+			return i, true
+		}
+		if c.pageHit[i] < oldestHit {
+			oldestIdx = i
+			oldestHit = c.pageHit[i]
+		}
+	}
+	c.lastIdx = oldestIdx
+	return oldestIdx, false
+}
+
+func (c *Cache) readPageToIndex(pageNum int64, idx int) error {
+	// Read from the underlying reader.
+	dataOffs := idx * pageSize
+	n, err := c.inner.ReadAt(c.data[dataOffs:dataOffs+pageSize], int64(pageNum*pageSize))
+	if err == io.EOF {
+		// We speculatively read more than the original caller asked us to,
+		// so running into EOF is actually expected for us.
+	} else if err != nil {
+		c.pageNum[idx] = -1
+		return err
+	}
+	c.pageSize[idx] = n
+	c.pageNum[idx] = pageNum
+	if c.pageHit[idx] != c.hit {
+		c.hit++
+		c.pageHit[idx] = c.hit
+	}
+	if debugEnabled {
+		val := c.loads[pageNum]
+		if val > 2 {
+			fmt.Printf("%s: read page %05d -> %d (%d b) [loads %d]\n", c.name, pageNum, idx, n, val)
+			debug.PrintStack()
+		}
+		c.loads[pageNum] = val + 1
+	}
+	return nil
+}
+
+func (c *Cache) getOrReadPage(pageNum int64) (data []byte, idx int, err error) {
+	if pageNum < 0 {
+		return nil, 0, fmt.Errorf("negative page %d", pageNum)
+	}
+	idx, ok := c.getPage(pageNum)
+	dataOffs := idx * pageSize
+	if !ok {
+		if err := c.readPageToIndex(pageNum, idx); err != nil {
+			return nil, 0, err
+		}
+	}
+	return c.data[dataOffs : dataOffs+c.pageSize[idx]], idx, nil
+}
+
+// ReadAt implements the `ReaderAt` interface.
+func (c *Cache) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, fmt.Errorf("negative offset value %d given", off)
+	}
+
+	// If reading large amounts of data, skip the cache and use inner ReadAt
+	// directly. This avoids a single read to trash the whole cache.
+	// When using underlying os.File this also reduces the number of syscalls
+	// made as the caching logic would split this to ReadAt call per page.
+	if uint(len(p)) > pageSize*3/2 {
+		return c.inner.ReadAt(p, off)
+	}
+
+	writeOffs := 0
+	remaining := len(p)
+	skipOffs := int(off % pageSize)
+	pageNum := off / pageSize
+
+	for {
+		data, _, err := c.getOrReadPage(pageNum)
+		if err != nil {
+			return int(writeOffs), err
+		}
+		if skipOffs > len(data) {
+			return 0, io.EOF
+		}
+
+		copyLen := min(remaining, len(data)-skipOffs)
+		copy(p[writeOffs:][:copyLen], data[skipOffs:][:copyLen])
+
+		skipOffs = 0
+		pageNum++
+		writeOffs += copyLen
+		remaining -= copyLen
+		if remaining == 0 {
+			return int(writeOffs), nil
+		}
+		if len(data) != pageSize {
+			return int(writeOffs), io.EOF
+		}
+	}
+}
+
+func (c *Cache) Uint8At(off int64) uint8 {
+	pageNum := off / pageSize
+	pageOff := int(off % pageSize)
+
+	buf, _, err := c.getOrReadPage(pageNum)
+	if err != nil || pageOff+1 > len(buf) {
+		return 0
+	}
+	return buf[pageOff]
+}
+
+func (c *Cache) slowUintAt(off int64, sz int, buf []byte, nextPageNum int64) uint64 {
+	var mergedBuf [8]byte
+
+	nextBuf, _, err := c.getOrReadPage(nextPageNum)
+	if err != nil {
+		return 0
+	}
+
+	copy(mergedBuf[:], buf)
+	remainingBuf := mergedBuf[len(buf):sz]
+	copy(remainingBuf, nextBuf)
+
+	return binary.LittleEndian.Uint64(mergedBuf[:])
+}
+
+func (c *Cache) Uint16At(off int64) uint16 {
+	pageNum := off / pageSize
+	pageOff := int(off % pageSize)
+
+	buf, _, err := c.getOrReadPage(pageNum)
+	if err != nil || pageOff > len(buf) {
+		return 0
+	}
+	if pageOff+2 <= len(buf) {
+		return binary.LittleEndian.Uint16(buf[pageOff:])
+	}
+	return uint16(c.slowUintAt(off, 2, buf[pageOff:], pageNum+1))
+}
+
+func (c *Cache) Uint32At(off int64) uint32 {
+	pageNum := off / pageSize
+	pageOff := int(off % pageSize)
+
+	buf, _, err := c.getOrReadPage(pageNum)
+	if err != nil || pageOff > len(buf) {
+		return 0
+	}
+	if pageOff+4 <= len(buf) {
+		return binary.LittleEndian.Uint32(buf[pageOff:])
+	}
+	return uint32(c.slowUintAt(off, 4, buf[pageOff:], pageNum+1))
+}
+
+func (c *Cache) Uint64At(off int64) uint64 {
+	pageNum := off / pageSize
+	pageOff := int(off % pageSize)
+
+	buf, _, err := c.getOrReadPage(pageNum)
+	if err != nil || pageOff > len(buf) {
+		return 0
+	}
+	if pageOff+8 <= len(buf) {
+		return binary.LittleEndian.Uint64(buf[pageOff:])
+	}
+	return c.slowUintAt(off, 8, buf[pageOff:], pageNum+1)
+}
+
+func (c *Cache) UnsafeReadAt(n int, off int64) ([]byte, error) {
+	if int(off&pageSize)+n >= 2*pageSize {
+		return nil, errors.New("too large unsafe read")
+	}
+
+	pageOffs := int(off % pageSize)
+	pageNum := off / pageSize
+
+	data, idx, err := c.getOrReadPage(pageNum)
+	if err != nil {
+		return nil, err
+	}
+	if pageOffs+n <= len(data) {
+		return data[pageOffs:], nil
+	}
+
+	// Arrange so that two consecutive cache pages form the data.
+	dataStart := idx * pageSize
+	if idx+1 >= numPages {
+		// Copy this page to the previous slot to make room
+		prevStart := dataStart - pageSize
+		copy(c.data[prevStart:dataStart], c.data[dataStart:])
+		c.pageHit[idx-1] = c.pageHit[idx]
+		c.pageNum[idx-1] = c.pageNum[idx]
+		c.pageSize[idx-1] = c.pageSize[idx]
+
+		idx--
+		dataStart = prevStart
+	}
+
+	// Read to the next page
+	if err = c.readPageToIndex(pageNum+1, idx+1); err != nil {
+		return nil, err
+	}
+	data = c.data[dataStart : dataStart+pageSize+c.pageSize[idx+1]]
+	if pageOffs+n <= len(data) {
+		return data[pageOffs:], nil
+	}
+
+	return nil, io.EOF
+}
+
+var ErrStringTooLong = errors.New("string is too long")
+
+func (c *Cache) UnsafeStringAt(off int64, maxSz int) (string, error) {
+	pageOff := int(off % pageSize)
+	pageNum := off / pageSize
+
+	data, idx, err := c.getOrReadPage(pageNum)
+	if err != nil {
+		return "", err
+	}
+	if pageOff > len(data) {
+		return "", io.EOF
+	}
+	data = data[pageOff:]
+	if zeroIdx := bytes.IndexByte(data, 0); zeroIdx >= 0 {
+		return pfunsafe.ToString(data[:+zeroIdx]), nil
+	}
+	if maxSz > 0 && len(data) >= maxSz {
+		return "", ErrStringTooLong
+	}
+
+	// Arrange so that two consecutive cache pages form the data.
+	dataStart := idx * pageSize
+	if idx+1 >= numPages {
+		// Copy this page to the previous slot to make room
+		prevStart := dataStart - pageSize
+		copy(c.data[prevStart:dataStart], c.data[dataStart:])
+		c.pageHit[idx-1] = c.pageHit[idx]
+		c.pageNum[idx-1] = c.pageNum[idx]
+		c.pageSize[idx-1] = c.pageSize[idx]
+
+		idx--
+		dataStart = prevStart
+	}
+
+	// Read to the next page
+	if err = c.readPageToIndex(pageNum+1, idx+1); err != nil {
+		return "", err
+	}
+	data = c.data[dataStart : dataStart+pageSize+c.pageSize[idx+1]]
+
+	if zeroIdx := bytes.IndexByte(data[pageSize:], 0); zeroIdx >= 0 {
+		return pfunsafe.ToString(data[pageOff : pageSize+zeroIdx]), nil
+	}
+	return "", ErrStringTooLong
+}
+
+func (c *Cache) InternStringAt(off int64) (libpf.String, error) {
+	str, err := c.UnsafeStringAt(off, 0)
+	return libpf.Intern(str), err
+}
+
+func (c *Cache) StringAt(off int64) (string, error) {
+	if str, err := c.UnsafeStringAt(off, 0); str != "" && err == nil {
+		return strings.Clone(str), nil
+	} else {
+		return str, err
+	}
+}
+
+func Search(rdr io.ReaderAt, needle []byte, result []byte) (int64, error) {
+	var buf [64 * 1024]byte
+
+	fileOffs := int64(0)
+	for {
+		n, err := rdr.ReadAt(buf[:], fileOffs)
+		// process 'n' bytes
+		bufOffs := bytes.Index(buf[:n], needle)
+		if bufOffs >= 0 {
+			if result != nil {
+				numCopied := copy(result, buf[bufOffs+len(needle):])
+				if numCopied < len(result) {
+					n, err = rdr.ReadAt(result[numCopied:], fileOffs+int64(n))
+					if err != nil {
+						return -1, err
+					}
+				}
+			}
+			return fileOffs + int64(bufOffs), nil
+		}
+		if err != nil {
+			return -1, err
+		}
+		fileOffs += int64(n - len(needle) + 1)
+	}
+	return -1, io.EOF
+}

--- a/libpf/pfatbuf/atbuf_test.go
+++ b/libpf/pfatbuf/atbuf_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pfatbuf_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfatbuf"
+	"go.opentelemetry.io/ebpf-profiler/testsupport"
+)
+
+func testVariant(t *testing.T, fileSize uint) {
+	file := testsupport.GenerateTestInputFile(255, fileSize)
+	rawReader := bytes.NewReader(file)
+	cachingReader := pfatbuf.Cache{}
+	cachingReader.Init(rawReader)
+	testsupport.ValidateReadAtWrapperTransparency(t, 10000, file, &cachingReader)
+}
+
+func TestCaching(t *testing.T) {
+	for _, sz := range []uint{1024, 1346, 889} {
+		t.Run(fmt.Sprintf("Size-%d", sz), func(t *testing.T) {
+			testVariant(t, sz)
+		})
+	}
+}
+
+func TestOutOfBoundsTail(t *testing.T) {
+	buf := bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7})
+	r := pfatbuf.Cache{}
+	r.Init(buf)
+	b := make([]byte, 1)
+	for i := range int64(32) {
+		_, err := r.ReadAt(b, i)
+		if i > 7 {
+			require.ErrorIs(t, err, io.EOF)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/libpf/pfelf/pfelf.go
+++ b/libpf/pfelf/pfelf.go
@@ -133,11 +133,8 @@ func getNoteDescBytes(sectionBytes []byte, name string, noteType uint32) (
 func getNoteHexString(sectionBytes []byte, name string, noteType uint32) (
 	noteHexString string, found bool, err error) {
 	noteBytes, found, err := getNoteDescBytes(sectionBytes, name, noteType)
-	if err != nil {
+	if err != nil || !found {
 		return "", false, err
-	}
-	if !found {
-		return "", false, nil
 	}
 	return hex.EncodeToString(noteBytes), true, nil
 }
@@ -145,11 +142,8 @@ func getNoteHexString(sectionBytes []byte, name string, noteType uint32) (
 func getNoteString(sectionBytes []byte, name string, noteType uint32) (
 	noteString string, found bool, err error) {
 	noteBytes, found, err := getNoteDescBytes(sectionBytes, name, noteType)
-	if err != nil {
+	if err != nil || !found {
 		return "", false, err
-	}
-	if !found {
-		return "", false, nil
 	}
 	return string(noteBytes), true, nil
 }

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -178,11 +178,9 @@ func OpenCoredumpFile(f *pfelf.File) (*CoredumpProcess, error) {
 		if p.ProgHeader.Type != elf.PT_NOTE {
 			continue
 		}
-		rdr, err := p.DataReader(maxNotesSection)
-		if err != nil {
-			return nil, err
-		}
+		rdr := p.Open()
 		var note Note64
+		var err error
 		for {
 			// Read the note header (name and size lengths), followed by reading
 			// their contents. This code advances the position in 'rdr' and should

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -368,14 +368,6 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	if cacheHit != 0 {
 		pm.frameCacheHit.Add(cacheHit)
 	}
-	pm.mu.RLock()
-	// Release resources that were used to symbolize this stack.
-	for _, instance := range pm.interpreters[pid] {
-		if err := instance.ReleaseResources(); err != nil {
-			log.Warnf("Failed to release resources for %d: %v", pid, err)
-		}
-	}
-	pm.mu.RUnlock()
 
 	trace.Hash = traceutil.HashTrace(trace)
 	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace.Hash, 1)


### PR DESCRIPTION
Do not allow large data reads from reads from the section and program headers. Instead use io.ReaderAt to access this data.

This removes the usage of mmap in pfelf. This is motivated by the fact, that if using mmap, we have no good control over how the RSS explodes. This caused extra complexity to try to madvice the unneeded pages, and additional things to not reference data in the mmap area. Also mmapped data may get changed in the file after validation, so this adds an extra layer of security.

A new cache `pfatbuf` is added. The concept is to be able to create this on stack, and use it to cache the reads so that the users can access the cache buffers directly without copying. It is also essential that multiple caches can be created so the localized reads go to the same cache. The performance impact is still measurable (2-4x slower or so) depending how the cache works. Further research might be needed to allow tuning the cache better for different portions (sequential vs. random access patterns).

cc @florianl @christos68k 

fixes #648