### PR TITLE
Intern process metadata

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -43,9 +43,9 @@ type Frame struct {
 
 type Trace struct {
 	Comm             string
-	ProcessName      string
-	ExecutablePath   string
-	ContainerID      string
+	ProcessName      libpf.String
+	ExecutablePath   libpf.String
+	ContainerID      libpf.String
 	Frames           []Frame
 	KTime            times.KTime
 	PID              libpf.PID
@@ -55,7 +55,7 @@ type Trace struct {
 	APMTraceID       libpf.APMTraceID
 	APMTransactionID libpf.APMTransactionID
 	CPU              int
-	EnvVars          map[string]string
+	EnvVars          map[libpf.String]libpf.String
 	CustomLabels     map[string]string
 	KernelFrames     libpf.Frames
 }

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -39,7 +39,7 @@ type CoredumpProcess struct {
 	pid libpf.PID
 
 	// fname is the the short name of the executable file that was running when the coredump was generated.
-	fname string
+	fname libpf.String
 
 	// machineData contains the parsed machine data.
 	machineData MachineData
@@ -264,7 +264,7 @@ func (cd *CoredumpProcess) GetProcessMeta(_ MetaConfig) ProcessMeta {
 	return ProcessMeta{}
 }
 
-func (cd *CoredumpProcess) GetExe() (string, error) {
+func (cd *CoredumpProcess) GetExe() (libpf.String, error) {
 	return cd.fname, nil
 }
 
@@ -463,7 +463,7 @@ func (cd *CoredumpProcess) parseProcessInfo(desc []byte) error {
 	if len(desc) == int(unsafe.Sizeof(PrpsInfo64{})) {
 		info := (*PrpsInfo64)(unsafe.Pointer(&desc[0]))
 		cd.pid = libpf.PID(info.PID)
-		cd.fname = string(info.FName[:])
+		cd.fname = libpf.Intern(pfunsafe.ToString(info.FName[:]))
 		return nil
 	}
 	return fmt.Errorf("unsupported NT_PRPSINFO size: %d", len(desc))

--- a/process/process.go
+++ b/process/process.go
@@ -82,33 +82,34 @@ func (sp *systemProcess) GetMachineData() MachineData {
 	return MachineData{Machine: pfelf.CurrentMachine}
 }
 
-func (sp *systemProcess) GetExe() (string, error) {
-	return os.Readlink(fmt.Sprintf("/proc/%d/exe", sp.pid))
+func (sp *systemProcess) GetExe() (libpf.String, error) {
+	str, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", sp.pid))
+	if err != nil {
+		return libpf.NullString, err
+	}
+	return libpf.Intern(str), nil
 }
 
 func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {
-	var processName string
+	var processName libpf.String
 	exePath, _ := sp.GetExe()
 	if name, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", sp.pid)); err == nil {
-		processName = string(name)
+		processName = libpf.Intern(pfunsafe.ToString(name))
 	}
 
-	envVarMap := make(map[string]string, len(cfg.IncludeEnvVars))
+	var envVarMap map[libpf.String]libpf.String
 	if len(cfg.IncludeEnvVars) > 0 {
 		if envVars, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", sp.pid)); err == nil {
+			envVarMap = make(map[libpf.String]libpf.String, len(cfg.IncludeEnvVars))
 			// environ has environment variables separated by a null byte (hex: 00)
-			splittedVars := strings.Split(string(envVars), "\000")
+			splittedVars := strings.Split(pfunsafe.ToString(envVars), "\000")
 			for _, envVar := range splittedVars {
-				keyValuePair := strings.SplitN(envVar, "=", 2)
-
-				// If the entry could not be split at a '=', ignore it
-				// (last entry of environ might be empty)
-				if len(keyValuePair) != 2 {
+				var fields [2]string
+				if stringutil.SplitN(envVar, "=", fields[:]) < 2 {
 					continue
 				}
-
-				if _, ok := cfg.IncludeEnvVars[keyValuePair[0]]; ok {
-					envVarMap[keyValuePair[0]] = keyValuePair[1]
+				if _, ok := cfg.IncludeEnvVars[fields[0]]; ok {
+					envVarMap[libpf.Intern(fields[0])] = libpf.Intern(fields[1])
 				}
 			}
 		}
@@ -127,7 +128,7 @@ func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {
 }
 
 // parseContainerID parses cgroup v2 container IDs
-func parseContainerID(cgroupFile io.Reader) string {
+func parseContainerID(cgroupFile io.Reader) libpf.String {
 	scanner := bufio.NewScanner(cgroupFile)
 	buf := make([]byte, 512)
 	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
@@ -141,24 +142,24 @@ func parseContainerID(cgroupFile io.Reader) string {
 		if bytes.Equal(b, []byte("0::/")) {
 			continue // Skip a common case
 		}
-		line := string(b)
+		line := pfunsafe.ToString(b)
 		pathParts = cgroupv2ContainerIDPattern.FindStringSubmatch(line)
 		if pathParts == nil {
 			log.Debugf("Could not extract cgroupv2 path from line: %s", line)
 			continue
 		}
-		return pathParts[1]
+		return libpf.Intern(pathParts[1])
 	}
 
 	// No containerID could be extracted
-	return ""
+	return libpf.NullString
 }
 
 // extractContainerID returns the containerID for pid if cgroup v2 is used.
-func extractContainerID(pid libpf.PID) (string, error) {
+func extractContainerID(pid libpf.PID) (libpf.String, error) {
 	cgroupFile, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
-		return "", err
+		return libpf.NullString, err
 	}
 
 	return parseContainerID(cgroupFile), nil

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -165,7 +165,7 @@ func TestExtractContainerID(t *testing.T) {
 		t.Run(tc.expectedContainerID, func(t *testing.T) {
 			reader := strings.NewReader(tc.line)
 			gotContainerID := parseContainerID(reader)
-			assert.Equal(t, tc.expectedContainerID, gotContainerID)
+			assert.Equal(t, tc.expectedContainerID, gotContainerID.String())
 		})
 	}
 }

--- a/process/types.go
+++ b/process/types.go
@@ -98,13 +98,13 @@ type MetaConfig struct {
 // ProcessMeta contains metadata about a tracked process.
 type ProcessMeta struct {
 	// process name retrieved from /proc/PID/comm
-	Name string
+	Name libpf.String
 	// executable path retrieved from /proc/PID/exe
-	Executable string
+	Executable libpf.String
 	// process env vars from /proc/PID/environ
-	EnvVariables map[string]string
+	EnvVariables map[libpf.String]libpf.String
 	// container ID retrieved from /proc/PID/cgroup
-	ContainerID string
+	ContainerID libpf.String
 }
 
 // Process is the interface to inspect ELF coredump/process.
@@ -122,7 +122,7 @@ type Process interface {
 	GetProcessMeta(MetaConfig) ProcessMeta
 
 	// GetExe returns the executable path of the process.
-	GetExe() (string, error)
+	GetExe() (libpf.String, error)
 
 	// GetMappings reads and parses process memory mappings.
 	GetMappings() ([]Mapping, uint32, error)

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -51,8 +51,8 @@ func (d *dummyProcess) GetProcessMeta(_ process.MetaConfig) process.ProcessMeta 
 	return process.ProcessMeta{}
 }
 
-func (d *dummyProcess) GetExe() (string, error) {
-	return "", errors.New("not implemented")
+func (d *dummyProcess) GetExe() (libpf.String, error) {
+	return libpf.NullString, errors.New("not implemented")
 }
 
 func (d *dummyProcess) GetMappings() ([]process.Mapping, uint32, error) {

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -71,7 +71,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 
 		rp := profiles.ResourceProfiles().AppendEmpty()
 		rp.Resource().Attributes().PutStr(string(semconv.ContainerIDKey),
-			string(containerID))
+			containerID.String())
 		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
@@ -244,9 +244,9 @@ func (p *Pdata) setProfile(
 		}
 		sample.SetStackIndex(stackIdx)
 
-		exeName := traceKey.ExecutablePath
-		if exeName != "" {
-			_, exeName = filepath.Split(exeName)
+		exeName := ""
+		if traceKey.ExecutablePath != libpf.NullString {
+			_, exeName = filepath.Split(traceKey.ExecutablePath.String())
 		}
 
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
@@ -255,7 +255,7 @@ func (p *Pdata) setProfile(
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ProcessExecutableNameKey, exeName)
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
-			semconv.ProcessExecutablePathKey, traceKey.ExecutablePath)
+			semconv.ProcessExecutablePathKey, traceKey.ExecutablePath.String())
 
 		attrMgr.AppendOptionalString(sample.AttributeIndices(),
 			semconv.ServiceNameKey, traceKey.ApmServiceName)
@@ -267,7 +267,7 @@ func (p *Pdata) setProfile(
 			semconv.CPULogicalNumberKey, int64(traceKey.CPU))
 
 		for key, value := range traceInfo.EnvVars {
-			env := semconv.ProcessEnvironmentVariable(key, value)
+			env := semconv.ProcessEnvironmentVariable(key.String(), value.String())
 			attrMgr.AppendOptionalString(
 				sample.AttributeIndices(),
 				env.Key, env.Value.AsString())

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -181,7 +181,7 @@ func TestFunctionTableOrder(t *testing.T) {
 			d, err := New(100, nil)
 			require.NoError(t, err)
 			tree := make(samples.TraceEventsTree)
-			tree[""] = tt.events
+			tree[libpf.NullString] = tt.events
 			res, _ := d.Generate(tree, tt.name, "version")
 			require.Equal(t, tt.expectedResourceProfiles, res.ResourceProfiles().Len())
 			if tt.expectedResourceProfiles == 0 {
@@ -231,7 +231,7 @@ func TestProfileDuration(t *testing.T) {
 			require.NoError(t, err)
 
 			tree := make(samples.TraceEventsTree)
-			tree[""] = tt.events
+			tree[libpf.NullString] = tt.events
 			res, err := d.Generate(tree, tt.name, "version")
 			require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func TestGenerate_EmptyTree(t *testing.T) {
 }
 
 func singleFrameTrace(ty libpf.FrameType, mappingFile libpf.FrameMappingFile,
-	lineno libpf.AddressOrLineno, funcName, sourceFile string,
+	lineno libpf.AddressOrLineno, funcName string, sourceFile libpf.String,
 	sourceLine libpf.SourceLineno,
 ) libpf.Frames {
 	frames := make(libpf.Frames, 0, 1)
@@ -261,7 +261,7 @@ func singleFrameTrace(ty libpf.FrameType, mappingFile libpf.FrameMappingFile,
 		Type:            ty,
 		AddressOrLineno: lineno,
 		FunctionName:    libpf.Intern(funcName),
-		SourceFile:      libpf.Intern(sourceFile),
+		SourceFile:      sourceFile,
 		SourceLine:      sourceLine,
 		MappingFile:     mappingFile,
 	})
@@ -273,10 +273,10 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 	require.NoError(t, err)
 
 	funcName := "main"
-	filePath := "/bin/test"
+	filePath := libpf.Intern("/bin/test")
 	mappingFile := libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
 		FileID:   libpf.NewFileID(1, 2),
-		FileName: libpf.Intern(filePath),
+		FileName: filePath,
 	})
 
 	traceKey := samples.TraceAndMetaKey{
@@ -292,12 +292,14 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 				Frames: singleFrameTrace(libpf.GoFrame, mappingFile,
 					0x10, funcName, filePath, 42),
 				Timestamps: []uint64{100},
-				EnvVars:    map[string]string{"FOO": "BAR"},
+				EnvVars:    map[libpf.String]libpf.String{
+					libpf.Intern("FOO"): libpf.Intern("BAR"),
+				},
 			},
 		},
 	}
 	tree := samples.TraceEventsTree{
-		"container1": events,
+		libpf.Intern("container1"): events,
 	}
 
 	profiles, err := d.Generate(tree, "agent", "v1")
@@ -348,8 +350,9 @@ func TestGenerate_MultipleOriginsAndContainers(t *testing.T) {
 		FileID:   libpf.NewFileID(5, 6),
 		FileName: libpf.Intern("/bin/foo"),
 	})
-	traceKey := samples.TraceAndMetaKey{ExecutablePath: "/bin/foo"}
-	frames := singleFrameTrace(libpf.PythonFrame, mappingFile, 0x20, "f", "/bin/foo", 1)
+	exec := libpf.Intern("/bin/foo")
+	traceKey := samples.TraceAndMetaKey{ExecutablePath: exec}
+	frames := singleFrameTrace(libpf.PythonFrame, mappingFile, 0x20, "f", exec, 1)
 
 	events1 := map[libpf.Origin]samples.KeyToEventMapping{
 		support.TraceOriginSampling: {
@@ -375,8 +378,8 @@ func TestGenerate_MultipleOriginsAndContainers(t *testing.T) {
 		},
 	}
 	tree := samples.TraceEventsTree{
-		"c1": events1,
-		"c2": events2,
+		libpf.Intern("c1"): events1,
+		libpf.Intern("c2"): events2,
 	}
 
 	profiles, err := d.Generate(tree, "agent", "v2")
@@ -405,10 +408,10 @@ func TestGenerate_StringAndFunctionTablePopulation(t *testing.T) {
 	require.NoError(t, err)
 
 	funcName := "myfunc"
-	filePath := "/bin/bar"
+	filePath := libpf.Intern("/bin/bar")
 	mappingFile := libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
 		FileID:   libpf.NewFileID(7, 8),
-		FileName: libpf.Intern(filePath),
+		FileName: filePath,
 	})
 
 	traceKey := samples.TraceAndMetaKey{ExecutablePath: filePath}
@@ -422,7 +425,7 @@ func TestGenerate_StringAndFunctionTablePopulation(t *testing.T) {
 		},
 	}
 	tree := samples.TraceEventsTree{
-		"c": events,
+		libpf.Intern("c"): events,
 	}
 
 	profiles, err := d.Generate(tree, "agent", "v3")
@@ -437,12 +440,12 @@ func TestGenerate_StringAndFunctionTablePopulation(t *testing.T) {
 		stringTableSlice = append(stringTableSlice, dic.StringTable().At(i))
 	}
 	assert.Contains(t, stringTableSlice, funcName)
-	assert.Contains(t, stringTableSlice, filePath)
+	assert.Contains(t, stringTableSlice, filePath.String())
 	// The function table should have the function name and file path indices set
 	require.Equal(t, 2, dic.FunctionTable().Len())
 	fn := dic.FunctionTable().At(1)
 	assert.Equal(t, funcName, dic.StringTable().At(int(fn.NameStrindex())))
-	assert.Equal(t, filePath, dic.StringTable().At(int(fn.FilenameStrindex())))
+	assert.Equal(t, filePath.String(), dic.StringTable().At(int(fn.FilenameStrindex())))
 }
 
 func singleFrameNative(mappingFile libpf.FrameMappingFile, lineno libpf.AddressOrLineno,
@@ -464,10 +467,10 @@ func TestGenerate_NativeFrame(t *testing.T) {
 	d, err := New(100, nil)
 	require.NoError(t, err)
 
-	filePath := "/usr/lib/libexample.so"
+	filePath := libpf.Intern("/usr/lib/libexample.so")
 	mappingFile := libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
 		FileID:   libpf.NewFileID(9, 10),
-		FileName: libpf.Intern(filePath),
+		FileName: filePath,
 	})
 
 	traceKey := samples.TraceAndMetaKey{
@@ -485,7 +488,7 @@ func TestGenerate_NativeFrame(t *testing.T) {
 		},
 	}
 	tree := samples.TraceEventsTree{
-		"native_container": events,
+		libpf.Intern("native_container"): events,
 	}
 
 	profiles, err := d.Generate(tree, "agent", "v1")
@@ -543,7 +546,7 @@ func TestGenerate_NativeFrame(t *testing.T) {
 	// Verify the filename is correctly set in the mapping
 	filenameStrIndex := nativeMapping.FilenameStrindex()
 	filename := dic.StringTable().At(int(filenameStrIndex))
-	assert.Equal(t, filePath, filename)
+	assert.Equal(t, filePath.String(), filename)
 
 	// For native frames, function information is not populated in the function table
 	// since it's resolved by the backend. The function table should be empty.
@@ -608,7 +611,7 @@ func TestStackTableOrder(t *testing.T) {
 			d, err := New(100, nil)
 			require.NoError(t, err)
 			tree := make(samples.TraceEventsTree)
-			tree[""] = tt.events
+			tree[libpf.NullString] = tt.events
 			res, _ := d.Generate(tree, tt.name, "version")
 
 			dic := res.Dictionary()

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -10,15 +10,15 @@ import (
 type TraceEventMeta struct {
 	Timestamp      libpf.UnixTime64
 	Comm           string
-	ProcessName    string
-	ExecutablePath string
+	ProcessName    libpf.String
+	ExecutablePath libpf.String
 	APMServiceName string
-	ContainerID    string
+	ContainerID    libpf.String
 	PID, TID       libpf.PID
 	CPU            int
 	Origin         libpf.Origin
 	OffTime        int64
-	EnvVars        map[string]string
+	EnvVars        map[libpf.String]libpf.String
 }
 
 // TraceEvents holds known information about a trace.
@@ -26,7 +26,7 @@ type TraceEvents struct {
 	Frames     libpf.Frames
 	Timestamps []uint64 // in nanoseconds
 	OffTimes   []int64  // in nanoseconds
-	EnvVars    map[string]string
+	EnvVars    map[libpf.String]libpf.String
 	Labels     map[string]string
 }
 
@@ -44,9 +44,9 @@ type TraceAndMetaKey struct {
 	Tid            int64
 	CPU            int64
 	// Process name is retrieved from /proc/PID/comm
-	ProcessName string
+	ProcessName libpf.String
 	// Executable path is retrieved from /proc/PID/exe
-	ExecutablePath string
+	ExecutablePath libpf.String
 
 	// ExtraMeta stores extra meta info that may have been produced by a
 	// `SampleAttrProducer` instance. May be nil.
@@ -58,7 +58,7 @@ type TraceAndMetaKey struct {
 type TraceEventsTree map[ContainerID]map[libpf.Origin]KeyToEventMapping
 
 // ContainerID represents an extracted key from /proc/<PID>/cgroup.
-type ContainerID string
+type ContainerID = libpf.String
 
 // KeyToEventMapping supports temporary mapping traces to additional information.
 type KeyToEventMapping map[TraceAndMetaKey]*TraceEvents


### PR DESCRIPTION
Typically much of this stays the same, so this should reduce GC pressure. Reading of the metadata is also improved to stress GC less.