### PR TITLE
Remove process.ExtractAsFile

### DIFF
--- a/interpreter/loaderinfo.go
+++ b/interpreter/loaderinfo.go
@@ -9,7 +9,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
-	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
@@ -68,14 +67,4 @@ func (i *LoaderInfo) FileName() string {
 // Gaps returns the gaps for the executable of this LoaderInfo.
 func (i *LoaderInfo) Gaps() []util.Range {
 	return i.gaps
-}
-
-// ExtractAsFile returns a filename referring to the ELF executable, extracting
-// it from a backing archive if needed.
-func (i *LoaderInfo) ExtractAsFile() (string, error) {
-	if pr, ok := i.elfRef.ELFOpener.(process.Process); ok {
-		return pr.ExtractAsFile(i.FileName())
-	}
-	return "", fmt.Errorf("unable to open main executable '%v' due to wrong interface type",
-		i.FileName())
 }

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -323,12 +323,6 @@ func (cd *CoredumpProcess) OpenELF(path string) (*pfelf.File, error) {
 	return nil, fmt.Errorf("ELF file `%s` not found", path)
 }
 
-// ExtractAsFile implements the Process interface.
-func (cd *CoredumpProcess) ExtractAsFile(_ string) (string, error) {
-	// Coredumps do not contain the original backing files.
-	return "", errors.New("coredump does not support opening backing file")
-}
-
 // getFile returns (creating if needed) a matching CoredumpFile for given file name.
 func (cd *CoredumpProcess) getFile(name string) *CoredumpFile {
 	if cf, ok := cd.files[name]; ok {

--- a/process/process.go
+++ b/process/process.go
@@ -458,7 +458,3 @@ func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
 	// Fall back to opening the file using the process specific root
 	return pfelf.Open(path.Join("/proc", strconv.Itoa(int(sp.pid)), "root", file))
 }
-
-func (sp *systemProcess) ExtractAsFile(file string) (string, error) {
-	return path.Join("/proc", strconv.Itoa(int(sp.pid)), "root", file), nil
-}

--- a/process/types.go
+++ b/process/types.go
@@ -143,13 +143,6 @@ type Process interface {
 	// CalculateMappingFileID calculates FileID of the backing file.
 	CalculateMappingFileID(*Mapping) (libpf.FileID, error)
 
-	// ExtractAsFile returns a filename suitable for opening the given file from
-	// the target process namespace. This is a last resort method to access the file
-	// when the ReaderAt interface from OpenMappingFile is not sufficient. The returned
-	// filename may refer to /proc or be a temporarily file, and it must not be modified
-	// or deleted.
-	ExtractAsFile(string) (string, error)
-
 	io.Closer
 
 	pfelf.ELFOpener

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -83,10 +83,6 @@ func (d *dummyProcess) OpenELF(name string) (*pfelf.File, error) {
 	return pfelf.Open(name)
 }
 
-func (d *dummyProcess) ExtractAsFile(name string) (string, error) {
-	return name, nil
-}
-
 func (d *dummyProcess) Close() error {
 	return nil
 }

--- a/tools/coredump/new.go
+++ b/tools/coredump/new.go
@@ -109,16 +109,6 @@ func (tc *trackedCoredump) OpenELF(fileName string) (*pfelf.File, error) {
 	return tc.CoredumpProcess.OpenELF(fileName)
 }
 
-func (tc *trackedCoredump) ExtractAsFile(fileName string) (string, error) {
-	prefixedFileName := path.Join(tc.prefix, fileName)
-	if _, err := os.Stat(prefixedFileName); err != nil {
-		tc.warnMissing(fileName)
-		return "", err
-	}
-	tc.seen[fileName] = libpf.Void{}
-	return prefixedFileName, nil
-}
-
 func newNewCmd(store *modulestore.Store) *ffcli.Command {
 	args := &newCmd{store: store}
 

--- a/tools/coredump/storecoredump.go
+++ b/tools/coredump/storecoredump.go
@@ -61,27 +61,6 @@ func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 	return scd.CoredumpProcess.OpenELF(path)
 }
 
-func (scd *StoreCoredump) ExtractAsFile(file string) (string, error) {
-	info, ok := scd.modules[file]
-	if !ok {
-		return "", os.ErrNotExist
-	}
-
-	f, err := os.CreateTemp("", "ebpf-profiler-coredump.*")
-	if err != nil {
-		return "", err
-	}
-	tmpFile := f.Name()
-	_ = f.Close()
-
-	if err := scd.store.UnpackModuleToPath(info.Ref, tmpFile); err != nil {
-		_ = os.Remove(tmpFile)
-		return "", err
-	}
-	scd.tempFiles[file] = tmpFile
-	return tmpFile, nil
-}
-
 func (scd *StoreCoredump) Close() error {
 	for _, tmpFile := range scd.tempFiles {
 		_ = os.Remove(tmpFile)


### PR DESCRIPTION
The Rust based Golang symbolizer needed this previously. Now that it is gone, remove this interface as unneeded.