### PR TITLE
Add go stable to collector tests

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Set up environment
         uses: ./.github/workflows/env
+      - name: Set up Go Stable
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version: stable
       - name: Cache coredump modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:


### PR DESCRIPTION
This should fix the issue generator not working because the Go version has the wrong patch.
See https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/19488856032/job/55776976935

Note: This only fixes the issue generator. It does not fix the test itself.