### PR TITLE
tools: fix missing golang.org/x/term

### DIFF
--- a/tools.sum
+++ b/tools.sum
@@ -986,6 +986,7 @@ golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=
 golang.org/x/term v0.35.0/go.mod h1:TPGtkTLesOwf2DE8CgVYiZinHAOuy5AYUYT1lENIZnA=
+golang.org/x/term v0.36.0 h1:zMPR+aF8gfksFprF/Nc/rd1wRS1EI6nDBGyWAvDzx2Q=
 golang.org/x/term v0.36.0/go.mod h1:Qu394IJq6V6dCBRgwqshf3mPF85AqzYEzofzRdZkWss=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
make test-junit failed with the following error:
```
go tool -modfile=tools.mod gotestsum --junitfile /tmp/testresults/junit.xml -- -buildvcs=false -ldflags="-X go.opentelemetry.io/ebpf-profiler/vc.version=v0.0.0 -X go.opentelemetry.io/ebpf-profiler/vc.revision=main-646ba4cd -X go.opentelemetry.io/ebpf-profiler/vc.buildTimestamp=1763546914 -extldflags=-static" -tags osusergo,netgo ./...
../../../../pkg/mod/gotest.tools/gotestsum@v1.13.0/testjson/dotformat.go:12:2: missing go.sum entry for module providing package golang.org/x/term (imported by gotest.tools/gotestsum/testjson); to add:
	go get gotest.tools/gotestsum/testjson@v1.13.0
make: *** [Makefile:112: test-junit] Error 1
```

Fixed issue with:
```
go get -modfile=tools.mod gotest.tools/gotestsum/testjson@v1.13.0
```