### PR TITLE
fix: ensure concurrent accesses to ProcessManager.interpreters and ProcessManager.pidToProcessInfo maps are safe

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -268,7 +268,8 @@ func (pm *ProcessManager) maybeNotifyAPMAgent(
 	rawTrace *host.Trace, umTraceHash libpf.TraceHash, count uint16,
 ) string {
 	pm.mu.RLock()
-	// Keeping the lock until end of the function is needed because inner map can be modified concurrently (by synchronizeMappings/newFrameMapping).
+	// Keeping the lock until end of the function is needed because inner map can be modified
+	// concurrently (by synchronizeMappings/newFrameMapping).
 	defer pm.mu.RUnlock()
 	pidInterp, ok := pm.interpreters[rawTrace.PID]
 	if !ok {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -131,6 +131,7 @@ func (pm *ProcessManager) getPidInformation(pid libpf.PID, pr process.Process,
 }
 
 // assignInterpreter will update the interpreters maps with given interpreter.Instance.
+// Caller is responsible to hold pm.mu write lock to avoid race conditions.
 func (pm *ProcessManager) assignInterpreter(pid libpf.PID, key util.OnDiskFileIdentifier,
 	instance interpreter.Instance,
 ) {
@@ -293,6 +294,7 @@ func (pm *ProcessManager) processRemovedMapping(pid libpf.PID, m *Mapping) uint6
 	return uint64(deleted)
 }
 
+// Caller is responsible to hold pm.mu write lock to avoid race conditions.
 func (pm *ProcessManager) processRemovedInterpreters(pid libpf.PID,
 	interpretersValid libpf.Set[util.OnDiskFileIdentifier]) {
 	if !pm.interpreterTracerEnabled {


### PR DESCRIPTION
Noticed some panics due to concurrent read and write to `ProcessManager.interpreters`:
 
> fatal error: concurrent map read and map write
> 
> goroutine 78 [running]:
> internal/runtime/maps.fatal({0x2b75cf7?, 0x421173?})
> 	/opt/hostedtoolcache/go/1.25.3/x64/src/runtime/panic.go:1046 +0x18
> go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).symbolizeFrame(0xc0002333b0, 0x16b6d1, 0xc009ee2a20, 0xc011940330)
> 	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20251121135054-4e7dcfdb7097/processmanager/manager.go:229 +0x234
> go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).convertFrame(0xc0002333b0, 0x16b6d1, 0xc009ee2a20, 0xc011940330)
> 	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20251121135054-4e7dcfdb7097/processmanager/manager.go:242 +0x291
> go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).HandleTrace(0xc0002333b0, 0xc00d31f860)
> 	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20251121135054-4e7dcfdb7097/processmanager/manager.go:375 +0x77a
> go.opentelemetry.io/ebpf-profiler/tracer.(*Tracer).HandleTrace(...)
> 	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20251121135054-4e7dcfdb7097/tracer/tracer.go:1167
> github.com/DataDog/dd-otel-host-profiler/runner.startTraceHandling.func1()
> 	/home/runner/work/dd-otel-host-profiler/dd-otel-host-profiler/runner/runner.go:73 +0xb7
> created by github.com/DataDog/dd-otel-host-profiler/runner.startTraceHandling in goroutine 1
> 	/home/runner/work/dd-otel-host-profiler/dd-otel-host-profiler/runner/runner.go:67 +0xf9

Fixes:
1. Updated ProcessManager.newFrameMapping to wrap the calls to assignLibcInfo and handleNewInterpreter with a write lock.
2. Updated ProcessManager.maybeNotifyAPMAgent to keep the read lock until end of the function.
3. Updated ProcessManager.HandleTrace to acquire a read lock before releasing resources.
4. Updated ProcessManager.synchronizeMappings to wrap processRemovedInterpreters with a write lock.