### PR TITLE
Reduce memory overhead of traces

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -312,7 +312,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *host.Trace) {
 	pid := bpfTrace.PID
 	kernelFramesLen := len(bpfTrace.KernelFrames)
 	trace := &libpf.Trace{
-		Frames:       make(libpf.Frames, kernelFramesLen, 512),
+		Frames:       make(libpf.Frames, kernelFramesLen, kernelFramesLen+len(bpfTrace.Frames)),
 		CustomLabels: bpfTrace.CustomLabels,
 	}
 	copy(trace.Frames, bpfTrace.KernelFrames)

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,7 +6,6 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
-	"slices"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -89,7 +88,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		return nil
 	}
 	(*eventsTree)[samples.ContainerID(containerID)][meta.Origin][key] = &samples.TraceEvents{
-		Frames:     slices.Clone(trace.Frames),
+		Frames:     trace.Frames,
 		Timestamps: []uint64{uint64(meta.Timestamp)},
 		OffTimes:   []int64{meta.OffTime},
 		EnvVars:    meta.EnvVars,


### PR DESCRIPTION
We noticed a large increase in profiler RSS (+170MiB) when updating opentelemetry-ebpf-profiler compare to the previous version:
<img width="1456" height="611" alt="image" src="https://github.com/user-attachments/assets/80bc5c3b-6d9a-4a05-817d-eb29430b2646" />

The increase was mostly because of memory allocated in `HandleTrace`:
<img width="2375" height="676" alt="image" src="https://github.com/user-attachments/assets/4e13d785-d722-4eca-9ed0-4b37e9b89f37" />

And more precisely when allocating the frame array for the new trace:
<img width="1235" height="465" alt="image" src="https://github.com/user-attachments/assets/6f1469a4-a7a3-4900-b56d-b6b6b9156025" />

This increase is most probably explained by this [commit](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/commit/97be3669b0f0d66f52ff9d6d33cd482f4eddb6d6) which added a fixed capacity of 512 frames for the new trace.

After investigating, we figured out that the reporter is expected to clone the frames for the reported trace instead of holding a reference to them, and that would probably solve the memory increase we observed.
But that's still:
* a heap allocation in HandleTrace (array cannot be stack allocated because it escapes `HandleTrace` function):
```
escape(make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames)) escapes to heap)optimizer details
manager.go(324, 21): escflow: flow: {storage for &libpf.Trace{...}} ← &{storage for make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames))}:
manager.go(324, 21): escflow: from make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames)) (spill)
manager.go(323, 23): escflow: from libpf.Trace{...} (struct literal element)
```
* a heap allocation + copy in reporter

It's seems more advantageous to adjust the capacity to the number of kernel and bpf frames: symbolication might add some additional frames because of inlining, but it does not seem vert common. Hence that would lead to a single heap allocation in HandleTrace without copy in reporter.

Testing on our side this change confirmed that it solved the memory increase:
<img width="2483" height="830" alt="image" src="https://github.com/user-attachments/assets/a4c7a823-f55d-46a1-982e-50134e590706" />

Without CPU increase:
<img width="2483" height="830" alt="image" src="https://github.com/user-attachments/assets/76168fb9-53ab-4026-bbb0-9c3bc1041a3a" />
