### PR TITLE
feat: added dynamic logger level changes + external logger configuration

### DIFF
--- a/internal/log/logging.go
+++ b/internal/log/logging.go
@@ -27,14 +27,14 @@ var globalLogger = func() *atomic.Pointer[slog.Logger] {
 }()
 
 // SetLogger sets the global logger to l while respecting programLevel's log
-// level. When default logger is overidden, SetLevelLogger has no effect.
+// level. When default logger is overidden, SetLevel has no effect.
 func SetLogger(l slog.Logger) {
 	globalLogger.Store(&l)
 }
 
-// SetLevelLogger dynamically changes the logger's log level, excluding
+// SetLevel dynamically changes the logger's log level, excluding
 // those set via SetLogger.
-func SetLevelLogger(level slog.Level) {
+func SetLevel(level slog.Level) {
 	programLevel.Set(level)
 }
 

--- a/interpreter/golabels/integrationtests/golabels_integration_test.go
+++ b/interpreter/golabels/integrationtests/golabels_integration_test.go
@@ -87,7 +87,7 @@ func Test_Golabels(t *testing.T) {
 			enabledTracers.Enable(tracertypes.Labels)
 			enabledTracers.Enable(tracertypes.GoTracer)
 
-			log.SetLevelLogger(slog.LevelDebug)
+			log.SetLevel(slog.LevelDebug)
 			trc, err := tracer.NewTracer(ctx, &tracer.Config{
 				Intervals:              &mockIntervals{},
 				IncludeTracers:         enabledTracers,

--- a/log/logging.go
+++ b/log/logging.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// SetLevel configures the log level for the profiler's internal logger.
-	SetLevel = log.SetLevelLogger
+	SetLevel = log.SetLevel
 	// SetLogger configures the profiler's internal logger.
 	SetLogger = log.SetLogger
 )

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func mainWithExitCode() exitCode {
 	}
 
 	if cfg.VerboseMode {
-		log.SetLevelLogger(slog.LevelDebug)
+		log.SetLevel(slog.LevelDebug)
 		// Dump the arguments in debug mode.
 		cfg.Dump()
 	}

--- a/tools/coredump/analyze.go
+++ b/tools/coredump/analyze.go
@@ -82,7 +82,7 @@ func (cmd *analyzeCmd) exec(context.Context, []string) (err error) {
 	}
 
 	if cmd.debugLog {
-		log.SetLevelLogger(slog.LevelDebug)
+		log.SetLevel(slog.LevelDebug)
 	}
 
 	var proc process.Process


### PR DESCRIPTION
Adds an external `log` package to allow library users of `opentelemetry-ebpf-profiler` to change the log level, and the logger itself.
`programLevel` is responsible for minimum log levels, even when using a custom logger handler.