### PR TITLE
go: add CPU handling to noFPSourceSuffixes

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -596,6 +596,8 @@ var noFPSourceSuffixes = []string{
 	"/src/crypto/sha256/sha256.go",
 	"/src/crypto/sha512/sha512.go",
 	"/src/crypto/elliptic/p256_asm.go",
+	"/src/internal/cpu/cpu_arm64.go",
+	"/src/internal/cpu/cpu_x86.go",
 	"golang.org/x/crypto/curve25519/curve25519_amd64.go",
 	"golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.go",
 }


### PR DESCRIPTION
Go 1.26 will introduce a new [simd/archsimd](https://go.dev/doc/go1.26#simd) package. This package makes use of CPU features that are implemented in some parts in assembly. Therefore extend noFPSourceSuffixes with these files, that call assembly code.