### PR TITLE
gopclntab: Use address of .text section for Go 1.26

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -469,7 +469,11 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 		g.funcdata = g.functab
 		g.textStart = hdr118.textStart
 		if g.textStart == 0 {
-			// Starting with Go 1.26 the field textStart is set to 0.
+			// Starting with Go 1.26 the field textStart is set to 0 but moduledata.text
+			// which contains the same value is unaffected.
+			// The following logic assumes that .text matches moduledata.text
+			// which might not always be true (in which case we need to switch to moduledata.text
+			// which can be found through runtime.firstmoduledata).
 			//
 			//nolint:lll
 			// See https://github.com/golang/go/commit/0e1bd8b5f17e337df0ffb57af03419b96c695fe4


### PR DESCRIPTION
Starting with Go 1.26 the field textStart in the gopclntab header is set to 0. Use the address of the .text section instead.