### PR TITLE
CI: run cargo test on Cargo.* changes

### DIFF
--- a/.github/workflows/unit-test-rust.yml
+++ b/.github/workflows/unit-test-rust.yml
@@ -5,10 +5,14 @@ on:
     branches: [main]
     paths:
       - rust-crates/**
+      - Cargo.toml
+      - Cargo.lock
   pull_request:
     branches: ["**"]
     paths:
       - rust-crates/**
+      - Cargo.toml
+      - Cargo.lock
 
 permissions:
   contents: read


### PR DESCRIPTION
At the moment, `cargo test` does not run if dependencies get updated.

This results in issues like this:
https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/20454325313/job/58773196338?pr=1035

Update CI to run rust related tests also on dependency updates.