### PR TITLE
refactor(controller): encapsulate context cancellation logic

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -50,7 +50,7 @@ func (c *Controller) Start(ctx context.Context) error {
 	intervals := times.New(c.config.ReporterInterval, c.config.MonitorInterval,
 		c.config.ProbabilisticInterval)
 
-	ctx, c.cancelFn = context.WithCancel(ctx)
+	ctx, c.cancelFunc = context.WithCancel(ctx)
 
 	// Start periodic synchronization with the realtime clock
 	times.StartRealtimeSync(ctx, c.config.ClockSyncInterval)


### PR DESCRIPTION
When the Controller is used as a library (e.g., within the OpenTelemetry Collector), the context passed to Start() is often long-lived and not cancelled when the component is shut down. Previously, this caused background tasks, such as startTraceHandling and trace handling loops, to leak or persist after Shutdown() was called.

This change moves the creation of a cancellable context inside Controller.Start(). The Controller now manages its own lifecycle using an internal CancelFunc.

Differently than the [profiler's main](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/main.go#L91), the [collectors start/shutdown workflow](https://github.com/open-telemetry/opentelemetry-collector/blob/main/otelcol/collector.go#L350-L392) does not explicitly cancel the `Start` context (or SIGTERM cancellation).