### PR TITLE
tracer: load only interpreter specific maps for enabled interpreters

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -225,7 +225,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to load eBPF code: %v", err)
 	}
 
-	ebpfHandler, err := pmebpf.LoadMaps(ctx, ebpfMaps, stackdeltaInnerMapSpec)
+	ebpfHandler, err := pmebpf.LoadMaps(ctx, cfg.IncludeTracers, ebpfMaps, stackdeltaInnerMapSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eBPF maps: %v", err)
 	}
@@ -522,34 +522,6 @@ func rewriteMaps(coll *cebpf.CollectionSpec, maps map[string]*cebpf.Map) error {
 	return nil
 }
 
-// isMapEnabled checks if the given map is enabled and should be loaded.
-func isMapEnabled(mapName string, includeTracers types.IncludedTracers) bool {
-	switch mapName {
-	case "perl_procs":
-		return includeTracers.Has(types.PerlTracer)
-	case "php_procs":
-		return includeTracers.Has(types.PHPTracer)
-	case "py_procs":
-		return includeTracers.Has(types.PythonTracer)
-	case "hotspot_procs":
-		return includeTracers.Has(types.HotspotTracer)
-	case "ruby_procs":
-		return includeTracers.Has(types.RubyTracer)
-	case "v8_procs":
-		return includeTracers.Has(types.V8Tracer)
-	case "dotnet_procs":
-		return includeTracers.Has(types.DotnetTracer)
-	case "beam_procs":
-		return includeTracers.Has(types.BEAMTracer)
-	case "go_labels_procs", "apm_int_procs":
-		// go_labels_procs and apm_int_procs are called from
-		// unwind_stop and therefore need to be available all the time.
-		return true
-	default:
-		return true // Not an interpreter map, so it should be loaded
-	}
-}
-
 // loadAllMaps loads all eBPF maps that are used in our eBPF programs.
 func loadAllMaps(coll *cebpf.CollectionSpec, cfg *Config,
 	ebpfMaps map[string]*cebpf.Map,
@@ -588,7 +560,7 @@ func loadAllMaps(coll *cebpf.CollectionSpec, cfg *Config,
 			continue
 		}
 
-		if !isMapEnabled(mapName, cfg.IncludeTracers) {
+		if !types.IsMapEnabled(mapName, cfg.IncludeTracers) {
 			log.Debugf("Skipping eBPF map %s: tracer not enabled", mapName)
 			continue
 		}

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -51,6 +51,34 @@ func init() {
 	}
 }
 
+// IsMapEnabled checks if the given map is enabled and should be loaded.
+func IsMapEnabled(mapName string, includeTracers IncludedTracers) bool {
+	switch mapName {
+	case "perl_procs":
+		return includeTracers.Has(PerlTracer)
+	case "php_procs":
+		return includeTracers.Has(PHPTracer)
+	case "py_procs":
+		return includeTracers.Has(PythonTracer)
+	case "hotspot_procs":
+		return includeTracers.Has(HotspotTracer)
+	case "ruby_procs":
+		return includeTracers.Has(RubyTracer)
+	case "v8_procs":
+		return includeTracers.Has(V8Tracer)
+	case "dotnet_procs":
+		return includeTracers.Has(DotnetTracer)
+	case "beam_procs":
+		return includeTracers.Has(BEAMTracer)
+	case "go_labels_procs", "apm_int_procs":
+		// go_labels_procs and apm_int_procs are called from
+		// unwind_stop and therefore need to be available all the time.
+		return true
+	default:
+		return true // Not an interpreter map, so it should be loaded
+	}
+}
+
 // tracerTypeFromName returns the tracer type for the given name.
 func tracerTypeFromName(s string) (tracerType, bool) {
 	tt, ok := tracerNameToType[s]


### PR DESCRIPTION
Reduce memory requirement by loading only eBPF maps of enabled tracers.