### PR TITLE
nativeunwind: fix Go 1.26

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -479,7 +479,6 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 			// See https://github.com/golang/go/commit/0e1bd8b5f17e337df0ffb57af03419b96c695fe4
 			if sec := ef.Section(".text"); sec != nil {
 				g.textStart = uintptr(sec.Addr)
-				break
 			}
 		}
 		// With the change of the type of the first field of _func in Go 1.18, this


### PR DESCRIPTION
As mentioned by @bobrik in https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1032#issuecomment-3762817151 I introduced a bug when handling Go 1.26 with https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1032.

Due to the incorrect break statement, `g.funcMapSize` and `g.funSize` are not set correctly and therefore break stack unwinding.

How to test this change:
```
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ebpf: generate
        $(MAKE) $(EBPF_FLAGS) -C support/ebpf
 
 ebpf-profiler: generate ebpf
-       go build $(GO_FLAGS) -tags $(GO_TAGS)
+       GOTOOLCHAIN=go1.26rc2 go build $(GO_FLAGS) -tags $(GO_TAGS)
 
```

When handling Go 1.26 binaries, there is still a log entry, like `level=ERROR msg="Failed to load /path/to/my/go/1.26/binary: unsupported Go version go1.26rc2 (need >= 1.13 and <= 1.25)"`. This log entry originates from the Go labels handling - which I didn't look into yet. My priority is/was being able to handle stack unwinding.