### PR TITLE
Use batch lookup and delete for monitorPIDEventsMap

### DIFF
--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -66,8 +66,9 @@ type ebpfMapsImpl struct {
 	errCounterLock sync.Mutex
 	errCounter     map[metrics.MetricID]int64
 
-	hasGenericBatchOperations bool
-	hasLPMTrieBatchOperations bool
+	hasGenericBatchOperations      bool
+	hasGenericBatchLookupAndDelete bool
+	hasLPMTrieBatchOperations      bool
 
 	updateWorkers *asyncMapUpdaterPool
 }
@@ -119,6 +120,11 @@ func LoadMaps(ctx context.Context, includeTracers types.IncludedTracers,
 	if err := probeBatchOperations(cebpf.Hash); err == nil {
 		log.Infof("Supports generic eBPF map batch operations")
 		impl.hasGenericBatchOperations = true
+	}
+
+	if err := probeBatchLookupAndDelete(cebpf.Hash); err == nil {
+		log.Infof("Supports generic eBPF map batch lookup-and-delete")
+		impl.hasGenericBatchLookupAndDelete = true
 	}
 
 	if err := probeBatchOperations(cebpf.LPMTrie); err == nil {
@@ -322,9 +328,9 @@ func getPIDPageMappingInfo(fileID, biasAndUnwindProgram uint64) *support.PIDPage
 	return cInfo
 }
 
-// probeBatchOperations tests if the BPF syscall accepts batch operations. It
-// returns nil if batch operations are supported for mapType or an error otherwise.
-func probeBatchOperations(mapType cebpf.MapType) error {
+// probeMapOperations tests if the BPF syscall supports operations by running a supplied closure.
+// It returns nil if batch operations are supported for mapType or an error otherwise.
+func probeMapOperations[T constraints.Unsigned](mapType cebpf.MapType, probe func(*cebpf.Map, ptrCastMarshaler[T], ptrCastMarshaler[uint64]) error) error {
 	restoreRlimit, err := rlimit.MaximizeMemlock()
 	if err != nil {
 		// In environment like github action runners, we can not adjust rlimit.
@@ -342,16 +348,11 @@ func probeBatchOperations(mapType cebpf.MapType) error {
 		Flags:      features.BPF_F_NO_PREALLOC,
 	}
 
-	var keys any
-	switch mapType {
-	case cebpf.Array:
+	if mapType == cebpf.Array {
 		// KeySize for Array maps always needs to be 4.
 		mapSpec.KeySize = 4
 		// Array maps are always preallocated.
 		mapSpec.Flags = 0
-		keys = generateSlice[uint32](updates)
-	default:
-		keys = generateSlice[uint64](updates)
 	}
 
 	probeMap, err := cebpf.NewMap(mapSpec)
@@ -361,17 +362,63 @@ func probeBatchOperations(mapType cebpf.MapType) error {
 	}
 	defer probeMap.Close()
 
-	values := generateSlice[uint64](updates)
+	return probe(probeMap, generateSlice[T](updates), generateSlice[uint64](updates))
+}
 
+// probeBatchLookupAndDeleteInner is the inner check to be used by probeBatchLookupAndDelete.
+func probeBatchLookupAndDeleteInner[T constraints.Unsigned](probeMap *cebpf.Map, keys ptrCastMarshaler[T], values ptrCastMarshaler[uint64]) error {
 	n, err := probeMap.BatchUpdate(keys, values, nil)
 	if err != nil {
 		// Older kernel do not support batch operations on maps.
 		// This is just fine and we return here.
 		return err
 	}
-	if n != updates {
+
+	batchKeys := make([]T, 16)
+	batchValues := make([]uint64, 16)
+
+	n, err = probeMap.BatchLookupAndDelete(&cebpf.MapBatchCursor{}, batchKeys, batchValues, nil)
+	if err != nil && !errors.Is(err, cebpf.ErrKeyNotExist) {
+		return err
+	}
+
+	if n != len(keys) {
+		return fmt.Errorf("unexpected batch lookup-and-delete return: expected %d but got %d",
+			len(keys), n)
+	}
+
+	for i := range n {
+		// Keys can come out of order, so we're checking them against returned values instead of input keys.
+		if uint64(batchKeys[i]) != batchValues[i] {
+			return fmt.Errorf("mismatched batch lookup-and-delete at index %d: expected %d but got %d",
+				i, batchKeys[i], batchValues[i])
+		}
+	}
+
+	return nil
+}
+
+// probeBatchLookupAndDelete tests if the BPF syscall supports batch lookup-and-delete operations.
+// It returns nil if batch operations are supported for mapType or an error otherwise.
+func probeBatchLookupAndDelete(mapType cebpf.MapType) error {
+	if mapType == cebpf.Array {
+		return probeMapOperations(mapType, probeBatchLookupAndDeleteInner[uint32])
+	}
+
+	return probeMapOperations(mapType, probeBatchLookupAndDeleteInner[uint64])
+}
+
+// probeBatchOperationsInner is the inner check to be used by probeBatchOperations.
+func probeBatchOperationsInner[T constraints.Unsigned](probeMap *cebpf.Map, keys ptrCastMarshaler[T], values ptrCastMarshaler[uint64]) error {
+	n, err := probeMap.BatchUpdate(keys, values, nil)
+	if err != nil {
+		// Older kernel do not support batch operations on maps.
+		// This is just fine and we return here.
+		return err
+	}
+	if n != len(keys) {
 		return fmt.Errorf("unexpected batch update return: expected %d but got %d",
-			updates, n)
+			len(keys), n)
 	}
 
 	// Remove the probe entries from the map.
@@ -379,11 +426,21 @@ func probeBatchOperations(mapType cebpf.MapType) error {
 	if err != nil {
 		return err
 	}
-	if m != updates {
+	if m != len(keys) {
 		return fmt.Errorf("unexpected batch delete return: expected %d but got %d",
-			updates, m)
+			len(keys), m)
 	}
 	return nil
+}
+
+// probeBatchOperations tests if the BPF syscall supports batch update and delete operations.
+// It returns nil if batch operations are supported for mapType or an error otherwise.
+func probeBatchOperations(mapType cebpf.MapType) error {
+	if mapType == cebpf.Array {
+		return probeMapOperations(mapType, probeBatchOperationsInner[uint32])
+	}
+
+	return probeMapOperations(mapType, probeBatchOperationsInner[uint64])
 }
 
 // getMapID returns the mapID number to use for given number of stack deltas.
@@ -678,6 +735,12 @@ func (impl *ebpfMapsImpl) LookupPidPageInformation(pid libpf.PID, page uint64) (
 // on hash and array maps.
 func (impl *ebpfMapsImpl) SupportsGenericBatchOperations() bool {
 	return impl.hasGenericBatchOperations
+}
+
+// SupportsGenericBatchLookupAndDelete returns true if the kernel supports eBPF batch
+// lookup-and-delete operations on hash and array maps.
+func (impl *ebpfMapsImpl) SupportsGenericBatchLookupAndDelete() bool {
+	return impl.hasGenericBatchLookupAndDelete
 }
 
 // SupportsLPMTrieBatchOperations returns true if the kernel supports eBPF batch operations

--- a/processmanager/ebpf/ebpf_integration_test.go
+++ b/processmanager/ebpf/ebpf_integration_test.go
@@ -82,6 +82,11 @@ func TestBatchOperations(t *testing.T) {
 			if err != nil {
 				require.ErrorIs(t, err, cebpf.ErrNotSupported)
 			}
+
+			err = probeBatchLookupAndDelete(mapType)
+			if err != nil {
+				require.ErrorIs(t, err, cebpf.ErrNotSupported)
+			}
 		})
 	}
 }

--- a/processmanager/ebpfapi/ebpf.go
+++ b/processmanager/ebpfapi/ebpf.go
@@ -60,6 +60,10 @@ type EbpfHandler interface {
 	// on hash and array maps.
 	SupportsGenericBatchOperations() bool
 
+	// SupportsGenericBatchLookupAndDelete returns true if the kernel supports eBPF batch
+	// lookup-and-delete operations on hash and array maps.
+	SupportsGenericBatchLookupAndDelete() bool
+
 	// SupportsLPMTrieBatchOperations returns true if the kernel supports eBPF batch operations
 	// on LPM trie maps.
 	SupportsLPMTrieBatchOperations() bool

--- a/tools/coredump/ebpfmaps.go
+++ b/tools/coredump/ebpfmaps.go
@@ -250,6 +250,10 @@ func (emc *ebpfMapsCoredump) SupportsGenericBatchOperations() bool {
 	return false
 }
 
+func (emc *ebpfMapsCoredump) SupportsGenericBatchLookupAndDelete() bool {
+	return false
+}
+
 func (emc *ebpfMapsCoredump) SupportsLPMTrieBatchOperations() bool {
 	return false
 }


### PR DESCRIPTION
This requires Linux v5.6, but it reduces the load significantly for environments where there's a lot of process creation/exit churn.

See: https://github.com/torvalds/linux/commit/057996380a42bb64ccc04383cfa9c0ace4ea11f0

Here's the flamegraph diff of this change deployed where you can see the new batched setup in red quite a bit smaller than the previous per key iteration in green:

<img width="3024" height="2434" alt="image" src="https://github.com/user-attachments/assets/2bd6e375-b594-4b69-8eec-117e158cbea2" />
