### PR TITLE
README: update list of supported HLL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ eBPF.
   languages.
 - Support for native code (C/C++, Rust, Zig, Go, etc. without debug symbols on
   host)
-- Support for a broad set of HLLs (Hotspot JVM, Python, Ruby, PHP, Node.JS, V8,
-  Perl), .NET is in preparation.
+- Support for a broad set of HLLs, like Hotspot JVM, Python, Ruby, PHP, Node.JS, V8,
+  Perl, Erlang and .NET.
 - 100% non-intrusive: there's no need to load agents or libraries into the
   processes that are being profiled.
 - No need for any reconfiguration, instrumentation or restarts of HLL


### PR DESCRIPTION
With #958 @GregMefford added the support of Erlang as HLL.