### PR TITLE
chore: add ignore-regex to .codespellrc for improved spell checking

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,6 +4,7 @@ builtin = clear,rare,informal
 check-filenames =
 check-hidden =
 ignore-words = .codespellignore
+ignore-regex = \b[a-z]+[A-Z][a-zA-Z0-9]*\b
 interactive = 1
 skip = .git,AUTHORS.md,go.mod,go.sum,LICENSES,zydis,tools.mod,tools.sum
 uri-ignore-words-list = *


### PR DESCRIPTION
## Summary
- add an ignore-regex to skip camelCase identifiers in codespell
- reduce false positives from identifiers (e.g., spOffs, prevEnd)

## Testing 
- codespell (CI-equivalent run); false positives reduced by 4

## References
- Refs #1108