### PR TITLE
reporter: make reporter jitter configurable

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -20,6 +20,7 @@ const (
 	// Default values for CLI flags
 	defaultArgSamplesPerSecond    = 20
 	defaultArgReporterInterval    = 5.0 * time.Second
+	defaultArgReporterJitter      = 0.2
 	defaultArgMonitorInterval     = 5.0 * time.Second
 	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
@@ -56,9 +57,13 @@ var (
 		tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1)
 	probabilisticIntervalHelp = "Time interval for which probabilistic profiling will be " +
 		"enabled or disabled."
-	pprofHelp             = "Listening address (e.g. localhost:6060) to serve pprof information."
-	samplesPerSecondHelp  = "Set the frequency (in Hz) of stack trace sampling."
-	reporterIntervalHelp  = "Set the reporter's interval in seconds."
+	pprofHelp            = "Listening address (e.g. localhost:6060) to serve pprof information."
+	samplesPerSecondHelp = "Set the frequency (in Hz) of stack trace sampling."
+	reporterIntervalHelp = "Set the reporter's interval in seconds."
+	reporterJitterHelp   = fmt.Sprintf("Set the jitter applied to the reporter's interval as a fraction. "+
+		"Valid values are in the range [0..1]. "+
+		"Default is %.1f.",
+		defaultArgReporterJitter)
 	monitorIntervalHelp   = "Set the monitor interval in seconds."
 	clockSyncIntervalHelp = "Set the sync interval with the realtime clock. " +
 		"If zero, monotonic-realtime clock sync will be performed once, " +
@@ -114,6 +119,8 @@ func parseArgs() (*controller.Config, error) {
 
 	fs.DurationVar(&args.ReporterInterval, "reporter-interval", defaultArgReporterInterval,
 		reporterIntervalHelp)
+	fs.Float64Var(&args.ReporterJitter, "reporter-jitter", defaultArgReporterJitter,
+		reporterJitterHelp)
 
 	fs.IntVar(&args.SamplesPerSecond, "samples-per-second", defaultArgSamplesPerSecond,
 		samplesPerSecondHelp)

--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -21,6 +21,7 @@ const (
 // Config is the configuration for the collector.
 type Config struct {
 	ReporterInterval       time.Duration `mapstructure:"reporter_interval"`
+	ReporterJitter         float64       `mapstructure:"reporter_jitter"`
 	MonitorInterval        time.Duration `mapstructure:"monitor_interval"`
 	SamplesPerSecond       int           `mapstructure:"samples_per_second"`
 	ProbabilisticInterval  time.Duration `mapstructure:"probabilistic_interval"`
@@ -79,6 +80,12 @@ func (cfg *Config) Validate() error {
 		return errors.New(
 			"invalid argument for off-cpu-threshold. The value " +
 				"should be in the range [0..1]. 0 disables off-cpu profiling")
+	}
+
+	if cfg.ReporterJitter < 0.0 || cfg.ReporterJitter > 1.0 {
+		return errors.New(
+			"invalid argument for reporter-jitter. The value " +
+				"should be in the range [0..1]. 0 disables jitter")
 	}
 
 	if !cfg.NoKernelVersionCheck {

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -31,6 +31,7 @@ func NewFactory() receiver.Factory {
 func defaultConfig() component.Config {
 	return &config.Config{
 		ReporterInterval:       5 * time.Second,
+		ReporterJitter:         0.2,
 		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,
 		ProbabilisticInterval:  1 * time.Minute,

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -49,6 +49,7 @@ func NewController(cfg *controller.Config, rs receiver.Settings,
 		GRPCStartupBackoffTime: intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:  intervals.GRPCConnectionTimeout(),
 		ReportInterval:         intervals.ReportInterval(),
+		ReportJitter:           cfg.ReporterJitter,
 		SamplesPerSecond:       cfg.SamplesPerSecond,
 	}, nextConsumer)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func mainWithExitCode() exitCode {
 		GRPCStartupBackoffTime: intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:  intervals.GRPCConnectionTimeout(),
 		ReportInterval:         intervals.ReportInterval(),
+		ReportJitter:           cfg.ReporterJitter,
 		SamplesPerSecond:       cfg.SamplesPerSecond,
 	})
 	if err != nil {

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -56,7 +56,7 @@ func (r *CollectorReporter) Start(ctx context.Context) error {
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
-	r.runLoop.Start(ctx, r.cfg.ReportInterval, func() {
+	r.runLoop.Start(ctx, r.cfg.ReportInterval, r.cfg.ReportJitter, func() {
 		if err := r.reportProfile(ctx); err != nil {
 			log.Errorf("Request failed: %v", err)
 		}

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	GRPCStartupBackoffTime time.Duration
 	GRPCConnectionTimeout  time.Duration
 	ReportInterval         time.Duration
+	ReportJitter           float64
 
 	// gRPCInterceptor is the client gRPC interceptor, e.g., for sending gRPC metadata.
 	GRPCClientInterceptor grpc.UnaryClientInterceptor

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -85,7 +85,7 @@ func (r *OTLPReporter) Start(ctx context.Context) error {
 	}
 	r.client = pprofileotlp.NewGRPCClient(otlpGrpcConn)
 
-	r.runLoop.Start(ctx, r.cfg.ReportInterval, func() {
+	r.runLoop.Start(ctx, r.cfg.ReportInterval, r.cfg.ReportJitter, func() {
 		if err := r.reportOTLPProfile(ctx); err != nil {
 			log.Errorf("Request failed: %v", err)
 		}

--- a/reporter/runloop.go
+++ b/reporter/runloop.go
@@ -16,7 +16,8 @@ type runLoop struct {
 	stopSignal chan libpf.Void
 }
 
-func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, run, purge func()) {
+func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, jitter float64,
+	run, purge func()) {
 	go func() {
 		tick := time.NewTicker(reportInterval)
 		defer tick.Stop()
@@ -31,7 +32,7 @@ func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, run,
 				return
 			case <-tick.C:
 				run()
-				tick.Reset(libpf.AddJitter(reportInterval, 0.2))
+				tick.Reset(libpf.AddJitter(reportInterval, jitter))
 			case <-purgeTick.C:
 				purge()
 			}


### PR DESCRIPTION
we're testing longer reporting intervals to improve dictionary compression (more samples per batch = better deduplication), but the jitter is currently significant at higher intervals (±12s at 60s) and eats into the gains.

this makes the jitter configurable by the end-user and/or other distributions.