### PR TITLE
unwinder: drop duplicate check for .NET on arm64

### DIFF
--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -161,9 +161,6 @@ func Parse(tracers string) (IncludedTracers, error) {
 		switch name {
 		case "all":
 			result.enableAll()
-			if runtime.GOARCH == "arm64" {
-				result.Disable(DotnetTracer)
-			}
 		case "native":
 			log.Warn("Enabling the `native` tracer explicitly is deprecated (it's always-on)")
 		default:


### PR DESCRIPTION
Remove duplicate disabling of DotnetTracer for arm64 architecture. The same check happens just a few lines below that check again.