### PR TITLE
ci: speed up apt-get update by reducing package indexes

### DIFF
--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -20,21 +20,27 @@ runs:
       run: |
         # Ubuntu has ARM64 packages in an entirely different repo, so we can't just
         # `dpkg --add-architecture arm64` here: we have to add a custom sources.list first.
+        #
+        # We only need 'main' and 'universe' components (not restricted/multiverse)
+        # to minimize package index downloads.
         sudo tee /etc/apt/sources.list.d/ubuntu.sources <<EOF > /dev/null
         Types: deb
         URIs: http://azure.archive.ubuntu.com/ubuntu/
         Suites: noble noble-updates noble-backports
-        Components: main universe restricted multiverse
+        Components: main universe
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: amd64
 
         Types: deb
         URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
         Suites: noble noble-updates noble-backports
-        Components: main universe restricted multiverse
+        Components: main universe
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
         EOF
+
+        # Skip downloading translations to speed up apt-get update
+        echo 'Acquire::Languages "none";' | sudo tee /etc/apt/apt.conf.d/99no-translations > /dev/null
 
         sudo dpkg --add-architecture arm64
         sudo apt-get update -y


### PR DESCRIPTION
previously, apt-get update could sometimes take up to 9+ minutes to fetch package indexes. For example, in a [recent run](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/21431053734/job/61710249378#step:3:140), it caused the job to exceed its 10 minute timeout.

This change:
- drop 'restricted' and 'multiverse' components from ARM64 sources.list since cross-compilation only needs packages from 'main' and 'universe'
- skip downloading translation files with Acquire::Languages "none"

this reduces the package index download from ~74 MB to [~52 MB](https://github.com/DataDog/opentelemetry-ebpf-profiler/actions/runs/21457836901/job/61803036610?pr=40), which should hopefully reduce the index download time by ~30%.