### PR TITLE
Delay executable info unloading to reduce churn

### DIFF
--- a/interpreter/golabels/integrationtests/golabels_integration_test.go
+++ b/interpreter/golabels/integrationtests/golabels_integration_test.go
@@ -44,9 +44,10 @@ var (
 
 type mockIntervals struct{}
 
-func (mockIntervals) MonitorInterval() time.Duration    { return 1 * time.Second }
-func (mockIntervals) TracePollInterval() time.Duration  { return 250 * time.Millisecond }
-func (mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Second }
+func (mockIntervals) MonitorInterval() time.Duration       { return 1 * time.Second }
+func (mockIntervals) TracePollInterval() time.Duration     { return 250 * time.Millisecond }
+func (mockIntervals) PIDCleanupInterval() time.Duration    { return 1 * time.Second }
+func (mockIntervals) ExecutableUnloadDelay() time.Duration { return 1 * time.Second }
 
 func isRoot() bool {
 	return os.Geteuid() == 0

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -290,7 +290,7 @@ func (pm *ProcessManager) processRemovedMapping(pid libpf.PID, m *Mapping) uint6
 	}
 
 	fileID := host.FileIDFromLibpf(mf.File.Value().FileID)
-	pm.eim.RemoveOrDecRef(fileID)
+	pm.eim.DecRef(fileID)
 	return uint64(deleted)
 }
 

--- a/times/times.go
+++ b/times/times.go
@@ -48,6 +48,7 @@ type Times struct {
 	grpcAuthErrorDelay        time.Duration
 	pidCleanupInterval        time.Duration
 	probabilisticInterval     time.Duration
+	executableUnloadDelay     time.Duration
 }
 
 // IntervalsAndTimers is a meta-interface that exists purely to document its functionality.
@@ -74,6 +75,9 @@ type IntervalsAndTimers interface {
 	// ProbabilisticInterval defines the interval for which probabilistic profiling will
 	// be enabled or disabled.
 	ProbabilisticInterval() time.Duration
+	// ExecutableUnloadDelay defines how long to wait after an executable is no longer used
+	// before unloading it from memory.
+	ExecutableUnloadDelay() time.Duration
 }
 
 func (t *Times) MonitorInterval() time.Duration { return t.monitorInterval }
@@ -93,6 +97,8 @@ func (t *Times) GRPCAuthErrorDelay() time.Duration { return t.grpcAuthErrorDelay
 func (t *Times) PIDCleanupInterval() time.Duration { return t.pidCleanupInterval }
 
 func (t *Times) ProbabilisticInterval() time.Duration { return t.probabilisticInterval }
+
+func (t *Times) ExecutableUnloadDelay() time.Duration { return t.executableUnloadDelay }
 
 // StartRealtimeSync calculates a delta between the monotonic clock
 // (CLOCK_MONOTONIC, rebased to unixtime) and the realtime clock. If syncInterval is
@@ -119,6 +125,7 @@ func New(reportInterval, monitorInterval, probabilisticInterval time.Duration) *
 		reportInterval:            reportInterval,
 		monitorInterval:           monitorInterval,
 		probabilisticInterval:     probabilisticInterval,
+		executableUnloadDelay:     5 * time.Minute,
 	}
 }
 

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -135,6 +135,8 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 	// function are never used.
 	monitorInterval := time.Hour * 24
 
+	executableUnloadDelay := time.Minute * 5
+
 	// Check compatibility.
 	pid := pr.PID()
 	machineData := pr.GetMachineData()
@@ -169,9 +171,9 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 	// Instantiate managers and enable all tracers by default
 	includeTracers, _ := tracertypes.Parse("all")
 
-	manager, err := pm.New(todo, includeTracers, monitorInterval, &coredumpEbpfMaps,
-		&traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(), false,
-		libpf.Set[string]{})
+	manager, err := pm.New(todo, includeTracers, monitorInterval, executableUnloadDelay,
+		&coredumpEbpfMaps, &traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(),
+		false, libpf.Set[string]{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)
 	}

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -30,9 +30,10 @@ import (
 
 type mockIntervals struct{}
 
-func (mockIntervals) MonitorInterval() time.Duration    { return 1 * time.Second }
-func (mockIntervals) TracePollInterval() time.Duration  { return 250 * time.Millisecond }
-func (mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Second }
+func (mockIntervals) MonitorInterval() time.Duration       { return 1 * time.Second }
+func (mockIntervals) TracePollInterval() time.Duration     { return 250 * time.Millisecond }
+func (mockIntervals) PIDCleanupInterval() time.Duration    { return 1 * time.Second }
+func (mockIntervals) ExecutableUnloadDelay() time.Duration { return 1 * time.Second }
 
 // forceContextSwitch makes sure two Go threads are running concurrently
 // and that there will be a context switch between those two.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -67,6 +67,7 @@ type Intervals interface {
 	MonitorInterval() time.Duration
 	TracePollInterval() time.Duration
 	PIDCleanupInterval() time.Duration
+	ExecutableUnloadDelay() time.Duration
 }
 
 // Tracer provides an interface for loading and initializing the eBPF components as
@@ -239,7 +240,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	hasBatchLookupAndDelete := ebpfHandler.SupportsGenericBatchLookupAndDelete()
 
 	processManager, err := pm.New(ctx, cfg.IncludeTracers, cfg.Intervals.MonitorInterval(),
-		ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
+		cfg.Intervals.ExecutableUnloadDelay(), ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
 		elfunwindinfo.NewStackDeltaProvider(),
 		cfg.FilterErrorFrames, cfg.IncludeEnvVars)
 	if err != nil {


### PR DESCRIPTION
We see a lot of the time spent loading and unloading the same executables:

<img width="2944" height="1082" alt="image" src="https://github.com/user-attachments/assets/d91d2d80-3238-443f-8e0a-ec6ea1c97891" />

Here instead of unloading immediately when the reference counter reaches zero, we delay it to allow possible reuse. This works great as most non-constantly-running things tend to run periodically (as opposed to once and then never again).

This is by no means final, but I'm opening it to kick off a conversation on whether this is the right approach.

See also: #532.