### PR TITLE
tracer: remove filterIdleFrames

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -122,9 +122,6 @@ type Tracer struct {
 
 	// probabilisticThreshold holds the threshold for probabilistic profiling.
 	probabilisticThreshold uint
-
-	// filterIdleFrames indicates whether idle frames should be filtered.
-	filterIdleFrames bool
 }
 
 type Config struct {
@@ -1163,9 +1160,6 @@ func (t *Tracer) AttachTracer() error {
 	perfAttribute.SetSampleFreq(uint64(t.samplesPerSecond))
 	if err := perf.CPUClock.Configure(perfAttribute); err != nil {
 		return fmt.Errorf("failed to configure software perf event: %v", err)
-	}
-	if !t.filterIdleFrames {
-		perfAttribute.Options.ExcludeIdle = false
 	}
 
 	onlineCPUIDs, err := getOnlineCPUIDs()


### PR DESCRIPTION
The configuration option filterIdleFrames in the tracer.Trace struct is never set and so it does not make a difference in configuring the perf event.

Enabling and disabling idle frame collection happens via tracer.Config and its field FilterIdleFrames.