### PR TITLE
Go: run modernize

### DIFF
--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func BenchmarkPythonInterpreter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		testPythonInterpreter(b)
 	}
 }

--- a/internal/linux/probe_linux.go
+++ b/internal/linux/probe_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/internal/linux/probe_other.go
+++ b/internal/linux/probe_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/interpreter/go/go_test.go
+++ b/interpreter/go/go_test.go
@@ -36,9 +36,8 @@ func BenchmarkGolang(b *testing.B) {
 	loaderInfo := interpreter.NewLoaderInfo(hostFileID, elfRef)
 	rm := remotememory.NewProcessVirtualMemory(libpfPID)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		gD, err := Loader(nil, loaderInfo)
 		if err != nil {
 			b.Fatalf("Failed to create loader: %v", err)

--- a/interpreter/python/decode_test.go
+++ b/interpreter/python/decode_test.go
@@ -46,7 +46,7 @@ func TestAnalyzeArm64Stubs(t *testing.T) {
 }
 
 func BenchmarkDecodeAmd64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		code := []byte{
 			0xf3, 0x0f, 0x1e, 0xfa, // 1bbba0: endbr64
 			0x48, 0x83, 0x3d, 0x74, 0x90, 0x1e, 0x00, // 1bbba4: cmp    QWORD PTR [rip+0x1e9074],0x0        # 3a4c20 <_PyRuntime+0x240>

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -1152,12 +1152,9 @@ func profileFrameFullLabel(classPath, label, baseLabel, methodName libpf.String,
 	baseLabelStr := baseLabel.String()
 	labelLength := len(labelStr)
 	baseLabelLength := len(baseLabelStr)
-	prefixLen := labelLength - baseLabelLength
-
-	// Ensure prefixLen doesn't exceed label length (defensive programming)
-	if prefixLen < 0 {
-		prefixLen = 0
-	}
+	prefixLen := max(
+		// Ensure prefixLen doesn't exceed label length (defensive programming)
+		labelLength-baseLabelLength, 0)
 
 	if prefixLen > labelLength {
 		prefixLen = labelLength

--- a/kallsyms/kallsyms_test.go
+++ b/kallsyms/kallsyms_test.go
@@ -129,7 +129,7 @@ ffffffffc13fcb20 t init_xfs_fs	[xfs]`)
 
 	s := &Symbolizer{}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		r.Seek(0, io.SeekStart)
 		if err := s.updateSymbolsFrom(r); err != nil {
 			b.Fail()

--- a/libpf/convenience_test.go
+++ b/libpf/convenience_test.go
@@ -47,7 +47,7 @@ func TestAddJitter(t *testing.T) {
 		// Test with jitter values including edge case near 1.0
 		jitterValues := []float64{0.2, 0.5, 0.9, 0.99, 1.0}
 		for _, jitter := range jitterValues {
-			for i := 0; i < 1000; i++ {
+			for range 1000 {
 				result := AddJitter(baseDuration, jitter)
 				assert.Greater(t, result, time.Duration(0),
 					"jitter=%f produced non-positive duration", jitter)
@@ -60,7 +60,7 @@ func TestAddJitter(t *testing.T) {
 		minExpected := time.Duration(float64(baseDuration) * (1 - jitter))
 		maxExpected := time.Duration(float64(baseDuration) * (1 + jitter))
 
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			result := AddJitter(baseDuration, jitter)
 			assert.GreaterOrEqual(t, result, minExpected)
 			assert.LessOrEqual(t, result, maxExpected)

--- a/libpf/xsync/once_test.go
+++ b/libpf/xsync/once_test.go
@@ -26,9 +26,8 @@ func TestOnceLock(t *testing.T) {
 	assert.Nil(t, once.Get())
 
 	for range 32 {
-		wg.Add(1)
 
-		go func() {
+		wg.Go(func() {
 			val, err := once.GetOrInit(func() (string, error) {
 				if attempt == 3 {
 					time.Sleep(25 * time.Millisecond)
@@ -49,8 +48,7 @@ func TestOnceLock(t *testing.T) {
 				assert.Fail(t, "unreachable")
 			}
 
-			wg.Done()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/lpm/lpm_test.go
+++ b/lpm/lpm_test.go
@@ -1,5 +1,4 @@
 //go:build !integration
-// +build !integration
 
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -89,7 +89,7 @@ func LoadMaps(ctx context.Context, includeTracers types.IncludedTracers,
 	impl.errCounter = make(map[metrics.MetricID]int64)
 
 	implRefVal := reflect.ValueOf(impl).Elem()
-	implRefType := reflect.TypeOf(impl).Elem()
+	implRefType := reflect.TypeFor[ebpfMapsImpl]()
 	for i := 0; i < implRefType.NumField(); i++ {
 		fieldType := implRefType.Field(i)
 		nameTag, ok := fieldType.Tag.Lookup("name")


### PR DESCRIPTION
This change was made by the following command:

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
```

The bump of the Go version in commit 8e3c1c51a3f67208b221560036034e1b169b2d41 enables these changes.