### PR TITLE
Makefile: leverage Go environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ docker-image:
 	docker build -t otel/opentelemetry-ebpf-profiler-dev -f Dockerfile .
 
 agent:
-	@./tools/docker-agent-build.sh "$(TARGET_ARCH)" "$(VERSION)" "$(REVISION)" "$(BUILD_TIMESTAMP)"
+	./tools/docker-agent-build.sh "$(TARGET_ARCH)" "$(VERSION)" "$(REVISION)" "$(BUILD_TIMESTAMP)"
 
 legal:
 	go tool $(GO_TOOLS) go-licenses save --force . --save_path=LICENSES

--- a/tools/docker-agent-build.sh
+++ b/tools/docker-agent-build.sh
@@ -10,8 +10,8 @@ VERSION="${2:-}"
 REVISION="${3:-}"
 BUILD_TIMESTAMP="${4:-}"
 
-HOST_GOPATH=$(go env GOPATH)
-HOST_GOCACHE=$(go env GOCACHE)
+HOST_GOPATH="$(go env GOPATH)"
+HOST_GOCACHE="$(go env GOCACHE)"
 WORK_DIR="/agent"
 VOLUME_MOUNTS=(-v "$PWD:/agent")
 ENV_VARS=()


### PR DESCRIPTION
Using `make agent` followed by `make lint` does result in an error like this:

```
pattern ./...: directory go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd outside main module or its selected dependencies
make: *** [Makefile:68: generate] Error 1
```

The work around is, to use `make clean` before `make lint` to remove the directories `go` and `.cache` that are created by `make agent`.

After removing `go` and `.cache` the command `make agent` slows down, as it has to download dependencies every time:

```
$ make agent
docker run -v "$PWD":/agent -it --rm --user 1000:1000 otel/opentelemetry-ebpf-profiler-dev:latest \
   "make TARGET_ARCH=amd64 VERSION=v0.0.0 REVISION=main-cc335385 BUILD_TIMESTAMP=1771337087"
GOARCH=amd64 go generate ./...
go: downloading github.com/elastic/go-freelru v0.16.0
go: downloading github.com/zeebo/xxh3 v1.1.0
go: downloading golang.org/x/sys v0.41.0
go: downloading golang.org/x/arch v0.24.0
go: downloading github.com/mdlayher/kobject v0.0.0-20200520190114-19ca17470d7d
go: downloading github.com/minio/sha256-simd v1.0.1
go: downloading github.com/google/uuid v1.6.0
go: downloading go.opentelemetry.io/otel/metric v1.40.0
go: downloading github.com/cilium/ebpf v0.20.0
[..]
```

The suggestion is to leverage the local Go environment, where available. This speeds up `make agent` and avoids conflicts with other targets like `make lint`.