### PR TITLE
chore: fix rust mismatched lifetime syntax warnings

### DIFF
--- a/rust-crates/symblib/src/objfile.rs
+++ b/rust-crates/symblib/src/objfile.rs
@@ -103,7 +103,7 @@ impl File {
     }
 
     /// Parse the header and create a reader.
-    pub fn parse(&self) -> Result<Reader> {
+    pub fn parse(&self) -> Result<Reader<'_>> {
         Ok(Reader(object::File::parse(&self.0[..])?))
     }
 }
@@ -578,7 +578,7 @@ impl<'obj> MemoryMap<'obj> {
     }
 
     /// Iterate over all memory regions.
-    pub fn iter(&self) -> std::slice::Iter<Section<'obj>> {
+    pub fn iter(&self) -> std::slice::Iter<'_, Section<'obj>> {
         self.0.iter()
     }
 }
@@ -761,7 +761,7 @@ mod tests {
         assert_eq!(
             alt_link.build_id,
             GnuBuildId([
-                0x83, 0xFF, 0xD1, 0xE5, 0x5E, 0xB9, 0x9F, 0x9A, 0x41, 0xA0, 
+                0x83, 0xFF, 0xD1, 0xE5, 0x5E, 0xB9, 0x9F, 0x9A, 0x41, 0xA0,
                 0x77, 0xAD, 0xBC, 0x95, 0x09, 0x96, 0xBF, 0xB7, 0x93, 0x7F,
             ]),
         );


### PR DESCRIPTION
Fixes the warnings produced for any cargo command on the crate:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> rust-crates/symblib/src/objfile.rs:106:18
    |
106 |     pub fn parse(&self) -> Result<Reader> {
    |                  ^^^^^            ^^^^^^ the same lifetime is hidden here
    |                  |
    |                  the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
106 |     pub fn parse(&self) -> Result<Reader<'_>> {
    |                                         ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> rust-crates/symblib/src/objfile.rs:581:17
    |
581 |     pub fn iter(&self) -> std::slice::Iter<Section<'obj>> {
    |                 ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
581 |     pub fn iter(&self) -> std::slice::Iter<'_, Section<'obj>> {
    |                                            +++

```