### PR TITLE
ci: group ocb renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,11 @@
       '//(^|/)tools\\.mod$//',
     ],
   },
+  ocb: {
+    managerFilePatterns: [
+      '/cmd/otelcol-ebpf-profiler/manifest.yaml$/',
+    ],
+  },
   packageRules: [
     {
       groupName: 'Go dependencies',
@@ -59,16 +64,13 @@
         'before 8am every weekday',
       ],
     },
-  ],
-  customManagers: [
     {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/cmd/otelcol-ebpf-profiler/manifest.yaml$/',
+      groupName: 'OCB (manifest) dependencies',
+      matchManagers: [
+        'ocb',
       ],
-      datasourceTemplate: 'go',
-      matchStrings: [
-        'gomod: (?<depName>.+) (?<currentValue>.+)',
+      schedule: [
+        'before 8am every weekday',
       ],
     },
   ],

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ clean:
 	@$(MAKE) -s -C support/ebpf clean
 	@chmod -Rf u+w go/ || true
 	@rm -rf go .cache support/*.test interpreter/golabels/integrationtests/pprof_1_*
-	@rm -f cmd/otelcol-ebpf-profiler/{*.go,go.mod,go.sum} || true
+	@rm -f otelcol-ebpf-profiler cmd/otelcol-ebpf-profiler/{*.go,go.mod,go.sum} || true
 	@cargo clean
 
 generate:


### PR DESCRIPTION
OCB is a supported manager in Renovate: https://docs.renovatebot.com/modules/manager/ocb/

This PR should indicate Renovate to group OCB's dependencies updates in a single PR.