### PR TITLE
Makefile: add otel-from-tree and otel-from-lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,35 +94,13 @@ otelcol-ebpf-profiler: ebpf generate-collector
 # 2. Run `make otel-from-tree` (only need to run it once to remap go modules)
 # 3. You can now build collector and it will use your local otel core changes.
 # 4. Before committing/pushing your changes, undo by running `make otel-from-lib`.
-.PHONY: otel-from-tree
 otel-from-tree:
-	@echo "Adding local opentelemetry-collector replaces to manifest.yaml"
-	@if grep -q "# START otel-from-tree" cmd/otelcol-ebpf-profiler/manifest.yaml; then \
-		echo "otel-from-tree already applied. Run 'make otel-from-lib' first to revert."; \
-		exit 1; \
-	fi
-	@echo "  # START otel-from-tree - Do not edit below this line" >> cmd/otelcol-ebpf-profiler/manifest.yaml
-	@grep -E "gomod: go.opentelemetry.io/collector/" cmd/otelcol-ebpf-profiler/manifest.yaml | \
-		sed -E 's/.*gomod: ([^ ]+) .*/\1/' | \
-		sort -u | \
-		while read -r module; do \
-			subpath=$${module#go.opentelemetry.io/collector}; \
-			echo "  - $${module} => ../opentelemetry-collector$${subpath}" >> cmd/otelcol-ebpf-profiler/manifest.yaml; \
-		done
-	@echo "Local replaces added. You can now build with local opentelemetry-collector changes."
+	./cmd/otelcol-ebpf-profiler/otel-from-tree.sh
 
 # Removes local opentelemetry-collector replaces from manifest.yaml.
 # (Undoes otel-from-tree.)
-.PHONY: otel-from-lib
 otel-from-lib:
-	@echo "Removing local opentelemetry-collector replaces from manifest.yaml"
-	@if ! grep -q "# START otel-from-tree" cmd/otelcol-ebpf-profiler/manifest.yaml; then \
-		echo "otel-from-tree not currently applied. Nothing to revert."; \
-		exit 0; \
-	fi
-	@sed -i '/# START otel-from-tree/,$$d' cmd/otelcol-ebpf-profiler/manifest.yaml
-	@echo "" >> cmd/otelcol-ebpf-profiler/manifest.yaml
-	@echo "Local replaces removed. Collector will use published opentelemetry-collector modules."
+	./cmd/otelcol-ebpf-profiler/otel-from-lib.sh
 
 rust-targets:
 	rustup target add $(ARCH_PREFIX)-unknown-linux-musl

--- a/cmd/otelcol-ebpf-profiler/otel-from-lib.sh
+++ b/cmd/otelcol-ebpf-profiler/otel-from-lib.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Removing local opentelemetry-collector replaces from manifest.yaml"
+
+if ! grep -q "# START otel-from-tree" cmd/otelcol-ebpf-profiler/manifest.yaml; then
+    echo "otel-from-tree not currently applied. Nothing to revert."
+    exit 0
+fi
+
+sed -i '/# START otel-from-tree/,$d' cmd/otelcol-ebpf-profiler/manifest.yaml
+echo "Local replaces removed. Collector will use published opentelemetry-collector modules."

--- a/cmd/otelcol-ebpf-profiler/otel-from-tree.sh
+++ b/cmd/otelcol-ebpf-profiler/otel-from-tree.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Adding local opentelemetry-collector replaces to manifest.yaml"
+
+if grep -q "# START otel-from-tree" cmd/otelcol-ebpf-profiler/manifest.yaml; then
+    echo "otel-from-tree already applied. Run 'make otel-from-lib' first to revert."
+    exit 1
+fi
+
+echo "  # START otel-from-tree - Do not edit below this line" >> cmd/otelcol-ebpf-profiler/manifest.yaml
+
+grep -E "gomod: go.opentelemetry.io/collector/" cmd/otelcol-ebpf-profiler/manifest.yaml | \
+    sed -E 's/.*gomod: ([^ ]+) .*/\1/' | \
+    sort -u | \
+    while read -r module; do
+        subpath=${module#go.opentelemetry.io/collector}
+        echo "  - ${module} => ../opentelemetry-collector${subpath}" >> cmd/otelcol-ebpf-profiler/manifest.yaml
+    done
+
+echo "Local replaces added. You can now build with local opentelemetry-collector changes."


### PR DESCRIPTION
When debugging elements in the otelcol-ebpf-profiler manually using replace statements can become a tedious task.

Use the same approach like OTel Collector contrib, to add/remove replace statements - see https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/eb4cda889af27384e0671979d7025b8cb57c97c7/Makefile#L557-L590.