### PR TITLE
CI: use pinned version for issuegenerator

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -48,5 +48,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go install go.opentelemetry.io/build-tools/issuegenerator@latest
+          go install go.opentelemetry.io/build-tools/issuegenerator@v0.28.1
           issuegenerator -path /tmp/testresults


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ebpf-profiler/security/code-scanning/126.