### PR TITLE
ci: fix invalid regex tools.mod path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,8 +12,7 @@
   ],
   gomod: {
     managerFilePatterns: [
-      '//(^|/)go\\.mod$//',
-      '//(^|/)tools\\.mod$//',
+      '/(^|/)tools\\.mod$/',
     ],
   },
   ocb: {


### PR DESCRIPTION
Tools mod file not being updated with Renovate updates.

`managerFilePatterns` extends the list of default's manager files path, for Go being `"/(^|/)go\\.mod$/"`

- Go manager: https://docs.renovatebot.com/modules/manager/gomod/
- Extending the files list: https://docs.renovatebot.com/modules/manager/#extending-a-managers-default-managerfilepatterns