### PR TITLE
test: initialize metrics once in TestMain to prevent concurrent map access

### DIFF
--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// Initialize metrics once to avoid concurrent map access between
-	// Start() and AddSlice() called from lingering periodiccaller goroutines.
+	// metrics.Start() and metrics.AddSlice() called from lingering periodiccaller goroutines.
 	metrics.Start(noop.Meter{})
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Periodic caller goroutines from earlier tests may still be calling metrics.AddSlice after cancelling the context, racing with metrics. Start in subsequent tests.

See failure example https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/runs/22881720558/job/66385932626?pr=1237#step:7:285

Periodic caller non waited routine: https://github.com/rogercoll/opentelemetry-ebpf-profiler/blob/fix_integration_metrics/tracer/tracer.go#L1138