### PR TITLE
collector: limit supported arch

### DIFF
--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build linux
+//go:build linux && (amd64 || arm64)
 
 package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 

--- a/collector/factory_others.go
+++ b/collector/factory_others.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !linux
+//go:build !(linux && (amd64 || arm64))
 
 package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 
@@ -21,7 +21,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 		_ component.Config,
 		_ xconsumer.Profiles,
 	) (xreceiver.Profiles, error) {
-		return nil, errors.New("profiling receiver is only supported on Linux")
+		return nil, errors.New("profiling receiver is only supported on Linux and arm64 or amd64")
 
 	}
 }


### PR DESCRIPTION
Return an error if the profiling receiver is build for an unsupported architecture.