### PR TITLE
README: Add policy around updating supported Linux kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Since the profiler is Linux-only, macOS and Windows users need to set up a Linux
 
 The project maintains its minimum supported kernel version in line with the lowest kernel version currently provided by actively maintained major Linux distributions, which include Debian stable, Red Hat Enterprise Linux, Ubuntu LTS, Amazon Linux and SUSE Linux. The minimum requirement may be increased when all such distributions no longer ship a specific kernel version. This approach enables the codebase to utilize newer eBPF features and avoids the need to maintain compatibility shims for obsolete kernels.
 
-It should be noted that certain distributions incorporate eBPF features from newer kernels into their supported versions. When this occurs, the distribution's stated kernel version does not accurately reflect its true eBPF capabilities and will not prevent us from increasing the minimum supported version.
+It should be noted that certain distributions incorporate eBPF features from newer kernels into their supported versions. When this occurs, the distribution's stated kernel version does not accurately reflect its true eBPF capabilities and will not prevent us from increasing the minimum supported version. On such kernels, the `no-kernel-version-check` configuration option can be used to bypass the checks and allow the profiler to execute.
 
 ## Alternative Build (Without Docker)
 You can build the agent without Docker by directly installing the dependencies listed in the Dockerfile. Once dependencies are set up, simply run:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/1178

And enables work on https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1172 and https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/1257.