### PR TITLE
Log errors in newFrameMapping as promised

### DIFF
--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -349,7 +349,7 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.Mapping
 
 	elfSpaceVA, ok := info.addressMapper.FileOffsetToVirtualAddress(m.FileOffset)
 	if !ok {
-		log.Debugf("Failed to map file offset of PID %d, file %s, offset %d",
+		log.Warnf("Failed to map file offset of PID %d, file %s, offset %d",
 			pr.PID(), m.Path, m.FileOffset)
 		return libpf.FrameMapping{}, errInvalidVirtualAddress
 	}
@@ -357,6 +357,8 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.Mapping
 	fileID := host.FileIDFromLibpf(info.mappingFile.Value().FileID)
 	ei, err := pm.eim.AddOrIncRef(fileID, elfRef)
 	if err != nil {
+		log.Errorf("Failed to load executable info for PID %d file %v (fileID %s): %v",
+			pr.PID(), m.Path, fileID.StringNoQuotes(), err)
 		return libpf.FrameMapping{}, err
 	}
 


### PR DESCRIPTION
In `synchronizeMappings` there's this comment:

```go
			fm, err = pm.newFrameMapping(pr, m)
			if err != nil {
				// newFrameMapping logged the message if needed
				continue
			}
```

With this change we actually do log errors, which can cause failure to unwind.

---

In #1230 I noticed continued failures to unwind. I was able to find some unlogged errors that explain things.

When unwinding fails, I can see a sea of these in `strace`:

```
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092428] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092455] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
[pid 2092513] newfstatat(AT_FDCWD, "/usr/local/bin/fl2", {st_mode=S_IFREG|0755, st_size=1088178912, ...}, 0) = 0
```

The error from `delve`:

```
> go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).newFrameMapping() /home/gitlab-runner/go/pkg/mod/github.com/bobrik/opentelemetry-ebpf-profiler@v0.0.0-20260323182331-4ea65558c19d/processmanager/processinfo.go:359 (PC: 0xd190b6)
Warning: debugging optimized function
(dlv) print err
error(*fmt.wrapError) *{
        msg: "failed to load deltas: failed UpdateStackDeltaPages for FileID 2...+74 more",
        err: error(*errors.errorString) *{
                s: "failed UpdateStackDeltaPages for FileID 24c958ecb917576b: batch ...+51 more",},}
```

There's an overflowing map:

```
ivan@11m700:~$ MAP_ID=$(sudo bpftool map show -p | jq -r '.[] | select(.type == "hash") | select(.name != null) | select(.name == "stack_delta_pag") | .id')
ivan@11m700:~$ sudo bpftool map dump id $MAP_ID 2>/dev/null | grep -c '"key":'
65536
```

It does not overflow on a good machine that can unwind (barely):

```
ivan@11m672:~$ sudo bpftool map dump id $MAP_ID 2>/dev/null | grep -c '"key":'
64962
```
The fix for me is to increase the map scale factor, but we should also log the errors to make this failure more obvious.