### PR TITLE
metrics: skip entries with empty field in Start()

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -49,7 +49,7 @@ func Start(meter metric.Meter) {
 	defs := GetDefinitions()
 	metricTypes = make(map[MetricID]MetricType, len(defs))
 	for _, md := range defs {
-		if md.Obsolete {
+		if md.Obsolete || md.Field == "" {
 			continue
 		}
 		metricTypes[md.ID] = md.Type


### PR DESCRIPTION
The id 0 "Invalid" sentinel in metrics.json has an intentionally empty field and is not marked obsolete (IDInvalid is used at runtime for bounds checking).

```
$ make otelcol-ebpf-profiler
```

```
2026-03-31T17:08:26.805+0800	error	Creating Int64Counter: invalid instrument name: : is empty	{"resource": {"service.instance.id": "2345a511-2883-4318-9742-51c20f09218f", "se     rvice.name": "otelcol-ebpf-profiler", "service.version": "dev"}, "otelcol.component.id": "profiling", "otelcol.component.kind": "receiver", "otelcol.signal": "profiles"}
go.opentelemetry.io/ebpf-profiler/internal/log.Errorf
	/home/neck/Documents/github/rogercoll/opentelemetry-ebpf-profiler/internal/log/logging.go:69
go.opentelemetry.io/ebpf-profiler/metrics.Start
	/home/neck/Documents/github/rogercoll/opentelemetry-ebpf-profiler/metrics/metrics.go:62
go.opentelemetry.io/ebpf-profiler/collector/internal.NewController
	/home/neck/Documents/github/rogercoll/opentelemetry-ebpf-profiler/collector/internal/controller.go:62
go.opentelemetry.io/ebpf-profiler/collector.NewFactory.BuildProfilesReceiver.func1
	/home/neck/Documents/github/rogercoll/opentelemetry-ebpf-profiler/collector/factory_linux.go:48
go.opentelemetry.io/collector/receiver/xreceiver.(*factory).CreateProfiles
	/home/neck/.go/pkg/mod/go.opentelemetry.io/collector/receiver/xreceiver@v0.148.0/receiver.go:76
```