### PR TITLE
Set default value to cfg.ErrorMode

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -154,6 +154,8 @@ func parseArgs() (*controller.Config, error) {
 
 	args.Fs = fs
 
+	args.ErrorMode = config.PropagateError
+
 	return &args, ff.Parse(fs, os.Args[1:],
 		ff.WithEnvVarPrefix("OTEL_PROFILING_AGENT"),
 		ff.WithConfigFileFlag("config"),

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"go.opentelemetry.io/ebpf-profiler/collector/config"
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
 	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
@@ -66,7 +65,6 @@ func mainWithExitCode() exitCode {
 		log.Errorf("Failure to parse arguments: %v", err)
 		return exitParseError
 	}
-	cfg.ErrorMode = config.PropagateError
 
 	if cfg.Copyright {
 		fmt.Print(copyright)


### PR DESCRIPTION
Fixes #1304 

Set default value to the `ErrorMode` to pass check in `Config.Validate`