### PR TITLE
coredump: fix ContinuationToken loop

### DIFF
--- a/tools/coredump/modulestore/util.go
+++ b/tools/coredump/modulestore/util.go
@@ -40,6 +40,7 @@ func getS3ObjectList(client *s3.Client, bucket, prefix string,
 			return nil, errors.New("too many matching items in bucket")
 		}
 
+		// Passing a nil continuation token to ListObjectsV2 will restart the operation and lead to an infinite loop
 		if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
 			break
 		}

--- a/tools/coredump/modulestore/util.go
+++ b/tools/coredump/modulestore/util.go
@@ -40,6 +40,9 @@ func getS3ObjectList(client *s3.Client, bucket, prefix string,
 			return nil, errors.New("too many matching items in bucket")
 		}
 
+		if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+			break
+		}
 		contToken = resp.ContinuationToken
 	}
 


### PR DESCRIPTION
When trying to upload coredump tests for https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1102 I did run into a bug. When the S3 API returned exactly batchSize items, the code would continue the loop without checking if there were more pages. If the ContinuationToken was nil (indicating end of results), passing it to the next ListObjectsV2 call would restart the listing from the beginning, creating an infinite loop.