### PR TITLE
CI: fix collector test

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           COLLECTOR_PATH=/tmp/opentelemetry-collector ./support/local-collector.sh
           go mod tidy
+          go mod tidy -modfile=internal/tools/go.mod
       - name: Tests
         run: make test-junit
       - name: Generate Issue

--- a/support/local-collector.sh
+++ b/support/local-collector.sh
@@ -16,4 +16,6 @@ go list -m -u all | grep 'go\.opentelemetry\.io/collector' | while read -r line;
   LOCAL_PATH="$COLLECTOR_PATH/$REL_PATH"
   echo "Replacing $MODULE => $LOCAL_PATH"
   go mod edit -replace="$MODULE=$LOCAL_PATH"
+  # Also add replace directive to internal/tools/go.mod
+  go mod edit -modfile=internal/tools/go.mod -replace="$MODULE=$LOCAL_PATH"
 done


### PR DESCRIPTION
internal/tools/go.mod depends on the root go.mod indirectly because of go.opentelemetry.io/collector/cmd/builder and
go.opentelemetry.io/collector/cmd/mdatagen.
When replacing the collector dependency with the most recent main, this conflicts.

To resolve this issue, also add a replace statement in internal/tools/go.mod and also run go mod tidy on it. This should fix the failing tests in https://github.com/open-telemetry/opentelemetry-ebpf-profiler/actions/workflows/collector-tests.yml.