### PR TITLE
CI: fix collector test

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -49,6 +49,9 @@ jobs:
           go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto@v0.0.0-20260226221140-a57be14db171'
           go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto/googleapis/rpc@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto/googleapis/rpc@v0.0.0-20260226221140-a57be14db171'
           go mod edit -modfile=internal/tools/go.mod -replace="go.opentelemetry.io/ebpf-profiler=$(pwd)"
+          go mod tidy
+          go mod tidy -modfile=internal/tools/go.mod
+          # Manual run of go generate and go mod tidy to have a clean start for make test-junit
           go generate ./...
           go mod tidy
           go mod tidy -modfile=internal/tools/go.mod

--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Setup replace statement
         run: |
           COLLECTOR_PATH=/tmp/opentelemetry-collector ./support/local-collector.sh
+          # Add replace directives to internal/tools for genproto and ebpf-profiler
+          go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto@v0.0.0-20260226221140-a57be14db171'
+          go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto/googleapis/rpc@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto/googleapis/rpc@v0.0.0-20260226221140-a57be14db171'
+          go mod edit -modfile=internal/tools/go.mod -replace="go.opentelemetry.io/ebpf-profiler=$(pwd)"
           go mod tidy
           go mod tidy -modfile=internal/tools/go.mod
       - name: Tests

--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -8,6 +8,7 @@ on:
     branches: ["**"]
     paths:
       - cmd/otelcol-ebpf-profiler/manifest.yaml
+      - .github/workflows/collector-tests.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -49,6 +49,7 @@ jobs:
           go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto@v0.0.0-20260226221140-a57be14db171'
           go mod edit -modfile=internal/tools/go.mod -replace='google.golang.org/genproto/googleapis/rpc@v0.0.0-20220519153652-3a47de7e79bd=google.golang.org/genproto/googleapis/rpc@v0.0.0-20260226221140-a57be14db171'
           go mod edit -modfile=internal/tools/go.mod -replace="go.opentelemetry.io/ebpf-profiler=$(pwd)"
+          go generate ./...
           go mod tidy
           go mod tidy -modfile=internal/tools/go.mod
       - name: Tests


### PR DESCRIPTION
These replace statements are necessary as golangci-lint introduces dependencies, that conflict with eBPF profiler and OTel collector.

```
$ go mod graph -modfile=internal/tools/go.mod | grep "google.golang.org/genproto"
github.com/securego/gosec/v2@v2.24.8-0.20260309165252-619ce2117e08 google.golang.org/genproto/googleapis/rpc@v0.0.0-20250818200422-3122310a409c
$ go mod graph -modfile=internal/tools/go.mod | grep github.com/securego/gosec/v2
github.com/open-telemetry/opentelemetry-ebpf-profiler/internal/tools github.com/securego/gosec/v2@v2.24.8-0.20260309165252-619ce2117e08
github.com/golangci/golangci-lint/v2@v2.11.4 github.com/securego/gosec/v2@v2.24.8-0.20260309165252-619ce2117e08
```