### PR TITLE
Detect container ID via cgroup inode when pa…

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -183,6 +183,16 @@ func extractContainerID(pid libpf.PID) (libpf.String, error) {
 	return parseContainerID(cgroupFile), nil
 }
 
+// CgroupRootInode returns the inode of /proc/<pid>/root/sys/fs/cgroup, which identifies
+// the cgroup namespace root visible to the given process, unaffected by namespace masking.
+func CgroupRootInode(pid libpf.PID) (uint64, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf("/proc/%d/root/sys/fs/cgroup", pid), &st); err != nil {
+		return 0, err
+	}
+	return st.Ino, nil
+}
+
 // DetectSelfContainerIDViaInode detects the current process's container ID by matching
 // cgroup directory inodes. When the process runs in a private cgroup namespace (cgroup v2),
 // /proc/self/cgroup returns a path relative to the namespace root (e.g. "0::/"), making it

--- a/process/process.go
+++ b/process/process.go
@@ -213,7 +213,10 @@ func DetectSelfContainerIDViaInode() (libpf.String, uint64, error) {
 	var matched libpf.String
 	err := filepath.WalkDir(hostCgroupRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil // skip inaccessible directories
+			if d == nil {
+				return err // root is inaccessible
+			}
+			return nil // skip inaccessible subdirectories
 		}
 		if !d.IsDir() {
 			return nil

--- a/process/process.go
+++ b/process/process.go
@@ -10,8 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -179,6 +181,49 @@ func extractContainerID(pid libpf.PID) (libpf.String, error) {
 	defer cgroupFile.Close()
 
 	return parseContainerID(cgroupFile), nil
+}
+
+// DetectSelfContainerIDViaInode detects the current process's container ID by matching
+// cgroup directory inodes. When the process runs in a private cgroup namespace (cgroup v2),
+// /proc/self/cgroup returns a path relative to the namespace root (e.g. "0::/"), making it
+// impossible to extract the container ID via the standard path. However, stat("/sys/fs/cgroup")
+// returns the inode of the process's actual cgroup directory on the host, unaffected by
+// namespace masking. This function walks the host's cgroup tree (via
+// /proc/1/root/sys/fs/cgroup) to find the directory whose inode matches, then extracts
+// the container ID from its path.
+func DetectSelfContainerIDViaInode() (libpf.String, uint64, error) {
+	const hostCgroupRoot = "/proc/1/root/sys/fs/cgroup"
+
+	var selfStat unix.Stat_t
+	if err := unix.Stat("/sys/fs/cgroup", &selfStat); err != nil {
+		return libpf.NullString, 0, fmt.Errorf("failed to stat /sys/fs/cgroup: %w", err)
+	}
+	selfIno := selfStat.Ino
+
+	var matched libpf.String
+	err := filepath.WalkDir(hostCgroupRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible directories
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		var st unix.Stat_t
+		if err := unix.Stat(path, &st); err != nil {
+			return nil
+		}
+		if st.Ino == selfIno {
+			if parts := expContainerID.FindStringSubmatch(path); len(parts) == 2 {
+				matched = libpf.Intern(parts[1])
+			}
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return libpf.NullString, 0, fmt.Errorf("failed to walk host cgroup tree: %w", err)
+	}
+	return matched, selfIno, nil
 }
 
 func trimMappingPath(path string) string {

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/nativeunwind"
 	"go.opentelemetry.io/ebpf-profiler/periodiccaller"
+	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
@@ -94,6 +95,11 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 
 	interpreters := make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance)
 
+	selfContainerID, selfCgroupIno, err := process.DetectSelfContainerIDViaInode()
+	if err != nil {
+		log.Debugf("Failed to detect self container ID via inode: %v", err)
+	}
+
 	pm := &ProcessManager{
 		interpreterTracerEnabled: em.NumInterpreterLoaders() > 0,
 		eim:                      em,
@@ -108,6 +114,8 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        filterErrorFrames,
 		includeEnvVars:           includeEnvVars,
+		selfCgroupIno:            selfCgroupIno,
+		selfContainerID:          selfContainerID,
 	}
 
 	collectInterpreterMetrics(ctx, pm, monitorInterval)

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -129,13 +129,30 @@ func (pm *ProcessManager) getPidInformation(pid libpf.PID, pr process.Process,
 		return nil
 	}
 
+	meta := pr.GetProcessMeta(process.MetaConfig{IncludeEnvVars: pm.includeEnvVars})
+	pm.fillSelfContainerID(pid, &meta)
 	info := &processInfo{
-		meta:     pr.GetProcessMeta(process.MetaConfig{IncludeEnvVars: pm.includeEnvVars}),
+		meta:     meta,
 		libcInfo: nil,
 	}
 	pm.pidToProcessInfo[pid] = info
 	pm.pidPageToMappingInfoSize++
 	return info
+}
+
+// fillSelfContainerID sets the container ID on meta if the process has the same cgroup
+// directory root as the profiler and the standard cgroup-based detection returned no result.
+func (pm *ProcessManager) fillSelfContainerID(pid libpf.PID, meta *process.ProcessMeta) {
+	if meta.ContainerID != libpf.NullString || pm.selfContainerID == libpf.NullString {
+		return
+	}
+	var st unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf("/proc/%d/root/sys/fs/cgroup", pid), &st); err != nil {
+		return
+	}
+	if st.Ino == pm.selfCgroupIno {
+		meta.ContainerID = pm.selfContainerID
+	}
 }
 
 // assignInterpreter will update the interpreters maps with given interpreter.Instance.
@@ -648,6 +665,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	var meta process.ProcessMeta
 	if updateProcessMeta {
 		meta = pr.GetProcessMeta(process.MetaConfig{IncludeEnvVars: pm.includeEnvVars})
+		pm.fillSelfContainerID(pid, &meta)
 	}
 
 	// Sort and publish the new mappings and meta

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -146,14 +146,14 @@ func (pm *ProcessManager) fillSelfContainerID(pid libpf.PID, meta *process.Proce
 	if meta.ContainerID != libpf.NullString || pm.selfContainerID == libpf.NullString {
 		return
 	}
-	var st unix.Stat_t
-	if err := unix.Stat(fmt.Sprintf("/proc/%d/root/sys/fs/cgroup", pid), &st); err != nil {
+	ino, err := process.CgroupRootInode(pid)
+	if err != nil {
 		return
 	}
-	if st.Ino == pm.selfCgroupIno {
+	if ino == pm.selfCgroupIno {
 		meta.ContainerID = pm.selfContainerID
 	} else {
-		log.Debugf("Process %d cgroup inode (%d) doesn't match profiler (%d)", pid, st.Ino, pm.selfCgroupIno)
+		log.Debugf("Process %d cgroup inode (%d) doesn't match profiler (%d)", pid, ino, pm.selfCgroupIno)
 	}
 }
 

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -152,6 +152,8 @@ func (pm *ProcessManager) fillSelfContainerID(pid libpf.PID, meta *process.Proce
 	}
 	if st.Ino == pm.selfCgroupIno {
 		meta.ContainerID = pm.selfContainerID
+	} else {
+		log.Debugf("Process %d cgroup inode (%d) doesn't match profiler (%d)", pid, st.Ino, pm.selfCgroupIno)
 	}
 }
 

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -113,6 +113,16 @@ type ProcessManager struct {
 
 	// includeEnvVars holds a list of env vars that should be captured from processes
 	includeEnvVars libpf.Set[string]
+
+	// selfCgroupIno is the inode of the profiler's cgroup directory
+	// (stat("/sys/fs/cgroup")). Used to identify processes whose cgroup root
+	// matches the profiler's, which need the selfContainerID fallback.
+	selfCgroupIno uint64
+
+	// selfContainerID is the profiler's own container ID, detected once at startup.
+	// Used as a fallback when /proc/<pid>/cgroup yields no container ID for processes
+	// that share the profiler's cgroup directory (e.g., private cgroup namespace).
+	selfContainerID libpf.String
 }
 
 // Mapping represents an executable memory mapping of a process.


### PR DESCRIPTION
Currently working on removing privilege needs for the profiler and instead grant specific capabilities to mitigate security risks, and when non-privileged with `hostPID: true`, it stays in its own private cgroup namespace. Its cgroup path appears as `0::/` rather than the full host path, making container ID extraction via the standard regex impossible.

This PR adds an inode-based fallback to recover the container ID.

1. At startup: walk /proc/1/root/sys/fs/cgroup (the host's view) looking for the directory whose inode matches the profiler's. The path of the matching directory contains the container ID.
2. Per new PID, if the standard extraction returned empty, compare the inode of /proc/<pid>/root/sys/fs/cgroup against the profiler's cached inode. Match -> same container -> same container ID.