### PR TITLE
reporter/samples: add OriginData any to TraceEventMeta

### DIFF
--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -21,6 +21,10 @@ type TraceEventMeta struct {
 	PID, TID       libpf.PID
 	SpanID         libpf.APMSpanID
 	TraceID        libpf.APMTraceID
+
+	// OriginData carries optional Origin-specific payload through the Reporter
+	// interface without requiring origin-specific fields on this struct.
+	OriginData any
 }
 
 // TraceEvents holds known information about a trace.


### PR DESCRIPTION
Adds a generic, optional extension point on `TraceEventMeta` that mirrors the existing `SampleKey.ExtraMeta any` field.

`Reporter` implementations that consume `TraceEventMeta` directly (rather than going through `BaseReporter` and `SampleAttrProducer`) currently have to either grow the shared struct with origin-specific fields, or use side channels, to carry origin-scoped payload (e.g. heap counters for a memory-profiling origin) through `Reporter.ReportTraceEvent`.

This adds a single `OriginData any` field that producers can set per-event and consumers can type-assert on based on `Origin`. The field is nil by default; existing producers and consumers are unaffected.

The pattern parallels `SampleKey.ExtraMeta any`, which already exists for the BaseReporter aggregation path.