### PR TITLE
processmanager: add TraceInterceptor extension point

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -387,6 +387,10 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	}
 	pm.mu.RUnlock()
 
+	if pm.interceptor != nil && pm.interceptor(trace, meta) {
+		return
+	}
+
 	trace.Hash = traceutil.HashTrace(trace)
 	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace.Hash, 1)
 

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -62,7 +62,8 @@ var (
 // and unloading of symbols for processes.
 func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInterval time.Duration,
 	executableUnloadDelay time.Duration, ebpf pmebpf.EbpfHandler, traceReporter reporter.TraceReporter,
-	exeReporter reporter.ExecutableReporter, sdp nativeunwind.StackDeltaProvider,
+	exeReporter reporter.ExecutableReporter, interceptor TraceInterceptor,
+	sdp nativeunwind.StackDeltaProvider,
 	filterErrorFrames bool, includeEnvVars libpf.Set[string]) (*ProcessManager, error) {
 	if exeReporter == nil {
 		exeReporter = executableReporterStub{}
@@ -111,6 +112,7 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		frameCache:               frameCache,
 		traceReporter:            traceReporter,
 		exeReporter:              exeReporter,
+		interceptor:              interceptor,
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        filterErrorFrames,
 		includeEnvVars:           includeEnvVars,

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -155,3 +155,82 @@ func TestFrameCacheCrossProcessPollution(t *testing.T) {
 	assert.Equal(t, libpf.NativeFrame, catFrame.Type)
 	assert.Equal(t, "", catFrame.FunctionName.String())
 }
+
+func TestInterceptor(t *testing.T) {
+	pid := libpf.PID(4242)
+	libcHostFileID, err := host.FileIDFromBytes(
+		[]byte{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE})
+	require.NoError(t, err)
+
+	mappings := []Mapping{
+		{FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
+			File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+				FileID:   libpf.NewFileID(uint64(libcHostFileID), 0),
+				FileName: libpf.Intern("libc.so.6"),
+			}),
+			Start: 0,
+			End:   0xFFFFFFF,
+		})},
+	}
+	slices.SortFunc(mappings, compareMapping)
+
+	pc, _, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	libcFrame := libpf.NewEbpfFrame(libpf.NativeFrame, 0, 2, uint64(pc))
+	libcFrame[1] = uint64(libcHostFileID)
+
+	makePM := func(interceptor TraceInterceptor, capture *traceCapture) *ProcessManager {
+		frameCache, err := lru.New[frameCacheKey, libpf.Frames](1024, hashFrameCacheKey)
+		require.NoError(t, err)
+		frameCache.SetLifetime(frameCacheLifetime)
+		return &ProcessManager{
+			interpreters: map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance{},
+			pidToProcessInfo: map[libpf.PID]*processInfo{
+				pid: {mappings: mappings},
+			},
+			frameCache:    frameCache,
+			traceReporter: capture,
+			interceptor:   interceptor,
+		}
+	}
+
+	bpfTrace := func() *libpf.EbpfTrace {
+		return &libpf.EbpfTrace{
+			PID:       pid,
+			TID:       pid,
+			NumFrames: 1,
+			FrameData: libcFrame,
+		}
+	}
+
+	t.Run("nil interceptor reports normally", func(t *testing.T) {
+		capture := &traceCapture{}
+		pm := makePM(nil, capture)
+		pm.HandleTrace(bpfTrace())
+		require.Len(t, capture.traces, 1)
+	})
+
+	t.Run("interceptor consuming trace skips reporter", func(t *testing.T) {
+		capture := &traceCapture{}
+		var seen []*libpf.Trace
+		pm := makePM(func(trace *libpf.Trace, _ *samples.TraceEventMeta) bool {
+			seen = append(seen, trace)
+			return true
+		}, capture)
+		pm.HandleTrace(bpfTrace())
+		require.Len(t, seen, 1)
+		require.Empty(t, capture.traces)
+	})
+
+	t.Run("interceptor returning false falls through to reporter", func(t *testing.T) {
+		capture := &traceCapture{}
+		var calls int
+		pm := makePM(func(_ *libpf.Trace, _ *samples.TraceEventMeta) bool {
+			calls++
+			return false
+		}, capture)
+		pm.HandleTrace(bpfTrace())
+		assert.Equal(t, 1, calls)
+		require.Len(t, capture.traces, 1)
+	})
+}

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -175,4 +175,3 @@ type processInfo struct {
 	// C-library Thread Specific Data information
 	libcInfo *libc.LibcInfo
 }
-

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -109,6 +109,7 @@ type ProcessManager struct {
 
 	// interceptor, if set, is called after symbolization. When it returns
 	// true the trace is consumed and HandleTrace skips its default reporting.
+	// Set once at construction; never mutated afterward.
 	interceptor TraceInterceptor
 
 	// exeReporter is the interface to report executables
@@ -175,9 +176,3 @@ type processInfo struct {
 	libcInfo *libc.LibcInfo
 }
 
-// SetInterceptor installs an interceptor that is invoked after symbolization
-// and before reporting. Pass nil to clear an existing interceptor. See
-// TraceInterceptor for semantics.
-func (pm *ProcessManager) SetInterceptor(interceptor TraceInterceptor) {
-	pm.interceptor = interceptor
-}

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -18,6 +18,7 @@ import (
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
@@ -39,6 +40,14 @@ type frameCacheKey struct {
 	// data is the frame data: frame header and the two first variable fields
 	data [3]uint64
 }
+
+// TraceInterceptor is called after symbolization with the symbolized trace
+// and metadata. Return true to consume the trace, in which case HandleTrace
+// skips its default reporting path; return false to let HandleTrace report
+// the trace normally. Consumers that need to report intercepted traces are
+// expected to do so via their own TraceReporter — the hook is intentionally
+// a one-way handoff, not a passthrough callback.
+type TraceInterceptor func(trace *libpf.Trace, meta *samples.TraceEventMeta) bool
 
 // ProcessManager is responsible for managing the events happening throughout the lifespan of a
 // process.
@@ -97,6 +106,10 @@ type ProcessManager struct {
 
 	// traceReporter is the interface to report traces
 	traceReporter reporter.TraceReporter
+
+	// interceptor, if set, is called after symbolization. When it returns
+	// true the trace is consumed and HandleTrace skips its default reporting.
+	interceptor TraceInterceptor
 
 	// exeReporter is the interface to report executables
 	exeReporter reporter.ExecutableReporter
@@ -160,4 +173,11 @@ type processInfo struct {
 	mappings []Mapping
 	// C-library Thread Specific Data information
 	libcInfo *libc.LibcInfo
+}
+
+// SetInterceptor installs an interceptor that is invoked after symbolization
+// and before reporting. Pass nil to clear an existing interceptor. See
+// TraceInterceptor for semantics.
+func (pm *ProcessManager) SetInterceptor(interceptor TraceInterceptor) {
+	pm.interceptor = interceptor
 }

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -172,7 +172,7 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 	includeTracers, _ := tracertypes.Parse("all")
 
 	manager, err := pm.New(todo, includeTracers, monitorInterval, executableUnloadDelay,
-		&coredumpEbpfMaps, &traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(),
+		&coredumpEbpfMaps, &traceReporter, nil, nil, elfunwindinfo.NewStackDeltaProvider(),
 		false, libpf.Set[string]{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1376,3 +1376,9 @@ func (t *Tracer) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	bpfTrace.KernelFrames = bpfTrace.KernelFrames[0:0]
 	t.tracePool.Put(bpfTrace)
 }
+
+// SetInterceptor installs a TraceInterceptor on the underlying ProcessManager.
+// Pass nil to clear an existing interceptor.
+func (t *Tracer) SetInterceptor(interceptor pm.TraceInterceptor) {
+	t.processManager.SetInterceptor(interceptor)
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1379,4 +1379,3 @@ func (t *Tracer) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	bpfTrace.KernelFrames = bpfTrace.KernelFrames[0:0]
 	t.tracePool.Put(bpfTrace)
 }
-

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -152,6 +152,9 @@ type Config struct {
 	ExecutableReporter reporter.ExecutableReporter
 	// TraceReporter is the interface to report traces with.
 	TraceReporter reporter.TraceReporter
+	// Interceptor, if non-nil, is invoked after symbolization and before
+	// reporting. See processmanager.TraceInterceptor for semantics.
+	Interceptor pm.TraceInterceptor
 	// Intervals provides access to globally configured timers and counters.
 	Intervals Intervals
 	// IncludeTracers holds information about which tracers are enabled.
@@ -260,7 +263,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 
 	processManager, err := pm.New(ctx, cfg.IncludeTracers, cfg.Intervals.MonitorInterval(),
 		cfg.Intervals.ExecutableUnloadDelay(), ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
-		elfunwindinfo.NewStackDeltaProvider(),
+		cfg.Interceptor, elfunwindinfo.NewStackDeltaProvider(),
 		cfg.FilterErrorFrames, cfg.IncludeEnvVars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
@@ -1377,8 +1380,3 @@ func (t *Tracer) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	t.tracePool.Put(bpfTrace)
 }
 
-// SetInterceptor installs a TraceInterceptor on the underlying ProcessManager.
-// Pass nil to clear an existing interceptor.
-func (t *Tracer) SetInterceptor(interceptor pm.TraceInterceptor) {
-	t.processManager.SetInterceptor(interceptor)
-}


### PR DESCRIPTION
## Summary

Adds an optional `TraceInterceptor` extension point to `ProcessManager`. The interceptor is invoked from `HandleTrace` after symbolization and before reporting; returning `true` consumes the trace and `HandleTrace` skips its default reporting path, returning `false` lets `HandleTrace` report it normally. There is no behavior change when no interceptor is installed.

```go
type TraceInterceptor func(trace *libpf.Trace, meta *samples.TraceEventMeta) bool
```

The hook is intentionally a one-way handoff, not a passthrough callback. Consumers that need to report intercepted traces are expected to do so via their own downstream mechanism.

## Motivation

Some symbolization sources arrive on a separate channel from the eBPF stack walker and only become available some time after the original sample. Today there is no clean way to plug additional symbolization or merging into the post-symbolization, pre-report path without forking the project. This change adds a single, narrowly-scoped hook so out-of-tree code can:

- inspect or pass the trace through unchanged
- consume the trace and re-emit it later (via its own reporter) once additional data has arrived.

