### PR TITLE
pfelf: remove redundant ReadVirtualMemory and unused Prog.Open

### DIFF
--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -2248,7 +2248,7 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 			sym.Address, sym.Size, sym.Size/3)
 		d.bytecodeSizes = make([]byte, sym.Size)
 		d.bytecodeCount = uint8(sym.Size / 3)
-		if _, err = ef.ReadVirtualMemory(d.bytecodeSizes, int64(sym.Address)); err != nil {
+		if _, err = ef.ReadAt(d.bytecodeSizes, int64(sym.Address)); err != nil {
 			return nil, fmt.Errorf("unable to read bytecode sizes: %v", err)
 		}
 		for _, opcodeLength := range d.bytecodeSizes {

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -162,7 +162,7 @@ func newData(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo,
 	for i, sym := range []libpf.SymbolName{"PL_revision", "PL_version", "PL_subversion"} {
 		addr, err := ef.LookupSymbolAddress(sym)
 		if err == nil {
-			_, err = ef.ReadVirtualMemory(verBytes[i:i+1], int64(addr))
+			_, err = ef.ReadAt(verBytes[i:i+1], int64(addr))
 		}
 		if err != nil {
 			return nil, fmt.Errorf("perl symbol '%s': %v", sym, err)

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -506,17 +506,6 @@ func (f *File) SymbolData(name libpf.SymbolName, maxCopy int) (*libpf.Symbol, []
 	return sym, data, err
 }
 
-// ReadVirtualMemory reads bytes from given virtual address
-func (f *File) ReadVirtualMemory(p []byte, addr int64) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	if ph := f.findVirtualAddressProg(uint64(addr)); ph != nil {
-		return ph.ReadAt(p, addr-int64(ph.Vaddr))
-	}
-	return 0, fmt.Errorf("no matching segment for 0x%x", uint64(addr))
-}
-
 // EHFrame constructs a Program header with the EH Frame sections
 func (f *File) EHFrame() (*Prog, error) {
 	if f.ehFrame == nil {
@@ -887,11 +876,6 @@ func (ph *Prog) ReadAt(p []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
-// Open returns a new ReadSeeker reading the ELF program body.
-func (ph *Prog) Open() io.ReadSeeker {
-	return io.NewSectionReader(ph, 0, 1<<63-1)
-}
-
 // Data loads the whole program header referenced data, and returns it as slice.
 func (ph *Prog) Data(maxSize uint) ([]byte, error) {
 	if mapping, ok := ph.elfReader.(*mmap.ReaderAt); ok {
@@ -963,7 +947,13 @@ func (f *File) SetDontNeed() {
 
 // ReadAt reads bytes from given virtual address
 func (f *File) ReadAt(p []byte, addr int64) (int, error) {
-	return f.ReadVirtualMemory(p, addr)
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if ph := f.findVirtualAddressProg(uint64(addr)); ph != nil {
+		return ph.ReadAt(p, addr-int64(ph.Vaddr))
+	}
+	return 0, fmt.Errorf("no matching segment for 0x%x", uint64(addr))
 }
 
 // GetRemoteMemory returns RemoteMemory interface for the core dump
@@ -980,7 +970,7 @@ func (f *File) readAndMatchSymbol(n uint32, name libpf.SymbolName) (libpf.Symbol
 
 	// Read symbol descriptor and expected name
 	symSz := int64(unsafe.Sizeof(sym))
-	if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&sym),
+	if _, err := f.ReadAt(pfunsafe.FromPointer(&sym),
 		f.symbolsAddr+int64(n)*symSz); err != nil {
 		return libpf.Symbol{}, false
 	}
@@ -1028,7 +1018,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		// blog link (on top of this file) for details how this works.
 		hdr := &f.gnuHash.header
 		if hdr.numBuckets == 0 {
-			if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(hdr), f.gnuHash.addr); err != nil {
+			if _, err := f.ReadAt(pfunsafe.FromPointer(hdr), f.gnuHash.addr); err != nil {
 				return nil, err
 			}
 			if hdr.numBuckets == 0 || hdr.bloomSize == 0 {
@@ -1042,7 +1032,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		var bloom uint
 		h := calcGNUHash(symbol)
 		offs := f.gnuHash.addr + int64(unsafe.Sizeof(gnuHashHeader{}))
-		if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&bloom), offs+
+		if _, err := f.ReadAt(pfunsafe.FromPointer(&bloom), offs+
 			ptrSize*int64((h/ptrSizeBits)%hdr.bloomSize)); err != nil {
 			return nil, err
 		}
@@ -1055,7 +1045,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		// Read the initial symbol index to start looking from
 		offs += int64(hdr.bloomSize) * int64(unsafe.Sizeof(bloom))
 		var i uint32
-		if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&i),
+		if _, err := f.ReadAt(pfunsafe.FromPointer(&i),
 			offs+4*int64(h%hdr.numBuckets)); err != nil {
 			return nil, err
 		}
@@ -1068,7 +1058,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		h |= 1
 		for {
 			var h2 uint32
-			if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&h2), offs); err != nil {
+			if _, err := f.ReadAt(pfunsafe.FromPointer(&h2), offs); err != nil {
 				return nil, err
 			}
 			// Do a full match of the symbol if the symbol hash matches
@@ -1088,7 +1078,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		// Normal ELF symbol lookup. Refer to ELF spec, part 2 "Hash Table" (2-19)
 		hdr := &f.sysvHash.header
 		if hdr.numBuckets == 0 {
-			if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(hdr), f.sysvHash.addr); err != nil {
+			if _, err := f.ReadAt(pfunsafe.FromPointer(hdr), f.sysvHash.addr); err != nil {
 				return nil, err
 			}
 			if hdr.numBuckets == 0 {
@@ -1099,7 +1089,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		offs := f.sysvHash.addr + int64(unsafe.Sizeof(*hdr))
 		h := calcSysvHash(symbol)
 		bucket := int64(h % hdr.numBuckets)
-		if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&i), offs+4*bucket); err != nil {
+		if _, err := f.ReadAt(pfunsafe.FromPointer(&i), offs+4*bucket); err != nil {
 			return nil, err
 		}
 		offs += 4 * int64(hdr.numBuckets)
@@ -1107,7 +1097,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 			if s, ok := f.readAndMatchSymbol(i, symbol); ok {
 				return &s, nil
 			}
-			if _, err := f.ReadVirtualMemory(pfunsafe.FromPointer(&i), offs+4*int64(i)); err != nil {
+			if _, err := f.ReadAt(pfunsafe.FromPointer(&i), offs+4*int64(i)); err != nil {
 				return nil, err
 			}
 		}

--- a/processmanager/execinfomanager/synthdeltas.go
+++ b/processmanager/execinfomanager/synthdeltas.go
@@ -55,7 +55,7 @@ func createVDSOSyntheticRecordArm64(ef *pfelf.File) sdtypes.IntervalData {
 		}
 		// Determine if LR is on stack
 		code := make([]byte, sym.Size)
-		if _, err := ef.ReadVirtualMemory(code, int64(sym.Address)); err != nil {
+		if _, err := ef.ReadAt(code, int64(sym.Address)); err != nil {
 			return true
 		}
 


### PR DESCRIPTION
Replace uses of ReadVirtualMemory with ReadAt which is the standard interface.