### PR TITLE
process: replace fileToMapping map with OpenELFMapping

### DIFF
--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -216,6 +216,18 @@ func NewFile(r io.ReaderAt, loadAddress uint64, hasMusl bool) (*File, error) {
 	return newFile(r, nil, loadAddress, hasMusl)
 }
 
+// NewFileWithCloser is like NewFile but takes ownership of closer:
+// on success closer is closed by the returned File's Close; on error
+// closer is closed before returning.
+func NewFileWithCloser(r io.ReaderAt, closer io.Closer, loadAddress uint64, hasMusl bool) (*File, error) {
+	f, err := newFile(r, closer, loadAddress, hasMusl)
+	if err != nil {
+		_ = closer.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
 func newFile(r io.ReaderAt, closer io.Closer,
 	loadAddress uint64, hasMusl bool,
 ) (*File, error) {

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -179,24 +179,7 @@ func Open(name string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ff, err := newFile(f, f, 0, false)
-	if err != nil {
-		_ = f.Close()
-		return nil, err
-	}
-	return ff, nil
-}
-
-// OpenFile prepares an already-open file for use as an ELF binary.
-// The file will be closed when the returned File is closed.
-func OpenFile(f *os.File) (*File, error) {
-	ff, err := newFile(f, f, 0, false)
-	if err != nil {
-		_ = f.Close()
-		return nil, err
-	}
-	return ff, nil
+	return newFile(f, f, 0, false)
 }
 
 // Close closes the File.
@@ -216,18 +199,21 @@ func NewFile(r io.ReaderAt, loadAddress uint64, hasMusl bool) (*File, error) {
 	return newFile(r, nil, loadAddress, hasMusl)
 }
 
-// NewFileWithCloser is like NewFile but takes ownership of closer:
-// on success closer is closed by the returned File's Close; on error
-// closer is closed before returning.
-func NewFileWithCloser(r io.ReaderAt, closer io.Closer, loadAddress uint64, hasMusl bool) (*File, error) {
-	f, err := newFile(r, closer, loadAddress, hasMusl)
-	if err != nil {
-		_ = closer.Close()
-		return nil, err
-	}
-	return f, nil
+// ReadAtCloser combines io.ReaderAt and io.Closer.
+type ReadAtCloser interface {
+	io.ReaderAt
+	io.Closer
 }
 
+// NewFileOwned is like NewFile but takes ownership of rc: rc is used as the
+// ELF reader and is closed by the returned File's Close, or before returning
+// on error.
+func NewFileOwned(rc ReadAtCloser) (*File, error) {
+	return newFile(rc, rc, 0, false)
+}
+
+// newFile builds a File from r. A non-nil closer is owned and closed by the
+// returned File's Close, or before returning on error.
 func newFile(r io.ReaderAt, closer io.Closer,
 	loadAddress uint64, hasMusl bool,
 ) (*File, error) {
@@ -236,6 +222,12 @@ func newFile(r io.ReaderAt, closer io.Closer,
 		InsideCore: loadAddress != 0,
 		closer:     closer,
 	}
+	success := false
+	defer func() {
+		if !success {
+			_ = f.Close()
+		}
+	}()
 
 	hdr := &f.elfHeader
 	if _, err := r.ReadAt(pfunsafe.FromPointer(hdr), 0); err != nil {
@@ -369,6 +361,7 @@ func newFile(r io.ReaderAt, closer io.Closer,
 		}
 	}
 
+	success = true
 	return f, nil
 }
 

--- a/libpf/pfelf/reference.go
+++ b/libpf/pfelf/reference.go
@@ -8,19 +8,35 @@ package pfelf // import "go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 
 // Reference is a reference to an ELF file which is loaded and cached on demand.
 type Reference struct {
-	// Interface to open ELF files as needed
+	// ELFOpener opens auxiliary files by name (e.g. debuglink targets). When
+	// open is nil it also opens the reference's own file via OpenELF(fileName).
 	ELFOpener
 
 	// fileName is the full path of the ELF to open.
 	fileName string
 
+	// open, when non-nil, opens the reference's own file instead of
+	// ELFOpener.OpenELF(fileName). It lets callers inject context that a bare
+	// filename cannot carry, e.g. a memory mapping.
+	open func() (*File, error)
+
 	// elfFile contains the cached ELF file
 	elfFile *File
 }
 
-// NewReference returns a new Reference
+// NewReference returns a Reference that opens both its own file and any
+// auxiliary files (e.g. debuglink targets) through elfOpener, by name.
 func NewReference(fileName string, elfOpener ELFOpener) *Reference {
 	return &Reference{fileName: fileName, ELFOpener: elfOpener}
+}
+
+// NewReferenceWithOpenFunc returns a Reference that opens its own file via
+// open, while auxiliary files (e.g. debuglink targets) are still opened by
+// name through elfOpener.
+func NewReferenceWithOpenFunc(fileName string, elfOpener ELFOpener,
+	open func() (*File, error),
+) *Reference {
+	return &Reference{fileName: fileName, ELFOpener: elfOpener, open: open}
 }
 
 // FileName returns the file name associated with this Reference
@@ -33,7 +49,11 @@ func (ref *Reference) FileName() string {
 func (ref *Reference) GetELF() (*File, error) {
 	var err error
 	if ref.elfFile == nil {
-		ref.elfFile, err = ref.OpenELF(ref.fileName)
+		if ref.open != nil {
+			ref.elfFile, err = ref.open()
+		} else {
+			ref.elfFile, err = ref.OpenELF(ref.fileName)
+		}
 	}
 	return ref.elfFile, err
 }

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -284,7 +284,7 @@ func (cd *CoredumpProcess) GetThreads() ([]ThreadInfo, error) {
 // OpenMappingFile implements the Process interface.
 func (cd *CoredumpProcess) OpenMappingFile(_ *RawMapping) (ReadAtCloser, error) {
 	// Coredumps do not contain the original backing files.
-	return nil, errors.New("coredump does not support opening backing file")
+	return nil, ErrMappingFileUnavailable
 }
 
 // GetMappingFileLastModified implements the Process interface.

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -223,6 +223,7 @@ func OpenCoredumpFile(f *pfelf.File) (*CoredumpProcess, error) {
 		pfbufio.PutReader(rdr)
 
 		if err != io.EOF {
+			_ = f.Close()
 			return nil, err
 		}
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -35,6 +35,12 @@ var ErrNoMappings = errors.New("no mappings")
 // false, signaling that iteration was intentionally interrupted.
 var ErrCallbackStopped = errors.New("IterateMappings stopped by callback")
 
+// ErrMappingFileUnavailable signals OpenELFMapping to fall back to
+// OpenELF. Returned both when the implementation has no backing-file
+// route (CoredumpProcess) and when a specific file is missing from the
+// backing store (StoreCoredump bundle miss).
+var ErrMappingFileUnavailable = errors.New("mapping backing file unavailable")
+
 const (
 	containerSource = "[0-9a-f]{64}"
 	taskSource      = "[0-9a-f]{32}-\\d+"
@@ -59,8 +65,6 @@ type systemProcess struct {
 
 	mainThreadExit bool
 	remoteMemory   remotememory.RemoteMemory
-
-	fileToMapping map[string]*RawMapping
 }
 
 var _ Process = &systemProcess{}
@@ -393,20 +397,13 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 	}
 	defer mapsFile.Close()
 
-	fileToMapping := make(map[string]*RawMapping)
 	gotMappings := false
-
-	collectForOpenELF := func(m RawMapping) bool {
+	trackedCallback := func(m RawMapping) bool {
 		gotMappings = true
-		if m.IsExecutable() || m.IsVDSO() {
-			stored := m
-			stored.Path = libpf.Intern(m.Path).String()
-			fileToMapping[stored.Path] = &stored
-		}
 		return callback(m)
 	}
 
-	numParseErrors, err := iterateMappings(mapsFile, collectForOpenELF)
+	numParseErrors, err := iterateMappings(mapsFile, trackedCallback)
 	if err != nil {
 		return numParseErrors, err
 	}
@@ -436,13 +433,12 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 			return numParseErrors, ErrNoMappings
 		}
 		defer mapsFileAlt.Close()
-		numParseErrors, err := iterateMappings(mapsFileAlt, collectForOpenELF)
+		numParseErrors, err := iterateMappings(mapsFileAlt, trackedCallback)
 		if err != nil || !gotMappings {
 			return numParseErrors, ErrNoMappings
 		}
 	}
 
-	sp.fileToMapping = fileToMapping
 	return numParseErrors, nil
 }
 
@@ -458,12 +454,13 @@ func (sp *systemProcess) GetRemoteMemory() remotememory.RemoteMemory {
 	return sp.remoteMemory
 }
 
-func (sp *systemProcess) extractMapping(m *RawMapping) (*bytes.Reader, error) {
+// extractMapping reads the mapping's memory into an in-memory reader.
+// Used to access mappings that have no usable backing file (e.g. VDSO).
+func extractMapping(pr Process, m *RawMapping) (*bytes.Reader, error) {
 	data := make([]byte, m.Length)
-	_, err := sp.remoteMemory.ReadAt(data, int64(m.Vaddr))
-	if err != nil {
+	if _, err := pr.GetRemoteMemory().ReadAt(data, int64(m.Vaddr)); err != nil {
 		return nil, fmt.Errorf("unable to extract mapping at %#x from PID %d",
-			m.Vaddr, sp.pid)
+			m.Vaddr, pr.PID())
 	}
 	return bytes.NewReader(data), nil
 }
@@ -525,7 +522,7 @@ func (sp *systemProcess) CalculateMappingFileID(m *RawMapping) (libpf.FileID, er
 		if vdsoFileID != (libpf.FileID{}) {
 			return vdsoFileID, nil
 		}
-		vdso, err := sp.extractMapping(m)
+		vdso, err := extractMapping(sp, m)
 		if err != nil {
 			return libpf.FileID{}, fmt.Errorf("failed to extract VDSO: %v", err)
 		}
@@ -541,31 +538,40 @@ func (sp *systemProcess) CalculateMappingFileID(m *RawMapping) (libpf.FileID, er
 }
 
 func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
-	// Always open via map_files as it can open deleted files if available.
-	// No fallback is attempted:
-	// - if the process exited, the fallback will error also (/proc/>PID> is gone)
-	// - if the error is due to ELF content, same error will occur in both cases
-	// - if the process unmapped the ELF, its data is no longer needed
-	if m, ok := sp.fileToMapping[file]; ok {
-		if m.IsVDSO() {
-			vdso, err := sp.extractMapping(m)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract VDSO: %v", err)
-			}
-			return pfelf.NewFile(vdso, 0, false)
-		}
-		f, err := sp.getMappingFile(m)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get mapping file: %v", err)
-		}
-		return pfelf.OpenFile(f)
-	}
-
-	// Fall back to opening the file using the process specific root.
+	// Open the file using the process-specific root. Callers that have a
+	// RawMapping should use OpenELFMapping instead, which can open deleted
+	// or replaced files via /proc/<pid>/map_files.
 	// Use openat2 with RESOLVE_IN_ROOT to prevent symlink escapes from the container.
 	f, err := openInProcRoot(sp.pid, file)
 	if err != nil {
 		return nil, err
 	}
 	return pfelf.OpenFile(f)
+}
+
+// OpenELFMapping opens a memory mapping as an ELF file. VDSO is read
+// from process memory; other mappings go through OpenMappingFile so
+// systemProcess can use /proc/<pid>/map_files for deleted-file safety.
+// Only ErrMappingFileUnavailable triggers a fallback to OpenELF; other
+// OpenMappingFile errors are wrapped and returned.
+func OpenELFMapping(pr Process, m *RawMapping) (*pfelf.File, error) {
+	if m.IsVDSO() {
+		vdso, err := extractMapping(pr, m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract VDSO: %v", err)
+		}
+		return pfelf.NewFile(vdso, 0, false)
+	}
+	rac, err := pr.OpenMappingFile(m)
+	if err != nil {
+		if errors.Is(err, ErrMappingFileUnavailable) {
+			return pr.OpenELF(m.Path)
+		}
+		return nil, fmt.Errorf("OpenMappingFile pid=%d vaddr=%#x path=%q: %w",
+			pr.PID(), m.Vaddr, m.Path, err)
+	}
+	if f, ok := rac.(*os.File); ok {
+		return pfelf.OpenFile(f)
+	}
+	return pfelf.NewFileWithCloser(rac, rac, 0, false)
 }

--- a/process/process.go
+++ b/process/process.go
@@ -546,7 +546,7 @@ func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pfelf.OpenFile(f)
+	return pfelf.NewFileOwned(f)
 }
 
 // OpenELFMapping opens a memory mapping as an ELF file. VDSO is read
@@ -567,11 +567,7 @@ func OpenELFMapping(pr Process, m *RawMapping) (*pfelf.File, error) {
 		if errors.Is(err, ErrMappingFileUnavailable) {
 			return pr.OpenELF(m.Path)
 		}
-		return nil, fmt.Errorf("OpenMappingFile pid=%d vaddr=%#x path=%q: %w",
-			pr.PID(), m.Vaddr, m.Path, err)
+		return nil, fmt.Errorf("OpenMappingFile vaddr=%#x: %w", m.Vaddr, err)
 	}
-	if f, ok := rac.(*os.File); ok {
-		return pfelf.OpenFile(f)
-	}
-	return pfelf.NewFileWithCloser(rac, rac, 0, false)
+	return pfelf.NewFileOwned(rac)
 }

--- a/process/process.go
+++ b/process/process.go
@@ -567,7 +567,7 @@ func OpenELFMapping(pr Process, m *RawMapping) (*pfelf.File, error) {
 		if errors.Is(err, ErrMappingFileUnavailable) {
 			return pr.OpenELF(m.Path)
 		}
-		return nil, fmt.Errorf("OpenMappingFile vaddr=%#x: %w", m.Vaddr, err)
+		return nil, fmt.Errorf("OpenMappingFile path=%q vaddr=%#x: %w", m.Path, m.Vaddr, err)
 	}
 	return pfelf.NewFileOwned(rac)
 }

--- a/process/types.go
+++ b/process/types.go
@@ -98,10 +98,7 @@ type MachineData struct {
 }
 
 // ReadAtCloser combines the io.ReaderAt and io.Closer interfaces.
-type ReadAtCloser interface {
-	io.ReaderAt
-	io.Closer
-}
+type ReadAtCloser = pfelf.ReadAtCloser
 
 // MetaConfig provides options that influences gathering ProcessMeta.
 type MetaConfig struct {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -352,8 +352,26 @@ func (pm *ProcessManager) processRemovedInterpreters(pid libpf.PID,
 
 var errInvalidVirtualAddress = errors.New("invalid ELF virtual address")
 
+// mappingELFOpener routes opens of mapping.Path through
+// process.OpenELFMapping (VDSO + /proc/<pid>/map_files for deleted-file
+// safety) and forwards everything else (e.g. .gnu_debuglink targets) to
+// OpenELF. Routing is by string equality, so the caller must pass the
+// same mapping.Path value to pfelf.NewReference and not mutate it for
+// the opener's lifetime.
+type mappingELFOpener struct {
+	pr      process.Process
+	mapping *process.RawMapping
+}
+
+func (o *mappingELFOpener) OpenELF(file string) (*pfelf.File, error) {
+	if file == o.mapping.Path {
+		return process.OpenELFMapping(o.pr, o.mapping)
+	}
+	return o.pr.OpenELF(file)
+}
+
 func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapping) (libpf.FrameMapping, error) {
-	elfRef := pfelf.NewReference(m.Path, pr)
+	elfRef := pfelf.NewReference(m.Path, &mappingELFOpener{pr: pr, mapping: m})
 	defer elfRef.Close()
 
 	info := pm.getELFInfo(pr, m, elfRef)

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -352,26 +352,13 @@ func (pm *ProcessManager) processRemovedInterpreters(pid libpf.PID,
 
 var errInvalidVirtualAddress = errors.New("invalid ELF virtual address")
 
-// mappingELFOpener routes opens of mapping.Path through
-// process.OpenELFMapping (VDSO + /proc/<pid>/map_files for deleted-file
-// safety) and forwards everything else (e.g. .gnu_debuglink targets) to
-// OpenELF. Routing is by string equality, so the caller must pass the
-// same mapping.Path value to pfelf.NewReference and not mutate it for
-// the opener's lifetime.
-type mappingELFOpener struct {
-	pr      process.Process
-	mapping *process.RawMapping
-}
-
-func (o *mappingELFOpener) OpenELF(file string) (*pfelf.File, error) {
-	if file == o.mapping.Path {
-		return process.OpenELFMapping(o.pr, o.mapping)
-	}
-	return o.pr.OpenELF(file)
-}
-
 func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapping) (libpf.FrameMapping, error) {
-	elfRef := pfelf.NewReference(m.Path, &mappingELFOpener{pr: pr, mapping: m})
+	// Open the mapping's own file via OpenELFMapping (VDSO from memory plus
+	// /proc/<pid>/map_files for deleted-file safety); auxiliary opens such as
+	// .gnu_debuglink targets go through pr.OpenELF.
+	elfRef := pfelf.NewReferenceWithOpenFunc(m.Path, pr, func() (*pfelf.File, error) {
+		return process.OpenELFMapping(pr, m)
+	})
 	defer elfRef.Close()
 
 	info := pm.getELFInfo(pr, m, elfRef)

--- a/tools/coredump/storecoredump.go
+++ b/tools/coredump/storecoredump.go
@@ -48,7 +48,7 @@ func (scd *StoreCoredump) openFile(path string) (process.ReadAtCloser, error) {
 
 func (scd *StoreCoredump) OpenMappingFile(m *process.RawMapping) (process.ReadAtCloser, error) {
 	rac, err := scd.openFile(m.Path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, os.ErrNotExist) {
 		// Bundle miss: let OpenELFMapping fall back to OpenELF, which
 		// can serve content from PT_LOAD segments for legacy test cases.
 		return nil, fmt.Errorf("%w: %w", process.ErrMappingFileUnavailable, err)
@@ -59,7 +59,7 @@ func (scd *StoreCoredump) OpenMappingFile(m *process.RawMapping) (process.ReadAt
 func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 	file, err := scd.openFile(path)
 	if err == nil {
-		return pfelf.NewFileWithCloser(file, file, 0, false)
+		return pfelf.NewFileOwned(file)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -130,7 +130,7 @@ func OpenStoreCoredump(store *modulestore.Store, coreFileRef modulestore.ID, mod
 	if err != nil {
 		return nil, fmt.Errorf("failed to open coredump file reader: %w", err)
 	}
-	coreELF, err := pfelf.NewFile(reader, 0, false)
+	coreELF, err := pfelf.NewFileOwned(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open coredump ELF: %w", err)
 	}

--- a/tools/coredump/storecoredump.go
+++ b/tools/coredump/storecoredump.go
@@ -47,13 +47,19 @@ func (scd *StoreCoredump) openFile(path string) (process.ReadAtCloser, error) {
 }
 
 func (scd *StoreCoredump) OpenMappingFile(m *process.RawMapping) (process.ReadAtCloser, error) {
-	return scd.openFile(m.Path)
+	rac, err := scd.openFile(m.Path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		// Bundle miss: let OpenELFMapping fall back to OpenELF, which
+		// can serve content from PT_LOAD segments for legacy test cases.
+		return nil, fmt.Errorf("%w: %w", process.ErrMappingFileUnavailable, err)
+	}
+	return rac, err
 }
 
 func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 	file, err := scd.openFile(path)
 	if err == nil {
-		return pfelf.NewFile(file, 0, false)
+		return pfelf.NewFileWithCloser(file, file, 0, false)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err


### PR DESCRIPTION
Replace the `systemProcess.fileToMapping` map (populated as a side effect of `IterateMappings`, then consulted by `OpenELF`) with an explicit `process.OpenELFMapping(pr, *RawMapping)` helper that takes the mapping directly. The mapping is passed in, removing the temporal coupling between the two methods and the path-keyed lookup.

`OpenELFMapping` routes through the existing `Process.OpenMappingFile` interface method, falling back to `OpenELF` when the implementation signals `ErrMappingFileUnavailable` (used by `CoredumpProcess`, which has no backing files, and by `StoreCoredump` on bundle miss).

In `processmanager.newFrameMapping`, the mapping's `pfelf.Reference` is built with `NewReferenceWithOpenFunc`: the mapping's own file is opened via `OpenELFMapping`, while auxiliary opens (e.g. `.gnu_debuglink` targets) resolve by name through `pr.OpenELF`. The `Reference` carries the mapping context directly rather than relying on an adapter that disambiguates opens by string-comparing the path.

This also fixes some issues with `fileToMapping`:
- The first iteration after process creation missed the map_files route because `sp.fileToMapping` was assigned only at the end of `IterateMappings` and subsequent iterations could use a stale RawMapping (from the previous iteration).
- Avoid path-keyed lookup that could pick the wrong file in some very rare cases (open-telemetry/opentelemetry-ebpf-profiler#812).

Supporting `pfelf` changes: add `NewFileOwned` (replacing `OpenFile`) and centralize close-on-error cleanup in `newFile`. Taking ownership of the reader fixes file-descriptor leaks in `StoreCoredump.OpenELF` and `OpenStoreCoredump`. `process.ReadAtCloser` becomes a type alias of `pfelf.ReadAtCloser`.
