### PR TITLE
PHP: include class name in symbolized function names

### DIFF
--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -125,6 +125,27 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 		fname = ""
 	}
 
+	// Read the class name from common.scope (zend_class_entry pointer).
+	// If the function is a method, scope points to the declaring class.
+	className := ""
+	scopePtr := npsr.Ptr(fobj, vms.zend_function.common_scope)
+	if scopePtr != 0 {
+		classNameStrPtr := i.rm.Ptr(scopePtr + libpf.Address(vms.zend_class_entry.name))
+		if classNameStrPtr != 0 {
+			className = i.rm.String(classNameStrPtr + vms.zend_string.val)
+			if className != "" && !util.IsValidString(className) {
+				log.Debugf("Extracted invalid PHP class name at 0x%x '%v'",
+					addr, []byte(className))
+				className = ""
+			}
+		}
+	}
+
+	// Combine class name and function name using PHP's ClassName::methodName convention.
+	if className != "" && fname != "" {
+		fname = className + "::" + fname
+	}
+
 	functionName := libpf.Intern(fname)
 	if functionName == libpf.NullString {
 		// If we're at the top-most scope then we can display that information.

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -127,7 +127,6 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 
 	// Read the class name from common.scope (zend_class_entry pointer).
 	// If the function is a method, scope points to the declaring class.
-	className := ""
 	scopePtr := npsr.Ptr(fobj, vms.zend_function.common_scope)
 	if scopePtr != 0 {
 		classNameStrPtr := i.rm.Ptr(scopePtr + libpf.Address(vms.zend_class_entry.name))

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -132,7 +132,7 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 	if scopePtr != 0 {
 		classNameStrPtr := i.rm.Ptr(scopePtr + libpf.Address(vms.zend_class_entry.name))
 		if classNameStrPtr != 0 {
-			className = i.rm.String(classNameStrPtr + vms.zend_string.val)
+			className := i.rm.String(classNameStrPtr + vms.zend_string.val)
 			if className != "" && !util.IsValidString(className) {
 				log.Debugf("Extracted invalid PHP class name at 0x%x '%v'",
 					addr, []byte(className))

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -138,12 +138,11 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 					addr, []byte(className))
 				className = ""
 			}
+			// Combine class name and function name using PHP's ClassName::methodName convention.
+			if className != "" && fname != "" {
+				fname = className + "::" + fname
+			}
 		}
-	}
-
-	// Combine class name and function name using PHP's ClassName::methodName convention.
-	if className != "" && fname != "" {
-		fname = className + "::" + fname
 	}
 
 	functionName := libpf.Intern(fname)

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -133,8 +133,7 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 		if classNameStrPtr != 0 {
 			className := i.rm.String(classNameStrPtr + vms.zend_string.val)
 			if className != "" && !util.IsValidString(className) {
-				log.Debugf("Extracted invalid PHP class name at 0x%x '%v'",
-					addr, []byte(className))
+				log.Debugf("Extracted invalid PHP class name at 0x%x", addr)
 				className = ""
 			}
 			// Combine class name and function name using PHP's ClassName::methodName convention.

--- a/interpreter/php/instance_test.go
+++ b/interpreter/php/instance_test.go
@@ -1,0 +1,241 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package php
+
+import (
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/elastic/go-freelru"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+// mockMemory implements io.ReaderAt for testing PHP remote memory reads.
+// It stores data as a set of (address, bytes) regions.
+type mockMemory struct {
+	regions []memRegion
+}
+
+type memRegion struct {
+	addr uint64
+	data []byte
+}
+
+func newMockMemory() *mockMemory {
+	return &mockMemory{}
+}
+
+func (m *mockMemory) writeAt(addr uint64, data []byte) {
+	m.regions = append(m.regions, memRegion{addr: addr, data: append([]byte{}, data...)})
+}
+
+func (m *mockMemory) writeUint64(addr uint64, val uint64) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, val)
+	m.writeAt(addr, buf)
+}
+
+func (m *mockMemory) writeString(addr uint64, s string) {
+	// Write null-terminated string
+	m.writeAt(addr, append([]byte(s), 0))
+}
+
+func (m *mockMemory) ReadAt(p []byte, off int64) (n int, err error) {
+	addr := uint64(off)
+	for _, r := range m.regions {
+		// Allow reads that start within a region, even if they extend beyond it
+		if addr >= r.addr && addr < r.addr+uint64(len(r.data)) {
+			offset := addr - r.addr
+			n = copy(p, r.data[offset:])
+			if n < len(p) {
+				return n, io.EOF
+			}
+			return n, nil
+		}
+	}
+	return 0, io.EOF
+}
+
+// buildDefaultVMStructs returns a phpData with standard PHP 8.x offsets for testing.
+func buildDefaultVMStructs() *phpData {
+	d := &phpData{version: phpVersion(8, 0, 0)}
+	vms := &d.vmStructs
+	vms.zend_executor_globals.current_execute_data = 488
+	vms.zend_execute_data.opline = 0
+	vms.zend_execute_data.function = 24
+	vms.zend_execute_data.this_type_info = 40
+	vms.zend_execute_data.prev_execute_data = 48
+	vms.zend_function.common_type = 0
+	vms.zend_function.common_funcname = 8
+	vms.zend_function.common_scope = 16
+	vms.zend_function.op_array_filename = 144
+	vms.zend_function.op_array_linestart = 152
+	vms.zend_function.Sizeof = 168
+	vms.zend_string.val = 24
+	vms.zend_class_entry.name = 8
+	vms.zend_op.lineno = 24
+	return d
+}
+
+func TestGetFunction_ClassName(t *testing.T) {
+	tests := []struct {
+		name             string
+		funcName         string
+		className        string
+		hasScope         bool
+		expectedFuncName string
+	}{
+		{
+			name:             "method with class name",
+			funcName:         "index",
+			className:        "UserController",
+			hasScope:         true,
+			expectedFuncName: "UserController::index",
+		},
+		{
+			name:             "function without class (no scope pointer)",
+			funcName:         "array_map",
+			className:        "",
+			hasScope:         false,
+			expectedFuncName: "array_map",
+		},
+		{
+			name:             "method with namespaced class",
+			funcName:         "handle",
+			className:        "App\\Http\\Middleware\\Auth",
+			hasScope:         true,
+			expectedFuncName: "App\\Http\\Middleware\\Auth::handle",
+		},
+		{
+			name:             "scope pointer set but class name string is empty",
+			funcName:         "doSomething",
+			className:        "",
+			hasScope:         true,
+			expectedFuncName: "doSomething",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := newMockMemory()
+			d := buildDefaultVMStructs()
+			vms := &d.vmStructs
+
+			// Layout addresses
+			const (
+				funcObjAddr       = uint64(0x1000)
+				funcNameStrAddr   = uint64(0x2000)
+				classEntryAddr    = uint64(0x3000)
+				classNameStrAddr  = uint64(0x4000)
+				sourceFileStrAddr = uint64(0x5000)
+			)
+
+			// Build the zend_function object
+			fobj := make([]byte, vms.zend_function.Sizeof)
+			// Set type to ZEND_USER_FUNCTION
+			fobj[vms.zend_function.common_type] = ZEND_USER_FUNCTION
+			// Set function name pointer (points to zend_string)
+			binary.LittleEndian.PutUint64(
+				fobj[vms.zend_function.common_funcname:], funcNameStrAddr)
+			// Set scope pointer (points to zend_class_entry)
+			if tt.hasScope {
+				binary.LittleEndian.PutUint64(
+					fobj[vms.zend_function.common_scope:], classEntryAddr)
+			}
+			// Set source filename pointer
+			binary.LittleEndian.PutUint64(
+				fobj[vms.zend_function.op_array_filename:], sourceFileStrAddr)
+			// Set line start
+			binary.LittleEndian.PutUint32(
+				fobj[vms.zend_function.op_array_linestart:], 10)
+
+			mem.writeAt(funcObjAddr, fobj)
+
+			// Write function name zend_string (val is at offset 24)
+			mem.writeString(funcNameStrAddr+uint64(vms.zend_string.val), tt.funcName)
+
+			// Write class entry and class name if scope is set
+			if tt.hasScope {
+				// zend_class_entry.name is at offset 8, points to a zend_string
+				mem.writeUint64(classEntryAddr+uint64(vms.zend_class_entry.name), classNameStrAddr)
+				// Write class name zend_string
+				mem.writeString(classNameStrAddr+uint64(vms.zend_string.val), tt.className)
+			}
+
+			// Write source file name
+			mem.writeString(sourceFileStrAddr+uint64(vms.zend_string.val), "/app/test.php")
+
+			// Create the phpInstance
+			addrToFunction, err := freelru.New[libpf.Address, *phpFunction](
+				interpreter.LruFunctionCacheSize, libpf.Address.Hash32)
+			require.NoError(t, err)
+
+			instance := &phpInstance{
+				d:              d,
+				rm:             remotememory.RemoteMemory{ReaderAt: mem},
+				addrToFunction: addrToFunction,
+			}
+
+			// Call getFunction
+			f, err := instance.getFunction(libpf.Address(funcObjAddr), 0)
+			require.NoError(t, err)
+			require.NotNil(t, f)
+
+			assert.Equal(t, tt.expectedFuncName, f.name.String())
+		})
+	}
+}
+
+func TestGetFunction_NullPointer(t *testing.T) {
+	mem := newMockMemory()
+	d := buildDefaultVMStructs()
+
+	addrToFunction, err := freelru.New[libpf.Address, *phpFunction](
+		interpreter.LruFunctionCacheSize, libpf.Address.Hash32)
+	require.NoError(t, err)
+
+	instance := &phpInstance{
+		d:              d,
+		rm:             remotememory.RemoteMemory{ReaderAt: mem},
+		addrToFunction: addrToFunction,
+	}
+
+	_, err = instance.getFunction(0, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "null pointer")
+}
+
+func TestGetFunction_TopLevelCode(t *testing.T) {
+	mem := newMockMemory()
+	d := buildDefaultVMStructs()
+	vms := &d.vmStructs
+
+	const funcObjAddr = uint64(0x1000)
+
+	// Build a zend_function with no name (simulates top-level code)
+	fobj := make([]byte, vms.zend_function.Sizeof)
+	fobj[vms.zend_function.common_type] = ZEND_USER_FUNCTION
+	// funcname pointer is 0 (null) — no function name
+	mem.writeAt(funcObjAddr, fobj)
+
+	addrToFunction, err := freelru.New[libpf.Address, *phpFunction](
+		interpreter.LruFunctionCacheSize, libpf.Address.Hash32)
+	require.NoError(t, err)
+
+	instance := &phpInstance{
+		d:              d,
+		rm:             remotememory.RemoteMemory{ReaderAt: mem},
+		addrToFunction: addrToFunction,
+	}
+
+	f, err := instance.getFunction(libpf.Address(funcObjAddr), ZEND_CALL_TOP_CODE)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.TopLevelFunctionName, f.name)
+}

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -82,9 +82,15 @@ type phpData struct {
 		}
 		// https://github.com/php/php-src/blob/PHP-7.4/Zend/zend_compile.h#L483
 		zend_function struct {
-			common_type, common_funcname          uint8
-			op_array_filename, op_array_linestart uint
-			Sizeof                                uint
+			common_type, common_funcname uint8
+			common_scope                 uint
+			op_array_filename            uint
+			op_array_linestart           uint
+			Sizeof                       uint
+		}
+		// https://github.com/php/php-src/blob/PHP-8.0/Zend/zend.h#L107
+		zend_class_entry struct {
+			name uint
 		}
 		// https://github.com/php/php-src/blob/PHP-7.4/Zend/zend_types.h#L235
 		zend_string struct {
@@ -333,6 +339,7 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	vms.zend_execute_data.prev_execute_data = 48
 	vms.zend_function.common_type = 0
 	vms.zend_function.common_funcname = 8
+	vms.zend_function.common_scope = 16
 	vms.zend_function.op_array_filename = 128
 	vms.zend_function.op_array_linestart = 136
 	// Note: the sizeof here isn't actually the sizeof the
@@ -341,6 +348,7 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	// need at most 168 bytes.
 	vms.zend_function.Sizeof = 168
 	vms.zend_string.val = 24
+	vms.zend_class_entry.name = 8
 	vms.zend_op.lineno = 24
 	switch {
 	case version >= phpVersion(8, 4, 0):

--- a/tools/coredump/testdata/amd64/php-8.3.31-class-method.json
+++ b/tools/coredump/testdata/amd64/php-8.3.31-class-method.json
@@ -1,0 +1,88 @@
+{
+  "coredump-ref": "92c859936ead41c115d888af1abf327650f0da35b0ee592cc84e46fd06018070",
+  "threads": [
+    {
+      "lwp": 19637,
+      "frames": [
+        "php8.3+0x34a07d",
+        "PrimeChecker::isPrime+11 in /tmp/tmp.ZVugDmXE19/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:16",
+        "<top-level>+29 in /tmp/tmp.ZVugDmXE19/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:30",
+        "php8.3+0x38b912",
+        "php8.3+0x3953a0",
+        "php8.3+0x31c95a",
+        "php8.3+0x2ad909",
+        "php8.3+0x40fe97",
+        "php8.3+0x130a30",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "php8.3+0x131bb4"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "3c593c01d1c3497b1276537a1002c90ce3beb729a3520087608838cf8bbd847d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "fe00408090ea084504d7cb0130af56a22554fe299034b864551b65a64ca8a7b5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "ddbb3718b8bd9cbd780e5ab08b4503c30a6c4fa0706ebe5d074ed6b596c1714e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libicudata.so.74.2"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "e00576d71d81d3ba0cfa4903c835a44a8723aac96f72f79ff75200b4cff9071b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.11.2"
+    },
+    {
+      "ref": "ab48df65018b40d1d56d003f427c13435091edb0084a5776164824803d3f38e2",
+      "local-path": "/usr/bin/php8.3"
+    },
+    {
+      "ref": "1fd75fe70354a416d75aef22bcae68c47bd25d20e2d0568c30b1a9838cf62f11",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33"
+    },
+    {
+      "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "e6391daf670544d3a8f2b8a0cb8e27b4246fea109352abed50a29ec57f03153d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "0ca2c28b026f0084661fbb0e69079436680f3b6dd1f4aa3436395442456a6d4c",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "1a960c92f3a3633832fbecd1345333c07e63807c4e0413b9878d708c5884f88f",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "7560aadde38e5f4237a47a1ddd5891f9b36768a77a60faae30beee003ac01901",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libicuuc.so.74.2"
+    },
+    {
+      "ref": "a9793942a8a5f6f4d0f523ef9e0a5be4f0033f2c6c28520cd2b4e706d53c6e17",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblzma.so.5.4.5"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/php-8.4.21-class-method.json
+++ b/tools/coredump/testdata/amd64/php-8.4.21-class-method.json
@@ -1,0 +1,87 @@
+{
+  "coredump-ref": "61d8c4b7bdd8850a90192df4c9e3c1a8635901b7170d0b35ff71b3fc92565028",
+  "threads": [
+    {
+      "lwp": 19738,
+      "frames": [
+        "PrimeChecker::isPrime+11 in /tmp/tmp.ZVugDmXE19/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:16",
+        "<top-level>+29 in /tmp/tmp.ZVugDmXE19/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:30",
+        "php8.4+0x3cbe0a",
+        "php8.4+0x3c9b30",
+        "php8.4+0x435895",
+        "php8.4+0x2c6147",
+        "php8.4+0x43785e",
+        "php8.4+0x138c42",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "php8.4+0x139dc4"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "e6391daf670544d3a8f2b8a0cb8e27b4246fea109352abed50a29ec57f03153d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "3c593c01d1c3497b1276537a1002c90ce3beb729a3520087608838cf8bbd847d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "fe00408090ea084504d7cb0130af56a22554fe299034b864551b65a64ca8a7b5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "0ca2c28b026f0084661fbb0e69079436680f3b6dd1f4aa3436395442456a6d4c",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "1fd75fe70354a416d75aef22bcae68c47bd25d20e2d0568c30b1a9838cf62f11",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33"
+    },
+    {
+      "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "a9793942a8a5f6f4d0f523ef9e0a5be4f0033f2c6c28520cd2b4e706d53c6e17",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblzma.so.5.4.5"
+    },
+    {
+      "ref": "e00576d71d81d3ba0cfa4903c835a44a8723aac96f72f79ff75200b4cff9071b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.11.2"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "7560aadde38e5f4237a47a1ddd5891f9b36768a77a60faae30beee003ac01901",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libicuuc.so.74.2"
+    },
+    {
+      "ref": "1a960c92f3a3633832fbecd1345333c07e63807c4e0413b9878d708c5884f88f",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "54875f0421820607299dcd0412deffcfb15538e82d7eaf8e5c088700ad07717e",
+      "local-path": "/usr/bin/php8.4"
+    },
+    {
+      "ref": "ddbb3718b8bd9cbd780e5ab08b4503c30a6c4fa0706ebe5d074ed6b596c1714e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libicudata.so.74.2"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/php-8.3.31-class-method.json
+++ b/tools/coredump/testdata/arm64/php-8.3.31-class-method.json
@@ -1,0 +1,88 @@
+{
+  "coredump-ref": "4f8f2fc6238620e01d9fca2948701302c7b3b237e4090d40b95b7713e07c110d",
+  "threads": [
+    {
+      "lwp": 21283,
+      "frames": [
+        "php8.3+0x3392d4",
+        "PrimeChecker::isPrime+11 in /tmp/tmp.jKn9fA0Ict/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:16",
+        "<top-level>+29 in /tmp/tmp.jKn9fA0Ict/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:30",
+        "php8.3+0x386aa7",
+        "php8.3+0x392a4f",
+        "php8.3+0x3060db",
+        "php8.3+0x295bab",
+        "php8.3+0x40c89b",
+        "php8.3+0x1113bb",
+        "libc.so.6+0x284c3",
+        "libc.so.6+0x28597",
+        "php8.3+0x1114af"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "cb4d37d810d354f1c3be46bd2897ba47c9f7388da7e6470a79e3accfa8e81f41",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblzma.so.5.4.5"
+    },
+    {
+      "ref": "6930483a3efc502e503f95ff7c39182cf32028ed237b4bfe534ed2cb53d35b00",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "aa4e91ff910dbb8e40472ed4fcaaeebfef19ad13fe925d9ed8e22e87d45ce13b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpcre2-8.so.0.11.2"
+    },
+    {
+      "ref": "ff32868c17ae1f3df951839604e7f8e022c06c938e104106a0833c80f86a0f8c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "f2d3ad2bf0b61f6bc944cc37d7b6ab7f88d2582b41ff989ca164803f56cc5f20",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "6e3112d35cfc86db7ee85b27e1746f67408e2837ff8628b46386c3eabd5682a4",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.33"
+    },
+    {
+      "ref": "96b1154b9ab94cfc908c0fe745edc128ee3f67e444c66e2d7a9cf06664df9255",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicudata.so.74.2"
+    },
+    {
+      "ref": "170380b4e7ab28ec86eb090b48df90f84089392cb72fecd5067e5b7a4dc5239f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "90b9521a9b393f57a03614adf6f86ab12c31483bffa74ceb385352da5af788f6",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "c1ba3c9dced8233b3ddfab4d0395956935afdc7c3d01af1f109b91ebf12df263",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "fe5966a43e068ad7cb389c3affa069f4ee6f296e07d7ccc0398a23cfde4f0b7e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "e10876a8cbf5cccde6e4e02846b705ff6e11b3eaefe4870e95b5445435924e36",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "d5b262e559d38769e4959f036a1cc2c4009fa60b4ec836a7a19ca8554aebf5a5",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "393384096ffa869e1be20d2f91fdf08dfadb9f3e531dfe724085d8501d3f85d9",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "916219143a3ec3772a46b33043af95d7c6862b1bbbee414eb6c2443c0a1c72a2",
+      "local-path": "/usr/bin/php8.3"
+    },
+    {
+      "ref": "9d58137df08c36a03417445cc39576b0a95b538bdf0733f5455d2255deb9b799",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicuuc.so.74.2"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/php-8.4.21-class-method.json
+++ b/tools/coredump/testdata/arm64/php-8.4.21-class-method.json
@@ -1,0 +1,87 @@
+{
+  "coredump-ref": "f0a3988c6c70e7f7ac8be0b7071f5e39ee5b94a4c574aa3684f0add5868b8b3a",
+  "threads": [
+    {
+      "lwp": 21941,
+      "frames": [
+        "PrimeChecker::isPrime+11 in /tmp/tmp.jKn9fA0Ict/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:16",
+        "<top-level>+29 in /tmp/tmp.jKn9fA0Ict/opentelemetry-ebpf-profiler/tools/coredump/testsources/php/class_method.php:30",
+        "php8.4+0x3c5b08",
+        "php8.4+0x3bffcf",
+        "php8.4+0x430a4b",
+        "php8.4+0x2ab70f",
+        "php8.4+0x4329d7",
+        "php8.4+0x117523",
+        "libc.so.6+0x284c3",
+        "libc.so.6+0x28597",
+        "php8.4+0x1175ef"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "6e3112d35cfc86db7ee85b27e1746f67408e2837ff8628b46386c3eabd5682a4",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.33"
+    },
+    {
+      "ref": "fe5966a43e068ad7cb389c3affa069f4ee6f296e07d7ccc0398a23cfde4f0b7e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "6930483a3efc502e503f95ff7c39182cf32028ed237b4bfe534ed2cb53d35b00",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "d5b262e559d38769e4959f036a1cc2c4009fa60b4ec836a7a19ca8554aebf5a5",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "393384096ffa869e1be20d2f91fdf08dfadb9f3e531dfe724085d8501d3f85d9",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "cb4d37d810d354f1c3be46bd2897ba47c9f7388da7e6470a79e3accfa8e81f41",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblzma.so.5.4.5"
+    },
+    {
+      "ref": "e10876a8cbf5cccde6e4e02846b705ff6e11b3eaefe4870e95b5445435924e36",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "aa4e91ff910dbb8e40472ed4fcaaeebfef19ad13fe925d9ed8e22e87d45ce13b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpcre2-8.so.0.11.2"
+    },
+    {
+      "ref": "90b9521a9b393f57a03614adf6f86ab12c31483bffa74ceb385352da5af788f6",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "ff32868c17ae1f3df951839604e7f8e022c06c938e104106a0833c80f86a0f8c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "c1ba3c9dced8233b3ddfab4d0395956935afdc7c3d01af1f109b91ebf12df263",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "f2d3ad2bf0b61f6bc944cc37d7b6ab7f88d2582b41ff989ca164803f56cc5f20",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "96b1154b9ab94cfc908c0fe745edc128ee3f67e444c66e2d7a9cf06664df9255",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicudata.so.74.2"
+    },
+    {
+      "ref": "9d58137df08c36a03417445cc39576b0a95b538bdf0733f5455d2255deb9b799",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicuuc.so.74.2"
+    },
+    {
+      "ref": "1a0fec374922714f0c08e29dec2d40c3bc784a64ee3c324e6923245417e51134",
+      "local-path": "/usr/bin/php8.4"
+    },
+    {
+      "ref": "170380b4e7ab28ec86eb090b48df90f84089392cb72fecd5067e5b7a4dc5239f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3"
+    }
+  ]
+}

--- a/tools/coredump/testsources/php/class_method.php
+++ b/tools/coredump/testsources/php/class_method.php
@@ -1,0 +1,34 @@
+<?php
+
+class PrimeChecker
+{
+    public function isPrime($number)
+    {
+        if ($number <= 1) {
+            return false;
+        }
+        if ($number == 2) {
+            return true;
+        }
+
+        $x = sqrt($number);
+        $x = floor($x);
+        for ($i = 2; $i <= $x; ++$i) {
+            if ($number % $i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+while (true) {
+    $checker = new PrimeChecker();
+    $start = 0;
+    $end = 1000000;
+    for ($i = $start; $i <= $end; $i++) {
+        if ($checker->isPrime($i)) {
+            // keep busy
+        }
+    }
+}


### PR DESCRIPTION
Read class name from zend_function.common.scope and prepend it using ClassName::methodName convention.

Fixes #1407