### PR TITLE
Read correct type for BytecodeArray source_position_table

### DIFF
--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -1114,9 +1114,13 @@ func (i *v8Instance) getSFI(taggedPtr libpf.Address) (*v8SFI, error) {
 		} else {
 			log.Debugf("Bytecode, %d bytes, not available", length)
 		}
+		typ := vms.Type.ByteArray
+		if vms.SourcePositionTable.TrustedByteArray {
+			typ = vms.Type.TrustedByteArray
+		}
 		sfi.bytecodePositionTable, err = i.readFixedTablePtr(
 			fdAddr+libpf.Address(vms.BytecodeArray.SourcePositionTable),
-			vms.Type.ByteArray, 1, 0)
+			typ, 1, 0)
 		log.Debugf("Bytecode positions: %d bytes: %v", len(sfi.bytecodePositionTable), err)
 	}
 


### PR DESCRIPTION
This partially fixes
https://github.com/parca-dev/parca-agent/issues/3180 : results now look right for Node v22, but not yet for v24 (there is probably another issue lurking somewhere)