### PR TITLE
asm/arm: prevent panic in DecodeImmediate for post-index LDR

### DIFF
--- a/asm/arm/helpers.go
+++ b/asm/arm/helpers.go
@@ -156,11 +156,19 @@ func DecodeImmediate(arg aa.Arg) (int64, bool) {
 			return int64(reg - aa.X0), true
 		}
 
-		// Otherwise all of the strings end with a ], so we just parse
-		// the string before that.
+		// For AddrOffset/AddrPreIndex the format is "[Xn, #imm]" or "[Xn, #imm]!",
+		// so "]" is present in fields[1].
+		// For AddrPostIndex the format is "[Xn], #imm", so "]" is only in fields[0].
 		endIndex := strings.Index(fields[1], "]")
+		var numStr string
+		if endIndex == -1 {
+			// Post-index case: no "]" in the offset field; parse to end of string.
+			numStr = strings.TrimSpace(fields[1][pos+1:])
+		} else {
+			numStr = fields[1][pos+1 : endIndex]
+		}
 		// The strings are base 10 encoded
-		out, err := strconv.ParseInt(fields[1][pos+1:endIndex], 10, 64)
+		out, err := strconv.ParseInt(numStr, 10, 64)
 		if err != nil {
 			return 0, false
 		}

--- a/asm/arm/tls_test.go
+++ b/asm/arm/tls_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	aa "golang.org/x/arch/arm64/arm64asm"
 )
 
 func TestExtractTLSOffset(t *testing.T) {
@@ -146,4 +147,68 @@ func TestExtractTLSOffset(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeImmediatePostIndex(t *testing.T) {
+	decodeOneMem := func(t *testing.T, code []byte) aa.MemImmediate {
+		t.Helper()
+		inst, err := aa.Decode(code)
+		require.NoError(t, err)
+		require.Equal(t, aa.LDR, inst.Op)
+		mem, ok := inst.Args[1].(aa.MemImmediate)
+		require.True(t, ok, "expected MemImmediate operand")
+		return mem
+	}
+
+	testdata := []struct {
+		name    string
+		code    []byte
+		wantVal int64
+		wantOK  bool
+	}{
+		{
+			// LDR X0, [X1], #8
+			name:    "post-index positive offset",
+			code:    []byte{0x20, 0x84, 0x40, 0xF8},
+			wantVal: 8,
+			wantOK:  true,
+		},
+		{
+			// LDR X0, [X1, #32]
+			name:    "offset mode",
+			code:    []byte{0x20, 0x10, 0x40, 0xF9},
+			wantVal: 32,
+			wantOK:  true,
+		},
+		{
+			// LDR X0, [X1, #16]!
+			name:    "pre-index mode",
+			code:    []byte{0x20, 0x0C, 0x41, 0xF8},
+			wantVal: 16,
+			wantOK:  true,
+		},
+	}
+
+	for _, td := range testdata {
+		t.Run(td.name, func(t *testing.T) {
+			mem := decodeOneMem(t, td.code)
+			// Must not panic.
+			val, ok := DecodeImmediate(mem)
+			require.Equal(t, td.wantOK, ok)
+			if td.wantOK {
+				assert.Equal(t, td.wantVal, val)
+			}
+		})
+	}
+}
+
+func TestExtractTLSOffsetPostIndexLDR(t *testing.T) {
+	code := []byte{
+		0x41, 0xd0, 0x3b, 0xd5, // MRS X1, TPIDR_EL0
+		0x20, 0x84, 0x40, 0xf8, // LDR X0, [X1], #8  (post-index — must not panic)
+		0xc0, 0x03, 0x5f, 0xd6, // RET
+	}
+	offset, err := ExtractTLSOffset(code, 0x1000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(8), offset)
 }


### PR DESCRIPTION
`DecodeImmediate` splits `MemImmediate.String()` on `,` and then calls `strings.Index` on `fields[1]` to find `]`.  For post-index addressing the format is `[Xn], #imm`, so `fields[1]` is `#imm` and does not contain a `]`, making `strings.Index` return `-1`.  The subsequent slice `fields[1][pos+1:-1]` then causes a runtime panic.