### PR TITLE
asm/expression: operands.Match() must not mutate expression trees

### DIFF
--- a/asm/expression/expression.go
+++ b/asm/expression/expression.go
@@ -28,10 +28,17 @@ func (os *operands) Match(other operands) bool {
 	if len(*os) != len(other) {
 		return false
 	}
-	sort.Sort(sortedOperands(*os))
-	sort.Sort(sortedOperands(other))
-	for i := 0; i < len(*os); i++ {
-		if !(*os)[i].Match(other[i]) {
+	// Sort copies, never the originals.  Sorting in-place mutates the
+	// expression tree, causing non-deterministic results when the same
+	// expression or pattern is reused across multiple Match() calls.
+	osCopy := make(operands, len(*os))
+	copy(osCopy, *os)
+	otherCopy := make(operands, len(other))
+	copy(otherCopy, other)
+	sort.Sort(sortedOperands(osCopy))
+	sort.Sort(sortedOperands(otherCopy))
+	for i := range osCopy {
+		if !osCopy[i].Match(otherCopy[i]) {
 			return false
 		}
 	}

--- a/asm/expression/expression.go
+++ b/asm/expression/expression.go
@@ -25,15 +25,16 @@ type Expression interface {
 type operands []Expression
 
 func (os *operands) Match(other operands) bool {
-	if len(*os) != len(other) {
+	osLen := len(*os)
+	if osLen != len(other) {
 		return false
 	}
 	// Sort copies, never the originals.  Sorting in-place mutates the
 	// expression tree, causing non-deterministic results when the same
 	// expression or pattern is reused across multiple Match() calls.
-	osCopy := make(operands, len(*os))
+	osCopy := make(operands, osLen)
 	copy(osCopy, *os)
-	otherCopy := make(operands, len(other))
+	otherCopy := make(operands, osLen)
 	copy(otherCopy, other)
 	sort.Sort(sortedOperands(osCopy))
 	sort.Sort(sortedOperands(otherCopy))

--- a/asm/expression/expression_test.go
+++ b/asm/expression/expression_test.go
@@ -113,4 +113,23 @@ func TestExpression(t *testing.T) {
 		v1 := Named("v1")
 		require.Equal(t, ZeroExtend(v1, 8), ZeroExtend(ZeroExtend(v1, 8), 8))
 	})
+
+	t.Run("match must not sort operand slices in place", func(t *testing.T) {
+		n1 := Named("n1")
+		n2 := Named("n2")
+		m := Mem8(Named("m"))
+
+		pattern := newOp(opAdd, operands{n1, n2, m})
+		expr := newOp(opAdd, operands{n2, n1, m})
+
+		wantPattern := pattern.DebugString()
+		wantExpr := expr.DebugString()
+
+		_ = expr.Match(pattern)
+
+		require.Equal(t, wantPattern, pattern.DebugString(),
+			"Match must not sort the pattern's operand slice in-place")
+		require.Equal(t, wantExpr, expr.DebugString(),
+			"Match must not sort the expression's operand slice in-place")
+	})
 }


### PR DESCRIPTION
`operands.Match()` called `sort.Sort()` directly on the backing arrays of both the receiver `(*operands)` and the `other` argument.  Because slices share their underlying array, this sorted the actual operands of the matched expression and the pattern in-place.

Consequently the second call to `Match()` on the same pattern (or the same expression) could see a different operand order than the caller built, and return a wrong result.