### PR TITLE
Add per-CPU targeting for profiler

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -84,6 +84,7 @@ var (
 	bpffsHelp = fmt.Sprintf("Set the root BPF FS path for pinned maps. Only used for OBI span/trace ID communication. Default is %s",
 		defaultBPFFSRoot)
 	obiProcessCtxHelp = "Load or create a pinned eBPF map for sharing process context information with OBI."
+	targetCPUIDsHelp  = "Range of CPUs to profile. Format: \"0-15,20,31\""
 )
 
 // Package-scope variable, so that conditionally compiled other components can refer
@@ -132,6 +133,19 @@ func parseArgs() (*controller.Config, error) {
 	fs.BoolVar(&args.SendErrorFrames, "send-error-frames", defaultArgSendErrorFrames,
 		sendErrorFramesHelp)
 	fs.BoolVar(&args.SendIdleFrames, "send-idle-frames", false, sendIdleFramesHelp)
+
+	fs.Func("target-cpu", targetCPUIDsHelp, func(cpuRange string) error {
+		if cpuRange == "" {
+			args.TargetCPUIDs = []int{}
+			return nil
+		}
+		CPUIDs, err := tracer.ReadCPURange(cpuRange)
+		if err != nil {
+			return fmt.Errorf("Failed to parse target CPUs range: %s", cpuRange)
+		}
+		args.TargetCPUIDs = CPUIDs
+		return nil
+	})
 
 	fs.StringVar(&args.Tracers, "t", "all", "Shorthand for -tracers.")
 	fs.StringVar(&args.Tracers, "tracers", "all", tracersHelp)

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DisableTLS    bool
 	PprofAddr     string
 	Version       bool
+	TargetCPUIDs  []int
 
 	ExecutableReporter reporter.ExecutableReporter
 	OnShutdown         func() error

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -126,7 +126,7 @@ func (c *Controller) Start(ctx context.Context) error {
 	log.Debug("Completed initial PID listing")
 
 	// Attach our tracer to the perf event
-	if err := trc.AttachTracer(); err != nil {
+	if err := trc.AttachTracer(c.config.TargetCPUIDs); err != nil {
 		return fmt.Errorf("failed to attach to perf event: %w", err)
 	}
 	log.Info("Attached tracer program")

--- a/support/ebpf/errors.h
+++ b/support/ebpf/errors.h
@@ -160,8 +160,7 @@ typedef enum ErrorCode {
   // Native: Unable to read the IRQ stack link
   ERR_NATIVE_CHASE_IRQ_STACK_LINK = 4010,
 
-  // Native: Unexpectedly encountered a kernel mode pointer while attempting to unwind user-mode
-  // stack
+  // Native: Unexpectedly encountered a kernel mode pointer while attempting to unwind user-mode stack
   ERR_NATIVE_UNEXPECTED_KERNEL_ADDRESS = 4011,
 
   // Native: Unable to locate the PID page mapping for the current instruction pointer

--- a/tracer/helper.go
+++ b/tracer/helper.go
@@ -57,13 +57,16 @@ func getOnlineCPUIDs() ([]int, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read %s: %v", cpuPath, err)
 	}
-	return readCPURange(string(buf))
+	return ReadCPURange(string(buf))
 }
 
 // Since the format of online CPUs can contain comma-separated, ranges or a single value
 // we need to try and parse it in all its different forms.
 // Reference: https://www.kernel.org/doc/Documentation/admin-guide/cputopology.rst
-func readCPURange(cpuRangeStr string) ([]int, error) {
+func ReadCPURange(cpuRangeStr string) ([]int, error) {
+	if cpuRangeStr == "" {
+		return []int{}, nil
+	}
 	var cpus []int
 	cpuRangeStr = strings.Trim(cpuRangeStr, "\n ")
 	for cpuRange := range strings.SplitSeq(cpuRangeStr, ",") {
@@ -86,4 +89,23 @@ func readCPURange(cpuRangeStr string) ([]int, error) {
 		}
 	}
 	return cpus, nil
+}
+
+// Intersects user-defined list of target CPU IDs with list of online CPU IDs
+func intersectCPURanges(onlineCPUs, targetCPUs []int) ([]int, error) {
+	var intersection []int
+	hash := make(map[int]bool)
+	for _, v := range onlineCPUs {
+		hash[v] = true
+	}
+
+	for _, cpu := range targetCPUs {
+		if hash[cpu] {
+			intersection = append(intersection, cpu)
+		}
+	}
+	if len(intersection) == 0 {
+		return nil, fmt.Errorf("List of target CPUs is empty")
+	}
+	return intersection, nil
 }

--- a/tracer/helper_test.go
+++ b/tracer/helper_test.go
@@ -19,13 +19,57 @@ func TestReadCPURange(t *testing.T) {
 			input:    "0-7",
 			expected: []int{0, 1, 2, 3, 4, 5, 6, 7},
 		},
+		"empty": {
+			input:    "",
+			expected: []int{},
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := readCPURange(tc.input)
+			got, err := ReadCPURange(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestIntersectCPURanges(t *testing.T) {
+	tests := map[string]struct {
+		online   []int
+		enabled  []int
+		expected []int
+		want_err bool
+	}{
+		"all": {
+			online:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			enabled:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want_err: false,
+		},
+		"partial intersection": {
+			online:   []int{0, 2, 4, 6, 8},
+			enabled:  []int{0, 1, 2, 3, 4},
+			expected: []int{0, 2, 4},
+			want_err: false,
+		},
+		"empty intersection": {
+			online:   []int{0, 2, 4, 6, 8},
+			enabled:  []int{1, 3, 5, 7, 9},
+			expected: nil,
+			want_err: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := intersectCPURanges(tc.online, tc.enabled)
+			if tc.want_err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, got)
+			}
 		})
 	}
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1145,7 +1145,7 @@ func terminatePerfEvents(events []*perf.Event) {
 // AttachTracer attaches the main tracer entry point to the perf interrupt events. The tracer
 // entry point is always the native tracer. The native tracer will determine when to invoke the
 // interpreter tracers based on address range information.
-func (t *Tracer) AttachTracer() error {
+func (t *Tracer) AttachTracer(targetCPUs []int) error {
 	tracerProg, ok := t.ebpfProgs["native_tracer_entry"]
 	if !ok {
 		return errors.New("entry program is not available")
@@ -1162,9 +1162,18 @@ func (t *Tracer) AttachTracer() error {
 		return fmt.Errorf("failed to get online cpus: %w", err)
 	}
 
+	if len(targetCPUs) == 0 {
+		targetCPUs = onlineCPUs
+	} else {
+		targetCPUs, err = intersectCPURanges(targetCPUs, onlineCPUs)
+		if err != nil {
+			return err
+		}
+	}
+
 	events := t.perfEntrypoints.WLock()
 	defer t.perfEntrypoints.WUnlock(&events)
-	for _, id := range onlineCPUs {
+	for _, id := range targetCPUs {
 		perfEvent, err := perf.Open(perfAttribute, perf.AllThreads, id, nil)
 		if err != nil {
 			terminatePerfEvents(*events)


### PR DESCRIPTION
It is very useful to choose which CPUs to profile in cases with [CPU pinning](https://www.intel.com/content/www/us/en/docs/mpi-library/developer-reference-linux/2021-8/process-pinning.html).

I added a cli flag `-target-cpu` supporting CPU ranges, for example `0-31,55,59`.

Example:
```bash
$ sudo ./ebpf-profiler  -collection-agent=127.0.0.1:4040 \
   -disable-tls=true -tracers='go' -samples-per-second=50  -target-cpu=0-2,6
```

<img width="1905" height="921" alt="image" src="https://github.com/user-attachments/assets/1d4c575a-fa5f-44ad-8515-b4a28f56c899" />
