### PR TITLE
feat(dotnet): add metrics for PE info and #Strings heap caches

### DIFF
--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/hash"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/libpf/readatbuf"
+	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -684,8 +685,10 @@ func (pi *peInfo) lookupString(rm remotememory.RemoteMemory, stringsHeapAddr uin
 		return libpf.NullString
 	}
 	if s, ok := pi.stringsCache.Get(offs); ok {
+		globalPeCache.stringsCacheHit.Add(1)
 		return s
 	}
+	globalPeCache.stringsCacheMiss.Add(1)
 	s := libpf.Intern(rm.String(libpf.Address(stringsHeapAddr + uint64(offs))))
 	if s == libpf.NullString {
 		return s
@@ -1239,6 +1242,11 @@ type peCache struct {
 	peInfoCacheHit  atomic.Uint64
 	peInfoCacheMiss atomic.Uint64
 
+	// stringsCacheHit / stringsCacheMiss aggregate hit/miss counts across the
+	// per-peInfo #Strings heap caches.
+	stringsCacheHit  atomic.Uint64
+	stringsCacheMiss atomic.Uint64
+
 	// elfInfoCache provides a cache to quickly retrieve the PE info and fileID for a particular
 	// executable. It caches results based on iNode number and device ID. Locked LRU.
 	peInfoCache *freelru.LRU[util.OnDiskFileIdentifier, *peInfo]
@@ -1303,4 +1311,28 @@ var globalPeCache peCache
 
 func init() {
 	globalPeCache.init()
+}
+
+// GetAndResetMetrics returns the current counters of the global PE info cache
+// and resets them to zero. It is intended to be called once per metrics
+// collection interval by the process manager.
+func GetAndResetMetrics() []metrics.Metric {
+	return []metrics.Metric{
+		{
+			ID:    metrics.IDDotnetPEInfoCacheHit,
+			Value: metrics.MetricValue(globalPeCache.peInfoCacheHit.Swap(0)),
+		},
+		{
+			ID:    metrics.IDDotnetPEInfoCacheMiss,
+			Value: metrics.MetricValue(globalPeCache.peInfoCacheMiss.Swap(0)),
+		},
+		{
+			ID:    metrics.IDDotnetStringsCacheHit,
+			Value: metrics.MetricValue(globalPeCache.stringsCacheHit.Swap(0)),
+		},
+		{
+			ID:    metrics.IDDotnetStringsCacheMiss,
+			Value: metrics.MetricValue(globalPeCache.stringsCacheMiss.Swap(0)),
+		},
+	}
 }

--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -650,6 +650,18 @@ const (
 	// Number of failures to read TLS variables via the DTV
 	IDUnwindErrBadDTVRead = 286
 
+	// Number of cache hits for dotnet PE information
+	IDDotnetPEInfoCacheHit = 287
+
+	// Number of cache misses for dotnet PE information
+	IDDotnetPEInfoCacheMiss = 288
+
+	// Number of cache hits for dotnet #Strings heap lookups
+	IDDotnetStringsCacheHit = 289
+
+	// Number of cache misses for dotnet #Strings heap lookups
+	IDDotnetStringsCacheMiss = 290
+
 	// max number of ID values, keep this as *last entry*
-	IDMax = 287
+	IDMax = 291
 )

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -2096,5 +2096,33 @@
     "name": "UnwindErrBadDTVRead",
     "field": "bpf.errors.bad_dtv_read",
     "id": 286
+  },
+  {
+    "description": "Number of cache hits for dotnet PE information",
+    "type": "counter",
+    "name": "DotnetPEInfoCacheHit",
+    "field": "agent.dotnet.pe_info_cache.hits",
+    "id": 287
+  },
+  {
+    "description": "Number of cache misses for dotnet PE information",
+    "type": "counter",
+    "name": "DotnetPEInfoCacheMiss",
+    "field": "agent.dotnet.pe_info_cache.misses",
+    "id": 288
+  },
+  {
+    "description": "Number of cache hits for dotnet #Strings heap lookups",
+    "type": "counter",
+    "name": "DotnetStringsCacheHit",
+    "field": "agent.dotnet.strings_cache.hits",
+    "id": 289
+  },
+  {
+    "description": "Number of cache misses for dotnet #Strings heap lookups",
+    "type": "counter",
+    "name": "DotnetStringsCacheMiss",
+    "field": "agent.dotnet.strings_cache.misses",
+    "id": 290
   }
 ]

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -22,6 +22,12 @@ type Metric struct {
 // processing it further.
 type Summary map[MetricID]MetricValue
 
+func (s Summary) Add(metrics []Metric) {
+	for _, metric := range metrics {
+		s[metric.ID] = metric.Value
+	}
+}
+
 type MetricDefinition struct {
 	ID          MetricID   `json:"id"`
 	Type        MetricType `json:"type"`

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/apmint"
+	"go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/lpm"
@@ -155,7 +156,7 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 		pm.mu.RLock()
 		defer pm.mu.RUnlock()
 
-		summary := make(map[metrics.MetricID]metrics.MetricValue)
+		summary := make(metrics.Summary)
 
 		for pid := range pm.interpreters {
 			for addr, ii := range pm.interpreters[pid] {
@@ -182,10 +183,8 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 		summary[metrics.IDTotalProcParseUsec] = metrics.MetricValue(pm.mappingStats.totalProcParseUsec.Swap(0))
 		summary[metrics.IDErrProcParse] = metrics.MetricValue(pm.mappingStats.numProcParseErrors.Swap(0))
 
-		mapsMetrics := pm.ebpf.CollectMetrics()
-		for _, metric := range mapsMetrics {
-			summary[metric.ID] = metric.Value
-		}
+		summary.Add(dotnet.GetAndResetMetrics())
+		summary.Add(pm.ebpf.CollectMetrics())
 
 		pm.eim.UpdateMetricSummary(summary)
 		pm.metricsAddSlice(metricSummaryToSlice(summary))


### PR DESCRIPTION
Track hits and misses for the package-global peCache and for the
per-peInfo #Strings heap caches. Counters are aggregated atomically
on globalPeCache and exported once per metrics interval.