### PR TITLE
libpf: add synthetic MemoryPayloadFrame for memory-origin payload

### DIFF
--- a/libpf/frametype.go
+++ b/libpf/frametype.go
@@ -55,6 +55,11 @@ const (
 	BEAMFrame FrameType = support.FrameMarkerBEAM
 	// LuaJITFrame identifies the LuaJIT interpreter frames.
 	LuaJITFrame FrameType = support.FrameMarkerLuaJIT
+	// MemoryPayloadFrame is a synthetic frame attached by the user-space
+	// reporter to memory-origin traces. It carries the alloc/free counters
+	// for the trace as plain frame fields and is not produced by the eBPF
+	// unwinder. Reporters should not render these as stack locations.
+	MemoryPayloadFrame FrameType = support.FrameMarkerMemoryPayload
 )
 
 const (

--- a/libpf/interpretertype.go
+++ b/libpf/interpretertype.go
@@ -37,6 +37,10 @@ const (
 	Go InterpreterType = support.FrameMarkerGo
 	// BEAM identifies the BEAM interpreter.
 	BEAM InterpreterType = support.FrameMarkerBEAM
+	// MemoryPayload is the pseudo-interpreter that owns the synthetic frame
+	// reporters use to carry memory-origin payload (alloc/free counts and
+	// byte totals) inside a trace.
+	MemoryPayload InterpreterType = support.FrameMarkerMemoryPayload
 )
 
 // Pseudo-interpreters without a corresponding frame type.
@@ -64,20 +68,21 @@ var interpreterTypeToString = map[InterpreterType]string{
 	UnknownInterp: "unknown",
 	PHP:           "php",
 	// OTel SemConv does not differentiate between jitted code and interpreted code.
-	PHPJIT:   "php",
-	Python:   "cpython",
-	Native:   "native",
-	Kernel:   "kernel",
-	HotSpot:  "jvm",
-	Ruby:     "ruby",
-	Perl:     "perl",
-	V8:       "v8js",
-	Dotnet:   "dotnet",
-	BEAM:     "beam",
-	APMInt:   "apm-integration",
-	LuaJIT:   "luajit",
-	Go:       "go",
-	GoLabels: "go-labels",
+	PHPJIT:        "php",
+	Python:        "cpython",
+	Native:        "native",
+	Kernel:        "kernel",
+	HotSpot:       "jvm",
+	Ruby:          "ruby",
+	Perl:          "perl",
+	V8:            "v8js",
+	Dotnet:        "dotnet",
+	BEAM:          "beam",
+	APMInt:        "apm-integration",
+	LuaJIT:        "luajit",
+	Go:            "go",
+	GoLabels:      "go-labels",
+	MemoryPayload: "memory-payload",
 }
 
 var stringToInterpreterType = make(map[string]InterpreterType, len(interpreterTypeToString))

--- a/libpf/memory_payload.go
+++ b/libpf/memory_payload.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package libpf // import "go.opentelemetry.io/ebpf-profiler/libpf"
+
+// MemoryPayloadKind identifies which counter pair a synthetic
+// MemoryPayloadFrame holds. The kind is stored in Frame.FunctionOffset so
+// payload frames can be decoded independently of their position in a trace.
+type MemoryPayloadKind uint32
+
+const (
+	// MemoryPayloadAllocs marks a frame whose AddressOrLineno is the
+	// allocation count and SourceLine is the total bytes allocated.
+	MemoryPayloadAllocs MemoryPayloadKind = 0
+	// MemoryPayloadFrees marks a frame whose AddressOrLineno is the free
+	// count and SourceLine is the total bytes freed.
+	MemoryPayloadFrees MemoryPayloadKind = 1
+)
+
+// NewMemoryPayloadFrame returns a synthetic frame carrying a memory-origin
+// counter pair. Reporters consuming a memory-origin trace decode the alloc
+// totals from one MemoryPayloadAllocs frame and the free totals from one
+// MemoryPayloadFrees frame; either may be omitted if its counters are zero.
+//
+// Each frame uses three uint64-sized fields:
+//
+//	FunctionOffset  = MemoryPayloadKind   (allocs vs frees)
+//	AddressOrLineno = count
+//	SourceLine      = bytes
+func NewMemoryPayloadFrame(kind MemoryPayloadKind, count, bytes uint64) Frame {
+	return Frame{
+		Type:            MemoryPayloadFrame,
+		FunctionOffset:  uint32(kind),
+		AddressOrLineno: AddressOrLineno(count),
+		SourceLine:      SourceLineno(bytes),
+	}
+}
+
+// DecodeMemoryPayload returns the (kind, count, bytes) triple stored on a
+// synthetic memory-payload frame. The caller is responsible for ensuring
+// f.Type == MemoryPayloadFrame before calling.
+func DecodeMemoryPayload(f Frame) (kind MemoryPayloadKind, count, bytes uint64) {
+	return MemoryPayloadKind(f.FunctionOffset),
+		uint64(f.AddressOrLineno),
+		uint64(f.SourceLine)
+}

--- a/support/ebpf/frametypes.h
+++ b/support/ebpf/frametypes.h
@@ -8,33 +8,37 @@
 #define OPTI_FRAMETYPES_H
 
 // Indicates that the interpreter/runtime this frame belongs to is unknown.
-#define FRAME_MARKER_UNKNOWN 0x0
+#define FRAME_MARKER_UNKNOWN        0x0
 // Indicates a Python frame
-#define FRAME_MARKER_PYTHON  0x1
+#define FRAME_MARKER_PYTHON         0x1
 // Indicates a PHP frame
-#define FRAME_MARKER_PHP     0x2
+#define FRAME_MARKER_PHP            0x2
 // Indicates a native frame
-#define FRAME_MARKER_NATIVE  0x3
+#define FRAME_MARKER_NATIVE         0x3
 // Indicates a kernel frame
-#define FRAME_MARKER_KERNEL  0x4
+#define FRAME_MARKER_KERNEL         0x4
 // Indicates a HotSpot frame
-#define FRAME_MARKER_HOTSPOT 0x5
+#define FRAME_MARKER_HOTSPOT        0x5
 // Indicates a Ruby frame
-#define FRAME_MARKER_RUBY    0x6
+#define FRAME_MARKER_RUBY           0x6
 // Indicates a Perl frame
-#define FRAME_MARKER_PERL    0x7
+#define FRAME_MARKER_PERL           0x7
 // Indicates a V8 frame
-#define FRAME_MARKER_V8      0x8
+#define FRAME_MARKER_V8             0x8
 // Indicates a PHP JIT frame
-#define FRAME_MARKER_PHP_JIT 0x9
+#define FRAME_MARKER_PHP_JIT        0x9
 // Indicates a Dotnet frame
-#define FRAME_MARKER_DOTNET  0xA
+#define FRAME_MARKER_DOTNET         0xA
 // Indicates a Go frame
-#define FRAME_MARKER_GO      0xB
+#define FRAME_MARKER_GO             0xB
 // Indicates a BEAM frame
-#define FRAME_MARKER_BEAM    0xC
+#define FRAME_MARKER_BEAM           0xC
 // Indicates a LuaJIT frame
-#define FRAME_MARKER_LUAJIT  0xD
+#define FRAME_MARKER_LUAJIT         0xD
+// Synthetic frame attached by the user-space reporter to a memory-origin
+// trace to carry the allocation payload (alloc/free counts and byte
+// totals). Not produced by the eBPF unwinder.
+#define FRAME_MARKER_MEMORY_PAYLOAD 0xE
 
 // Frame flags
 // Indicates that this frame is an error frame.

--- a/support/types.go
+++ b/support/types.go
@@ -11,20 +11,21 @@ import (
 )
 
 const (
-	FrameMarkerUnknown = 0x0
-	FrameMarkerPython  = 0x1
-	FrameMarkerNative  = 0x3
-	FrameMarkerPHP     = 0x2
-	FrameMarkerPHPJIT  = 0x9
-	FrameMarkerKernel  = 0x4
-	FrameMarkerHotSpot = 0x5
-	FrameMarkerRuby    = 0x6
-	FrameMarkerPerl    = 0x7
-	FrameMarkerV8      = 0x8
-	FrameMarkerDotnet  = 0xa
-	FrameMarkerLuaJIT  = 0xd
-	FrameMarkerBEAM    = 0xc
-	FrameMarkerGo      = 0xb
+	FrameMarkerUnknown       = 0x0
+	FrameMarkerPython        = 0x1
+	FrameMarkerNative        = 0x3
+	FrameMarkerPHP           = 0x2
+	FrameMarkerPHPJIT        = 0x9
+	FrameMarkerKernel        = 0x4
+	FrameMarkerHotSpot       = 0x5
+	FrameMarkerRuby          = 0x6
+	FrameMarkerPerl          = 0x7
+	FrameMarkerV8            = 0x8
+	FrameMarkerDotnet        = 0xa
+	FrameMarkerLuaJIT        = 0xd
+	FrameMarkerBEAM          = 0xc
+	FrameMarkerGo            = 0xb
+	FrameMarkerMemoryPayload = 0xe
 )
 
 const (

--- a/support/types_def.go
+++ b/support/types_def.go
@@ -17,20 +17,21 @@ import (
 import "C"
 
 const (
-	FrameMarkerUnknown = C.FRAME_MARKER_UNKNOWN
-	FrameMarkerPython  = C.FRAME_MARKER_PYTHON
-	FrameMarkerNative  = C.FRAME_MARKER_NATIVE
-	FrameMarkerPHP     = C.FRAME_MARKER_PHP
-	FrameMarkerPHPJIT  = C.FRAME_MARKER_PHP_JIT
-	FrameMarkerKernel  = C.FRAME_MARKER_KERNEL
-	FrameMarkerHotSpot = C.FRAME_MARKER_HOTSPOT
-	FrameMarkerRuby    = C.FRAME_MARKER_RUBY
-	FrameMarkerPerl    = C.FRAME_MARKER_PERL
-	FrameMarkerV8      = C.FRAME_MARKER_V8
-	FrameMarkerDotnet  = C.FRAME_MARKER_DOTNET
-	FrameMarkerLuaJIT  = C.FRAME_MARKER_LUAJIT
-	FrameMarkerBEAM    = C.FRAME_MARKER_BEAM
-	FrameMarkerGo      = C.FRAME_MARKER_GO
+	FrameMarkerUnknown       = C.FRAME_MARKER_UNKNOWN
+	FrameMarkerPython        = C.FRAME_MARKER_PYTHON
+	FrameMarkerNative        = C.FRAME_MARKER_NATIVE
+	FrameMarkerPHP           = C.FRAME_MARKER_PHP
+	FrameMarkerPHPJIT        = C.FRAME_MARKER_PHP_JIT
+	FrameMarkerKernel        = C.FRAME_MARKER_KERNEL
+	FrameMarkerHotSpot       = C.FRAME_MARKER_HOTSPOT
+	FrameMarkerRuby          = C.FRAME_MARKER_RUBY
+	FrameMarkerPerl          = C.FRAME_MARKER_PERL
+	FrameMarkerV8            = C.FRAME_MARKER_V8
+	FrameMarkerDotnet        = C.FRAME_MARKER_DOTNET
+	FrameMarkerLuaJIT        = C.FRAME_MARKER_LUAJIT
+	FrameMarkerBEAM          = C.FRAME_MARKER_BEAM
+	FrameMarkerGo            = C.FRAME_MARKER_GO
+	FrameMarkerMemoryPayload = C.FRAME_MARKER_MEMORY_PAYLOAD
 )
 
 const (


### PR DESCRIPTION
## Summary

Reserve `FRAME_MARKER_MEMORY_PAYLOAD` (`0xE`) for synthetic frames that user-space reporters can attach to a memory-origin trace to carry the trace's alloc/free counters (counts and byte totals) inline on `trace.Frames`, so memory-profile reporters can decode the payload from the trace itself without growing `TraceEventMeta` with origin-specific fields.

- New `libpf.MemoryPayloadFrame` / `libpf.MemoryPayload` constants and `"memory-payload"` interpreter-type string.
- New `libpf/memory_payload.go` with `NewMemoryPayloadFrame(kind, count, bytes)` and `DecodeMemoryPayload(f) -> (kind, count, bytes)` helpers. One frame per counter pair, two frames per trace:

  | field             | meaning                                |
  |-------------------|----------------------------------------|
  | `Type`            | `MemoryPayloadFrame`                   |
  | `FunctionOffset`  | `MemoryPayloadKind` (0 = allocs, 1 = frees) |
  | `AddressOrLineno` | count                                  |
  | `SourceLine`      | bytes                                  |

  Either kind may be omitted if its counters are zero.
- The eBPF unwinder never produces this marker; producers and consumers live entirely in user-space. Reporters that don't care about memory-origin payload can treat these frames as a no-op interpreter kind.
