### PR TITLE
processmanager: fix go vet issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/zeebo/xxh3 v1.1.0
 	go.opentelemetry.io/collector/component v1.58.0
 	go.opentelemetry.io/collector/component/componenttest v0.152.1
+	go.opentelemetry.io/collector/confmap v1.58.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.152.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.152.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.152.1
@@ -39,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.opentelemetry.io/proto/otlp/profiles/v1development v0.3.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap/exp v0.3.0
 	golang.org/x/arch v0.27.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
@@ -88,7 +90,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/confmap v1.58.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.58.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.152.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.58.0 // indirect

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -47,20 +47,20 @@ func TestAssignLibcInfoMergesLibcInfo(t *testing.T) {
 	}
 
 	libcInfoWithTSD := libc.LibcInfo{
-		libc.TSDInfo{
+		TSDInfo: libc.TSDInfo{
 			Offset:     8,
 			Multiplier: 8,
 			Indirect:   0,
 		},
-		libc.DTVInfo{},
+		DTVInfo: libc.DTVInfo{},
 	}
 	pm.assignLibcInfo(pid, &libcInfoWithTSD)
 
 	assert.Equal(libcInfoWithTSD, interp.info)
 
 	libcInfoWithDTV := libc.LibcInfo{
-		libc.TSDInfo{},
-		libc.DTVInfo{
+		TSDInfo: libc.TSDInfo{},
+		DTVInfo: libc.DTVInfo{
 			Offset:     -8,
 			Multiplier: 16,
 		},


### PR DESCRIPTION
`go vet` reports the following issues:
```
processmanager/processinfo_test.go:49:21: go.opentelemetry.io/ebpf-profiler/libc.LibcInfo struct literal uses unkeyed fields
processmanager/processinfo_test.go:61:21: go.opentelemetry.io/ebpf-profiler/libc.LibcInfo struct literal uses unkeyed fields
```

Fix this issue by using the respective field name in the assignment.