### PR TITLE
[chore]lint: fix deprecation warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - godot
     - godox # complains about TODO etc
     - gomoddirectives
+    - gomodguard # deprecated since golangci-lint v2.12.0, replaced by gomodguard_v2
     - gosmopolitan
     - inamedparam
     - interfacebloat

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/zeebo/xxh3 v1.1.0
 	go.opentelemetry.io/collector/component v1.58.0
 	go.opentelemetry.io/collector/component/componenttest v0.152.1
+	go.opentelemetry.io/collector/confmap v1.58.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.152.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.152.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.152.1
@@ -39,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.opentelemetry.io/proto/otlp/profiles/v1development v0.3.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap/exp v0.3.0
 	golang.org/x/arch v0.27.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
@@ -88,7 +90,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/confmap v1.58.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.58.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.152.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.58.0 // indirect


### PR DESCRIPTION
Handle the following warning:
```
$ make lint
[..]
WARN The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2.
WARN Suggested new configuration:
linters:
  enable:
    - gomodguard_v2
```

To resolve this, disable `gomodguard`. `gomodguard_v2` is enabled by `linters.default: all`.