### PR TITLE
feat(dotnet): enable .NET unwinder on ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ eBPF.
 - No need for any reconfiguration, instrumentation or restarts of HLL
   interpreters and VMs: the agent supports unwinding each of the supported
   languages in the default configuration.
-- ARM64 support for all unwinders except .NET.
+- ARM64 support for all unwinders.
 - Support for native `inline frames`, which provide insights into compiler
   optimizations and offer a higher precision of function call chains.
 

--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -4,6 +4,7 @@
 package dotnet // import "go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
 
 import (
+	"debug/elf"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -179,6 +180,9 @@ type dotnetData struct {
 	// version contains the version
 	version uint32
 
+	// machine is the ELF machine type of the target process (e.g. elf.EM_X86_64, elf.EM_AARCH64)
+	machine elf.Machine
+
 	// dacTableAddr contains the ELF symbol 'g_dacTable' value
 	// https://github.com/dotnet/runtime/blob/v7.0.15/src/coreclr/debug/ee/dactable.cpp#L80-L81
 	dacTableAddr libpf.SymbolValue
@@ -291,7 +295,11 @@ func (d *dotnetData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address)
 		vms.RangeSection.HeapList = 0x28
 		vms.RangeSection.RangeList = 0x30
 		vms.RangeSection.SizeOf = 0x38
-		vms.Module.SimpleName = 0x108
+		if d.machine == elf.EM_AARCH64 {
+			vms.Module.SimpleName = 0x110
+		} else {
+			vms.Module.SimpleName = 0x108
+		}
 		fallthrough
 	case 10:
 		vms.CodeRangeMapRangeList.RangeListType = 0x120

--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -171,6 +171,7 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 
 	d := &dotnetData{
 		version:      version,
+		machine:      ef.Machine,
 		dacTableAddr: addr,
 		cdacDescAddr: cdac,
 	}

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -45,6 +45,12 @@ const (
 	// Maximum size of the LRU cache holding strings from #Strings heap per PE.
 	peInfoStringsCacheSize = 1024
 
+	// imageFileMachineDotnetX64 is an undocumented machine type seen in dotnet-internal x64 DLLs.
+	imageFileMachineDotnetX64 = 0xfd1d
+
+	// imageFileMachineDotnetARM64 is an undocumented machine type seen in dotnet-internal ARM64 DLLs.
+	imageFileMachineDotnetARM64 = 0xd11d
+
 	// TTL of entries in the LRU cache holding the .NET strings.
 	peInfoStringsCacheTTL = 1 * time.Hour
 )
@@ -193,11 +199,18 @@ type ReadyToRunSection struct {
 	Section pe.DataDirectory
 }
 
-// ReadyToRunRuntimeFunction is the R2RFMT RUNTIME_FUNCTION for x86_64
+// ReadyToRunRuntimeFunction is the R2RFMT RUNTIME_FUNCTION for x86_64 (12 bytes).
 type ReadyToRunRuntimeFunction struct {
 	StartRVA uint32
 	EndRVA   uint32
 	GCInfo   uint32
+}
+
+// ReadyToRunRuntimeFunctionARM64 is the R2RFMT RUNTIME_FUNCTION for ARM64 (8 bytes).
+// ARM64 omits the EndRVA field present in the x86_64 layout.
+type ReadyToRunRuntimeFunctionARM64 struct {
+	StartRVA   uint32
+	UnwindData uint32
 }
 
 // MetadataRoot is the ECMA-335 II.24.2.1 Metadata root (non-variable length header)
@@ -388,8 +401,10 @@ func (pp *peParser) parsePE() error {
 	// Ready to Run code has been generated.
 	switch pp.nt.Machine {
 	case pe.IMAGE_FILE_MACHINE_AMD64,
-		pe.IMAGE_FILE_MACHINE_I386, // According to ECMA spec always this
-		0xfd1d:                     // Seen on dotnet internal .dlls
+		pe.IMAGE_FILE_MACHINE_I386,  // According to ECMA spec always this
+		pe.IMAGE_FILE_MACHINE_ARM64, // R2R binaries on arm64
+		imageFileMachineDotnetX64,   // Seen on dotnet internal x64 .dlls
+		imageFileMachineDotnetARM64: // Seen on dotnet internal arm64 .dlls
 		// ok
 	default:
 		return fmt.Errorf("unrecognized PE machine: %#x", pp.nt.Machine)
@@ -515,6 +530,13 @@ func (pp *peParser) parseR2RMethodDefs(table pe.DataDirectory) error {
 	prevIndex := uint32(0)
 	prevRVA := uint32(0)
 
+	// ARM64 RUNTIME_FUNCTION is 8 bytes {StartRVA, UnwindData}; x86_64 is 12 bytes
+	// {StartRVA, EndRVA, GCInfo}. Use the correct stride so seeks land on the right entry.
+	stride := int64(binary.Size(ReadyToRunRuntimeFunction{}))
+	if pp.nt.Machine == pe.IMAGE_FILE_MACHINE_ARM64 || pp.nt.Machine == imageFileMachineDotnetARM64 {
+		stride = int64(binary.Size(ReadyToRunRuntimeFunctionARM64{}))
+	}
+
 	// The ready-to-run MethodDefs table is a lookup table indexed with MethodDef index,
 	// and the data contains R2R RuntimeFunction table index (among other things).
 	// The callback will get monotonic MethodDef index, and monotonic startRVA.
@@ -531,18 +553,17 @@ func (pp *peParser) parseR2RMethodDefs(table pe.DataDirectory) error {
 			id >>= 1
 		}
 		// id is index to the RuntimeFunctions table.
-		// Read the Function start address.
-		var f ReadyToRunRuntimeFunction
-		_, err = pp.r2rFunctions.Seek(int64(id*uint32(binary.Size(f))), io.SeekStart)
-		if err != nil {
+		// Read the Function start address (first field, shared by both struct layouts).
+		if _, err = pp.r2rFunctions.Seek(int64(id)*stride, io.SeekStart); err != nil {
 			return err
 		}
-		if err := binary.Read(pp.r2rFunctions, binary.LittleEndian, &f); err != nil {
+		var startRVA uint32
+		if err := binary.Read(pp.r2rFunctions, binary.LittleEndian, &startRVA); err != nil {
 			return err
 		}
 		// Shift by one, so that the methods without r2r implementation can
 		// be inserted in-between valid RVAs
-		startRVA := f.StartRVA << 1
+		startRVA <<= 1
 		if startRVA < prevRVA {
 			return fmt.Errorf("non-monotonic R2R code RVA: %x < %x",
 				startRVA, prevRVA)

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -199,19 +199,16 @@ type ReadyToRunSection struct {
 	Section pe.DataDirectory
 }
 
-// ReadyToRunRuntimeFunction is the R2RFMT RUNTIME_FUNCTION for x86_64 (12 bytes).
-type ReadyToRunRuntimeFunction struct {
-	StartRVA uint32
-	EndRVA   uint32
-	GCInfo   uint32
-}
-
-// ReadyToRunRuntimeFunctionARM64 is the R2RFMT RUNTIME_FUNCTION for ARM64 (8 bytes).
-// ARM64 omits the EndRVA field present in the x86_64 layout.
-type ReadyToRunRuntimeFunctionARM64 struct {
-	StartRVA   uint32
-	UnwindData uint32
-}
+// R2RFMT RUNTIME_FUNCTION on-disk record sizes for the RuntimeFunctions section.
+// Only the leading 4-byte StartRVA field is decoded; the remaining bytes are skipped
+// via the per-architecture stride.
+// See: https://github.com/dotnet/runtime/blob/v8.0.0/docs/design/coreclr/botr/readytorun-format.md#readytorunsectiontyperuntimefunctions
+const (
+	// x86_64 layout: {StartRVA, EndRVA, GCInfo} (3 x uint32).
+	r2rRuntimeFunctionSize = 12
+	// ARM64 layout: {StartRVA, UnwindData} (2 x uint32); EndRVA is omitted.
+	r2rRuntimeFunctionSizeARM64 = 8
+)
 
 // MetadataRoot is the ECMA-335 II.24.2.1 Metadata root (non-variable length header)
 type MetadataRoot struct {
@@ -530,11 +527,9 @@ func (pp *peParser) parseR2RMethodDefs(table pe.DataDirectory) error {
 	prevIndex := uint32(0)
 	prevRVA := uint32(0)
 
-	// ARM64 RUNTIME_FUNCTION is 8 bytes {StartRVA, UnwindData}; x86_64 is 12 bytes
-	// {StartRVA, EndRVA, GCInfo}. Use the correct stride so seeks land on the right entry.
-	stride := int64(binary.Size(ReadyToRunRuntimeFunction{}))
+	stride := int64(r2rRuntimeFunctionSize)
 	if pp.nt.Machine == pe.IMAGE_FILE_MACHINE_ARM64 || pp.nt.Machine == imageFileMachineDotnetARM64 {
-		stride = int64(binary.Size(ReadyToRunRuntimeFunctionARM64{}))
+		stride = int64(r2rRuntimeFunctionSizeARM64)
 	}
 
 	// The ready-to-run MethodDefs table is a lookup table indexed with MethodDef index,

--- a/tools/coredump/testdata/arm64/dotnet10-helloworld.json
+++ b/tools/coredump/testdata/arm64/dotnet10-helloworld.json
@@ -1,0 +1,218 @@
+{
+  "coredump-ref": "8422e8a609afd93a821bdcf0ebd398883fc5f030d261cecf9c565049a4e1afe7",
+  "threads": [
+    {
+      "lwp": 430615,
+      "frames": [
+        "libc.so.6+0xddc9c",
+        "libSystem.Native.so+0x1d49f",
+        "System.IO.StreamWriter.Flush+477 in System.Private.CoreLib.dll:0",
+        "System.IO.StreamWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.IO.TextWriter/SyncTextWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.Console.WriteLine+0 in System.Console.dll:0",
+        "foo.bar+0 in helloworld.dll:0",
+        "main.Main+0 in helloworld.dll:0",
+        "libcoreclr.so+0x5cca2f",
+        "libcoreclr.so+0x4471df",
+        "libcoreclr.so+0x33dc67",
+        "libcoreclr.so+0x33dfc3",
+        "libcoreclr.so+0x364023",
+        "libcoreclr.so+0x1e7ea3",
+        "libhostpolicy.so+0x3b90b",
+        "libhostpolicy.so+0x3cb9f",
+        "libhostfxr.so+0x3023b",
+        "libhostfxr.so+0x2f167",
+        "libhostfxr.so+0x2a1f7",
+        "helloworld+0x17523",
+        "helloworld+0x17837",
+        "libc.so.6+0x27743",
+        "libc.so.6+0x27817",
+        "helloworld+0x16523",
+        "<unwinding aborted due to error native_exceeded_delta_lookup_iterations>"
+      ]
+    },
+    {
+      "lwp": 430616,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x6044cb",
+        "libcoreclr.so+0x603e9f",
+        "libcoreclr.so+0x60e19f",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 430617,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x2969c7",
+        "libcoreclr.so+0x210353",
+        "libcoreclr.so+0x21494f",
+        "libcoreclr.so+0x60e19f",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 430618,
+      "frames": [
+        "libc.so.6+0xdd90c",
+        "libcoreclr.so+0x296373",
+        "libcoreclr.so+0x29197f",
+        "libcoreclr.so+0x29094f",
+        "libcoreclr.so+0x60e19f",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 430619,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81387",
+        "libcoreclr.so+0x60269b",
+        "libcoreclr.so+0x6023fb",
+        "libcoreclr.so+0x606f37",
+        "libcoreclr.so+0x28f0eb",
+        "libcoreclr.so+0x28ef4f",
+        "libcoreclr.so+0x28ecb7",
+        "libcoreclr.so+0x60e19f",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 430620,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81687",
+        "libcoreclr.so+0x602793",
+        "libcoreclr.so+0x6023fb",
+        "libcoreclr.so+0x606f37",
+        "libcoreclr.so+0x47c227",
+        "libcoreclr.so+0x47c31f",
+        "libcoreclr.so+0x415dcb",
+        "libcoreclr.so+0x47c823",
+        "libcoreclr.so+0x60e19f",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 430622,
+      "frames": [
+        "libc.so.6+0xddbc8",
+        "libSystem.Native.so+0x2415b",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "ee1700446a1c377924df1d2fc6e3f972ebc28c04c08036bda730733597faae60",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Memory.dll"
+    },
+    {
+      "ref": "59c5e5b4168f9ca4aa9801225a95b8ed0dc4f7381dee908e7df153b54a1f26fa",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/Microsoft.Win32.Primitives.dll"
+    },
+    {
+      "ref": "7796e0b797561d4e63693dcebf48b69342f96b22069486c83c850772ce8a9d45",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicuuc.so.72.1"
+    },
+    {
+      "ref": "fca9d1700db17a978028587d9b688492cb505e03b9a942b5d78f27c80e32cfd4",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/libcoreclr.so"
+    },
+    {
+      "ref": "3c4cb3be0b974edf05f023f85ab15107fb5afc2687163593d0d4cf8e80c17b39",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "532f3a12d7b8fef6cc7a064ea106b6c4ab2365674b73e743e4a385d4ffb6c8ab",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30"
+    },
+    {
+      "ref": "17538b8f9889a470c061f69a8fea8124da89627311cd16546c133a89f09056df",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "7c3c0f59a295af5dffd942700951c1323d7a6a9d291cf38ba009594799bb5957",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/libSystem.Native.so"
+    },
+    {
+      "ref": "046856f95f4636f1fc7c3a12bf4f3cd5634c2fc5145c3fdf7395d4f349fa69c7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "e5e9474a683596d59cc9e13246bc83878433e53c3befbabd73e3da9ccb5fe174",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libdl.so.2"
+    },
+    {
+      "ref": "7fd139eca9804e850044a7150fce73b8d0c384fe748cd57fe16b4a3b6aec75a2",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Collections.dll"
+    },
+    {
+      "ref": "927d5e75e440e56695636032c1cf972d121e3bb4f6f8a9712645d3a291cf40e6",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Runtime.InteropServices.dll"
+    },
+    {
+      "ref": "5a8607afbfbe6b42c4495789550f73456c2f62a763ac1550ff0b563d01ccd86b",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Threading.dll"
+    },
+    {
+      "ref": "93dfb2592947ab31ed5ad9c758dfcb429bbcbaa295379408932cb061736cfcfd",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Console.dll"
+    },
+    {
+      "ref": "5daf3fce37e9a0f26d5a2c721232b645c61897026e179b5833890b3ef179ae23",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Runtime.dll"
+    },
+    {
+      "ref": "77fafd9c1430cb90318d560769a64873894b80eaf4ab1a115dc4c18075f89689",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net10.0/helloworld"
+    },
+    {
+      "ref": "eaf2eb6008b89c0b36753ebf64f3043edbaa44f86a95cbb35192cca8ef9079d2",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/libclrjit.so"
+    },
+    {
+      "ref": "41d135537fba3875ebccccace6e4bb5e546941877376504b3921e663f83e42e7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/librt.so.1"
+    },
+    {
+      "ref": "483a341d463ebdb8e6a5666b3771f41739439af440dc081ff29f1b4af5f38256",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/libhostpolicy.so"
+    },
+    {
+      "ref": "51e5dd832373983aadcf0c3b12fcf03fe01f183d1c5dfe3b6187eb86bc33ed7f",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net10.0/helloworld.dll"
+    },
+    {
+      "ref": "d0619595f7b31f7ee5210a2a195f0367fc7251e80a0489ce6405c31f6efea23d",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicudata.so.72.1"
+    },
+    {
+      "ref": "8831af0ffb1a88a7ea751469acc39530e22d6dd5db96d3eebd8e0aeba54aa9bb",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicui18n.so.72.1"
+    },
+    {
+      "ref": "23a95d0965242c1f1af7b6797342bf31b250d1e731eb08bc8c06a14385effcf2",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/host/fxr/10.0.3/libhostfxr.so"
+    },
+    {
+      "ref": "e4ac8ae1d81e4865e3aadedb962879cf9415903b3f2ba81ec75e9962b86ab8b0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "434dcd27f22fc8bf236c0c00541a1e503d302aa796c333729a2cd15a4cfe4814",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpthread.so.0"
+    },
+    {
+      "ref": "c7f3f6d31d3b80158005163faca722017405ec4ccae2a7f4c2d9f74577a0993d",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/10.0.3/System.Private.CoreLib.dll"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/dotnet8-helloworld.json
+++ b/tools/coredump/testdata/arm64/dotnet8-helloworld.json
@@ -1,0 +1,221 @@
+{
+  "coredump-ref": "69eea6314f063cef438d97a09b2770a9a6d8dda72f8d4f936e4f6c613186e673",
+  "threads": [
+    {
+      "lwp": 460095,
+      "frames": [
+        "libc.so.6+0xddc9c",
+        "libSystem.Native.so+0x1cd3b",
+        "Interop/Sys.Write+0 in System.Console.dll:0",
+        "System.ConsolePal.Write+0 in System.Console.dll:0",
+        "System.IO.StreamWriter.Flush+0 in System.Private.CoreLib.dll:0",
+        "System.IO.StreamWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.IO.TextWriter/SyncTextWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.Console.WriteLine+0 in System.Console.dll:0",
+        "foo.bar+6 in helloworld.dll:0",
+        "main.Main+11 in helloworld.dll:0",
+        "libcoreclr.so+0x4873b3",
+        "libcoreclr.so+0x2e8bd7",
+        "libcoreclr.so+0x1dfe4b",
+        "libcoreclr.so+0x1e01a3",
+        "libcoreclr.so+0x209c0b",
+        "libcoreclr.so+0x1cabeb",
+        "libhostpolicy.so+0x3b8a7",
+        "libhostpolicy.so+0x3c873",
+        "libhostfxr.so+0x2d2bb",
+        "libhostfxr.so+0x2c59b",
+        "libhostfxr.so+0x28cbf",
+        "helloworld+0x1fb8b",
+        "helloworld+0x1fec3",
+        "libc.so.6+0x27743",
+        "libc.so.6+0x27817",
+        "helloworld+0x1654b",
+        "<unwinding aborted due to error native_exceeded_delta_lookup_iterations>"
+      ]
+    },
+    {
+      "lwp": 460096,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x5eddf3",
+        "libcoreclr.so+0x5ed4bb",
+        "libcoreclr.so+0x5f68e7",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 460097,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x4eafcf",
+        "libcoreclr.so+0x5a15bf",
+        "libcoreclr.so+0x59f357",
+        "libcoreclr.so+0x5f68e7",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 460098,
+      "frames": [
+        "libc.so.6+0xdd90c",
+        "libcoreclr.so+0x4ebb47",
+        "libcoreclr.so+0x4e662b",
+        "libcoreclr.so+0x4e56ab",
+        "libcoreclr.so+0x5f68e7",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 460099,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81387",
+        "libcoreclr.so+0x5eb77f",
+        "libcoreclr.so+0x5eb4a3",
+        "libcoreclr.so+0x5efd9b",
+        "libcoreclr.so+0x4e3dcf",
+        "libcoreclr.so+0x4e3c4f",
+        "libcoreclr.so+0x4e39bf",
+        "libcoreclr.so+0x5f68e7",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 460100,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81687",
+        "libcoreclr.so+0x5eb873",
+        "libcoreclr.so+0x5eb4a3",
+        "libcoreclr.so+0x5efd9b",
+        "libcoreclr.so+0x32013f",
+        "libcoreclr.so+0x3202e7",
+        "libcoreclr.so+0x2ba3db",
+        "libcoreclr.so+0x2ba8ff",
+        "libcoreclr.so+0x32057b",
+        "libcoreclr.so+0x5f68e7",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 460102,
+      "frames": [
+        "libc.so.6+0xddbc8",
+        "libSystem.Native.so+0x230fb",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "a4886325f95be03285eec9d8757e8efa14f4df9a5385b54f4b6556e4f3844fe1",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net8.0/helloworld"
+    },
+    {
+      "ref": "d0619595f7b31f7ee5210a2a195f0367fc7251e80a0489ce6405c31f6efea23d",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicudata.so.72.1"
+    },
+    {
+      "ref": "7796e0b797561d4e63693dcebf48b69342f96b22069486c83c850772ce8a9d45",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicuuc.so.72.1"
+    },
+    {
+      "ref": "41d135537fba3875ebccccace6e4bb5e546941877376504b3921e663f83e42e7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/librt.so.1"
+    },
+    {
+      "ref": "532f3a12d7b8fef6cc7a064ea106b6c4ab2365674b73e743e4a385d4ffb6c8ab",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30"
+    },
+    {
+      "ref": "e5e9474a683596d59cc9e13246bc83878433e53c3befbabd73e3da9ccb5fe174",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libdl.so.2"
+    },
+    {
+      "ref": "0a98b9d1bc9aaf604c45b16858deb3d81978492f61f993e70008f4479f56e32f",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/libclrjit.so"
+    },
+    {
+      "ref": "f966863590fca0a02e67ac3d98c59bdf61979044e91a599f9e91abacf061d5ef",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/libcoreclr.so"
+    },
+    {
+      "ref": "117575029d1727e63c5c63ab3754c2409a9d6dfd30cc7aad78cf5f97cf1e605e",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/host/fxr/8.0.27/libhostfxr.so"
+    },
+    {
+      "ref": "e4ac8ae1d81e4865e3aadedb962879cf9415903b3f2ba81ec75e9962b86ab8b0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "3c4cb3be0b974edf05f023f85ab15107fb5afc2687163593d0d4cf8e80c17b39",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "434dcd27f22fc8bf236c0c00541a1e503d302aa796c333729a2cd15a4cfe4814",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpthread.so.0"
+    },
+    {
+      "ref": "1cce6242c4831e654d7597cb6b5772ed3ac158fec3a21c8d506e3a2ff2ebbdfa",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Runtime.InteropServices.dll"
+    },
+    {
+      "ref": "ccac1dfe98b1ce531e7fcb7b7f90b27f87f210996deb8aad8cc9e564422b2853",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Console.dll"
+    },
+    {
+      "ref": "8831af0ffb1a88a7ea751469acc39530e22d6dd5db96d3eebd8e0aeba54aa9bb",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicui18n.so.72.1"
+    },
+    {
+      "ref": "b5ecef7dfd449403740edda29c8567246bb4ab69aa0ec48e4558b3f9e7a543e4",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/libSystem.Native.so"
+    },
+    {
+      "ref": "5fdd3938fba6b2359426b7e6cb455d957caee1ade816e5434497d664c99beccf",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/libhostpolicy.so"
+    },
+    {
+      "ref": "046856f95f4636f1fc7c3a12bf4f3cd5634c2fc5145c3fdf7395d4f349fa69c7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "c3497cd34f4df60301af3891c0a0f53d3e44d4e910f05520476514e052ca4c04",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Memory.dll"
+    },
+    {
+      "ref": "d5d76f8c404f2e84a4dd198483ad2e08b3fc4eca1640a8a5f6731626bd73a163",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Collections.dll"
+    },
+    {
+      "ref": "60de1ffdb5dde2ec507a50ae42796c75adfb3fed73fd79b2b02191a96f8ab874",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Threading.dll"
+    },
+    {
+      "ref": "06f5683218a2798c97a228b828228ba9b0b93bbdd110fa121ddfd4f57f1c7d00",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net8.0/helloworld.dll"
+    },
+    {
+      "ref": "17538b8f9889a470c061f69a8fea8124da89627311cd16546c133a89f09056df",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "1694922f9ebadd6d1f7c42a239b9ea7227bfefe32312d64e664924475ac332b3",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Private.CoreLib.dll"
+    },
+    {
+      "ref": "335291e1cf99a76ece6de3d3b1d8d0d719a450dc4ceb7c351cdcddc4e46f7b30",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/System.Runtime.dll"
+    },
+    {
+      "ref": "0e34293a3099026ef35a4109b1ed7c372cd30ffb88e62920a6d1e2bacc77af49",
+      "local-path": "/home/parallels/.local/share/mise/installs/dotnet/8.0.421/shared/Microsoft.NETCore.App/8.0.27/Microsoft.Win32.Primitives.dll"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/dotnet9-helloworld.json
+++ b/tools/coredump/testdata/arm64/dotnet9-helloworld.json
@@ -1,0 +1,222 @@
+{
+  "coredump-ref": "2e5fe1742d9e3ee2b172502749fab01a9c53bc7c6b5ed647369f5a4a8279a735",
+  "threads": [
+    {
+      "lwp": 439793,
+      "frames": [
+        "libc.so.6+0xddc9c",
+        "libSystem.Native.so+0x1d153",
+        "Interop/Sys.Write+0 in System.Console.dll:0",
+        "System.ConsolePal.Write+0 in System.Console.dll:0",
+        "System.ConsolePal.WriteFromConsoleStream+0 in System.Console.dll:0",
+        "System.IO.StreamWriter.Flush+0 in System.Private.CoreLib.dll:0",
+        "System.IO.StreamWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.IO.TextWriter/SyncTextWriter.WriteLine+0 in System.Private.CoreLib.dll:0",
+        "System.Console.WriteLine+0 in System.Console.dll:0",
+        "foo.bar+6 in helloworld.dll:0",
+        "main.Main+11 in helloworld.dll:0",
+        "libcoreclr.so+0x4ab93f",
+        "libcoreclr.so+0x310bcb",
+        "libcoreclr.so+0x2073b3",
+        "libcoreclr.so+0x207723",
+        "libcoreclr.so+0x22dfab",
+        "libcoreclr.so+0x1f41d7",
+        "libhostpolicy.so+0x3ae9b",
+        "libhostpolicy.so+0x3be6f",
+        "libhostfxr.so+0x3023b",
+        "libhostfxr.so+0x2f167",
+        "libhostfxr.so+0x2a1f7",
+        "helloworld+0x174e7",
+        "helloworld+0x1781f",
+        "libc.so.6+0x27743",
+        "libc.so.6+0x27817",
+        "helloworld+0x1673b",
+        "<unwinding aborted due to error native_exceeded_delta_lookup_iterations>"
+      ]
+    },
+    {
+      "lwp": 439794,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x633ca7",
+        "libcoreclr.so+0x633363",
+        "libcoreclr.so+0x63cccf",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 439795,
+      "frames": [
+        "libc.so.6+0xe1c3c",
+        "libcoreclr.so+0x556e97",
+        "libcoreclr.so+0x4d345f",
+        "libcoreclr.so+0x4d787b",
+        "libcoreclr.so+0x63cccf",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 439796,
+      "frames": [
+        "libc.so.6+0xdd90c",
+        "libcoreclr.so+0x556833",
+        "libcoreclr.so+0x5521ff",
+        "libcoreclr.so+0x5512f3",
+        "libcoreclr.so+0x63cccf",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 439797,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81387",
+        "libcoreclr.so+0x6316e7",
+        "libcoreclr.so+0x63143b",
+        "libcoreclr.so+0x635bd3",
+        "libcoreclr.so+0x54faab",
+        "libcoreclr.so+0x54f91b",
+        "libcoreclr.so+0x54f687",
+        "libcoreclr.so+0x63cccf",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 439798,
+      "frames": [
+        "libc.so.6+0x7e834",
+        "libc.so.6+0x81687",
+        "libcoreclr.so+0x6317e3",
+        "libcoreclr.so+0x63143b",
+        "libcoreclr.so+0x635bd3",
+        "libcoreclr.so+0x3483cb",
+        "libcoreclr.so+0x348567",
+        "libcoreclr.so+0x2e1443",
+        "libcoreclr.so+0x2e18b7",
+        "libcoreclr.so+0x348753",
+        "libcoreclr.so+0x63cccf",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    },
+    {
+      "lwp": 439800,
+      "frames": [
+        "libc.so.6+0xddbc8",
+        "libSystem.Native.so+0x23ffb",
+        "libc.so.6+0x8202f",
+        "libc.so.6+0xebf5b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "d0619595f7b31f7ee5210a2a195f0367fc7251e80a0489ce6405c31f6efea23d",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicudata.so.72.1"
+    },
+    {
+      "ref": "d3020df367e59309ced3dbdd6abcb9a4cab51629778962913e07df884282029b",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/libSystem.Native.so"
+    },
+    {
+      "ref": "41d135537fba3875ebccccace6e4bb5e546941877376504b3921e663f83e42e7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/librt.so.1"
+    },
+    {
+      "ref": "046856f95f4636f1fc7c3a12bf4f3cd5634c2fc5145c3fdf7395d4f349fa69c7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "3c4cb3be0b974edf05f023f85ab15107fb5afc2687163593d0d4cf8e80c17b39",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "7c2fd17a3c1f1e4647cf4b536ee7441c7557b9fcdf4abe207e150de2a65431e6",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Threading.dll"
+    },
+    {
+      "ref": "0b5a3e5b8da1becc7eb480bcd8fc0836a35554f47704f3a24369a3e38a285721",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net9.0/helloworld"
+    },
+    {
+      "ref": "7796e0b797561d4e63693dcebf48b69342f96b22069486c83c850772ce8a9d45",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicuuc.so.72.1"
+    },
+    {
+      "ref": "23a95d0965242c1f1af7b6797342bf31b250d1e731eb08bc8c06a14385effcf2",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/host/fxr/10.0.3/libhostfxr.so"
+    },
+    {
+      "ref": "434dcd27f22fc8bf236c0c00541a1e503d302aa796c333729a2cd15a4cfe4814",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpthread.so.0"
+    },
+    {
+      "ref": "e5e9474a683596d59cc9e13246bc83878433e53c3befbabd73e3da9ccb5fe174",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libdl.so.2"
+    },
+    {
+      "ref": "17538b8f9889a470c061f69a8fea8124da89627311cd16546c133a89f09056df",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "bad3002bd1069776cc1df30482836ee813980eff2ad8e7f5620d9d5ee7b6da9c",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Private.CoreLib.dll"
+    },
+    {
+      "ref": "45748cd8737a6c0838571ba442f79b045ce32ed7a4d445b5df20e7f2a8cfbbbb",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Collections.dll"
+    },
+    {
+      "ref": "992134b82a6f91869ff71e77d75b05fa2050961105744a18ec89ec21faa93f30",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/libcoreclr.so"
+    },
+    {
+      "ref": "15d25b5fe6290cc4f04dab0687d9c87710b8f2b507ff5f0cf3122cd4cc95d8c2",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/libhostpolicy.so"
+    },
+    {
+      "ref": "532f3a12d7b8fef6cc7a064ea106b6c4ab2365674b73e743e4a385d4ffb6c8ab",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30"
+    },
+    {
+      "ref": "29a72311753812df78dd3e5bead4c5f263e79cffe18dd00c2a65fb06d6019672",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Runtime.InteropServices.dll"
+    },
+    {
+      "ref": "9db2f7dd854e23264a01db7c5e0c4c40644006376c8bf3a28fb2bbf328a00d17",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Console.dll"
+    },
+    {
+      "ref": "3bd1c90df8197ba5ba453ab8cb16ca3cab602604e3553714bae2dd0cd4e408c6",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Runtime.dll"
+    },
+    {
+      "ref": "4946c355c68d33a8e8f548488533d98a71b5c85cacf0c26ccb89b48081ef5652",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/Microsoft.Win32.Primitives.dll"
+    },
+    {
+      "ref": "974241d7c9d789960f8ba1f6cc17321e84ea710319107e10864d23a7ffec4038",
+      "local-path": "/home/parallels/go/src/github.com/danielpacak/opentelemetry-ebpf-profiler/tools/coredump/testsources/dotnet/helloworld/bin/Debug/net9.0/helloworld.dll"
+    },
+    {
+      "ref": "8831af0ffb1a88a7ea751469acc39530e22d6dd5db96d3eebd8e0aeba54aa9bb",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libicui18n.so.72.1"
+    },
+    {
+      "ref": "1b1735eebe22c10be6096b980b0fddbff70beab9b30e4bc06fb11108ee388137",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/libclrjit.so"
+    },
+    {
+      "ref": "e4ac8ae1d81e4865e3aadedb962879cf9415903b3f2ba81ec75e9962b86ab8b0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "bbec0dfaa674384b39636c99ea7c5239af9418bd0744edcc17ab01ec636f406a",
+      "local-path": "/home/parallels/.local/share/mise/dotnet-root/shared/Microsoft.NETCore.App/9.0.13/System.Memory.dll"
+    }
+  ]
+}

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -5,7 +5,6 @@ package types // import "go.opentelemetry.io/ebpf-profiler/tracer/types"
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
@@ -167,13 +166,6 @@ func Parse(tracers string) (IncludedTracers, error) {
 			log.Warn("Enabling the `native` tracer explicitly is deprecated (it's always-on)")
 		default:
 			return result, fmt.Errorf("unknown tracer: %s", name)
-		}
-	}
-
-	if runtime.GOARCH == "arm64" {
-		if result.Has(DotnetTracer) {
-			result.Disable(DotnetTracer)
-			log.Warn("The dotnet tracer is currently not supported on ARM64")
 		}
 	}
 

--- a/tracer/types/parse_test.go
+++ b/tracer/types/parse_test.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -44,18 +43,14 @@ func TestParseTracers(t *testing.T) {
 
 			if tt.expectedTracers == nil {
 				for tracer := range maxTracers {
-					if availableOnArch(tracer) {
-						require.True(t, include.Has(tracer))
-					} else {
-						require.False(t, include.Has(tracer))
-					}
+					require.True(t, include.Has(tracer))
 				}
 				return
 			}
 
 			expected := strings.Split(in, ",")
 			for tracer := range maxTracers {
-				if slices.Contains(expected, tracer.String()) && availableOnArch(tracer) {
+				if slices.Contains(expected, tracer.String()) {
 					require.True(t, include.Has(tracer))
 				} else {
 					require.False(t, include.Has(tracer))
@@ -70,16 +65,5 @@ func TestParseTracers(t *testing.T) {
 			_, err := Parse(in)
 			require.Error(t, err)
 		})
-	}
-}
-
-func availableOnArch(tracer tracerType) bool {
-	switch runtime.GOARCH {
-	case "amd64":
-		return true
-	case "arm64":
-		return tracer != DotnetTracer
-	default:
-		panic("unsupported architecture")
 	}
 }


### PR DESCRIPTION
The dotnet unwinder was unconditionally disabled on ARM64 due to three
bugs that this commit fixes:

1. PE machine type allowlist (interpreter/dotnet/pe.go): parsePE()
   rejected ARM64 PE files with "unrecognized PE machine" because
   IMAGE_FILE_MACHINE_ARM64 (0xaa64) and the dotnet-internal ARM64
   marker (0xd11d) were missing from the switch. Adds both, and
   promotes the previously inline 0xfd1d x64 marker to a named
   constant.

2. Wrong RUNTIME_FUNCTION stride (interpreter/dotnet/pe.go): the
   R2RFMT RUNTIME_FUNCTION struct is 12 bytes on x86_64
   {StartRVA, EndRVA, GCInfo} but only 8 bytes on ARM64
   {StartRVA, UnwindData}. parseR2RMethodDefs() used the 12-byte
   struct unconditionally, making every seek land 50% too far into
   the RuntimeFunctions table on ARM64 and producing the
   "non-monotonic R2R code RVA" errors. The fix detects ARM64 PEs
   and uses a stride of 8 instead of 12, reading only the shared
   StartRVA first field.

3. Wrong Module.SimpleName VM offset (interpreter/dotnet/data.go,
   interpreter/dotnet/dotnet.go): on .NET 9 the Module.SimpleName
   field sits at 0x108 on x86_64 but at 0x110 on ARM64. The loader
   now records the target process's ELF machine type on dotnetData
   and newVMData() picks the correct offset accordingly.

4. Adds ARM64 test fixtures for .NET 8/9/10 helloworld traces.

Resolves: #1126