### PR TITLE
process: split openInRoot and checkInodeDeviceMapping by build tag

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -468,44 +468,6 @@ func (sp *systemProcess) extractMapping(m *RawMapping) (*bytes.Reader, error) {
 	return bytes.NewReader(data), nil
 }
 
-// openInRoot securely opens a file within a given root directory using openat2
-// with RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS to prevent symlink escapes from
-// containers. It opens with O_PATH first (never blocks on FIFOs or sockets),
-// verifies the target is a non-empty regular file, then reopens for reading.
-func openInRoot(rootPath, filePath string) (*os.File, error) {
-	rootDir, err := unix.Open(rootPath, unix.O_PATH|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", rootPath, err)
-	}
-	defer unix.Close(rootDir)
-
-	fd, err := unix.Openat2(rootDir, filePath, &unix.OpenHow{
-		Flags:   unix.O_PATH | unix.O_CLOEXEC,
-		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("openat2 %s in %s: %w", filePath, rootPath, err)
-	}
-	defer unix.Close(fd)
-
-	var stat unix.Stat_t
-	if err := unix.Fstat(fd, &stat); err != nil {
-		return nil, fmt.Errorf("fstat %s: %w", filePath, err)
-	}
-	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
-		return nil, fmt.Errorf("%s: not a regular file", filePath)
-	}
-	if stat.Size == 0 {
-		return nil, fmt.Errorf("%s: empty file", filePath)
-	}
-
-	f, err := os.Open(fmt.Sprintf("/proc/self/fd/%d", fd))
-	if err != nil {
-		return nil, fmt.Errorf("reopen %s: %w", filePath, err)
-	}
-	return f, nil
-}
-
 // openInProcRoot opens a file within a process's filesystem namespace.
 func openInProcRoot(pid libpf.PID, filePath string) (*os.File, error) {
 	return openInRoot(fmt.Sprintf("/proc/%d/root", pid), filePath)
@@ -527,15 +489,9 @@ func (sp *systemProcess) getMappingFile(m *RawMapping) (*os.File, error) {
 			return nil, err
 		}
 		// Verify inode and device match the mapping to detect file substitution.
-		var stat unix.Stat_t
-		if err := unix.Fstat(int(f.Fd()), &stat); err != nil {
+		if err = checkInodeDeviceMapping(f, m); err != nil {
 			_ = f.Close()
-			return nil, fmt.Errorf("fstat %s: %w", m.Path, err)
-		}
-		if stat.Ino != m.Inode || stat.Dev != m.Device {
-			_ = f.Close()
-			return nil, fmt.Errorf("inode/device mismatch for %s: got %d/%d, expected %d/%d",
-				m.Path, stat.Dev, stat.Ino, m.Device, m.Inode)
+			return nil, err
 		}
 		return f, nil
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package process // import "go.opentelemetry.io/ebpf-profiler/process"
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openInRoot securely opens a file within a given root directory using openat2
+// with RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS to prevent symlink escapes from
+// containers. It opens with O_PATH first (never blocks on FIFOs or sockets),
+// verifies the target is a non-empty regular file, then reopens for reading.
+func openInRoot(rootPath, filePath string) (*os.File, error) {
+	rootDir, err := unix.Open(rootPath, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", rootPath, err)
+	}
+	defer unix.Close(rootDir)
+
+	fd, err := unix.Openat2(rootDir, filePath, &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("openat2 %s in %s: %w", filePath, rootPath, err)
+	}
+	defer unix.Close(fd)
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return nil, fmt.Errorf("fstat %s: %w", filePath, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return nil, fmt.Errorf("%s: not a regular file", filePath)
+	}
+	if stat.Size == 0 {
+		return nil, fmt.Errorf("%s: empty file", filePath)
+	}
+
+	f, err := os.Open(fmt.Sprintf("/proc/self/fd/%d", fd))
+	if err != nil {
+		return nil, fmt.Errorf("reopen %s: %w", filePath, err)
+	}
+	return f, nil
+}
+
+// checkInodeDeviceMapping verifies that the open file f corresponds to the
+// mapping m by comparing inode and device numbers.
+func checkInodeDeviceMapping(f *os.File, m *RawMapping) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(f.Fd()), &stat); err != nil {
+		return fmt.Errorf("fstat %s: %w", m.Path, err)
+	}
+	if stat.Ino != m.Inode || stat.Dev != m.Device {
+		return fmt.Errorf("inode/device mismatch for %s: got %d/%d, expected %d/%d",
+			m.Path, stat.Dev, stat.Ino, m.Device, m.Inode)
+	}
+	return nil
+}

--- a/process/process_other.go
+++ b/process/process_other.go
@@ -1,0 +1,57 @@
+//go:build !linux
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package process // import "go.opentelemetry.io/ebpf-profiler/process"
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openInRoot opens filePath relative to rootPath. On non-Linux platforms
+// RESOLVE_IN_ROOT is unavailable, so this uses openat(2) with O_NOFOLLOW
+// to at least prevent following symlinks on the final path component.
+func openInRoot(rootPath, filePath string) (*os.File, error) {
+	rootDir, err := unix.Open(rootPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", rootPath, err)
+	}
+	defer unix.Close(rootDir)
+
+	fd, err := unix.Openat(rootDir, filePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("openat %s in %s: %w", filePath, rootPath, err)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("fstat %s: %w", filePath, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		unix.Close(fd)
+		return nil, fmt.Errorf("%s: not a regular file", filePath)
+	}
+	if stat.Size == 0 {
+		unix.Close(fd)
+		return nil, fmt.Errorf("%s: empty file", filePath)
+	}
+
+	return os.NewFile(uintptr(fd), filePath), nil
+}
+
+func checkInodeDeviceMapping(f *os.File, m *RawMapping) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(f.Fd()), &stat); err != nil {
+		return fmt.Errorf("fstat %s: %w", m.Path, err)
+	}
+	if stat.Ino != m.Inode || uint64(stat.Dev) != m.Device {
+		return fmt.Errorf("inode/device mismatch for %s: got %d/%d, expected %d/%d",
+			m.Path, stat.Dev, stat.Ino, m.Device, m.Inode)
+	}
+	return nil
+}


### PR DESCRIPTION
Move openInRoot and the inode/device verification helper into platform-specific files so coredump tests build and run on Darwin/ARM64:

Regression introduced by 234b685c.