### PR TITLE
dotnet: replace panic with error handling

### DIFF
--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -103,6 +103,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"sync"
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 
@@ -134,6 +135,10 @@ func dotnetVer(x, y, z uint32) uint32 {
 	return (x << 24) + (y << 16) + z
 }
 
+var dotnetGlobalInit = sync.OnceValue(func() error {
+	return globalPeCache.init()
+})
+
 func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpreter.Data, error) {
 	// The dotnet DSOs are in a directory with the version such as:
 	// /usr/lib/dotnet/shared/Microsoft.NETCore.App/6.0.25/libcoreclr.so
@@ -161,6 +166,10 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 
 	addr, err := ef.LookupSymbolAddress("g_dacTable")
 	if err != nil {
+		return nil, err
+	}
+
+	if err := dotnetGlobalInit(); err != nil {
 		return nil, err
 	}
 

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -68,6 +68,8 @@ const (
 // negligible at any plausible cache population.
 type peHash [16]byte
 
+var globalPeCache peCache
+
 // peHashFromHeader computes the cache key for a dotnet PE file from its
 // first up-to-4 KiB.
 func peHashFromHeader(hdr []byte) peHash {
@@ -1311,10 +1313,10 @@ type peCache struct {
 	peInfoErrCache *freelru.LRU[util.OnDiskFileIdentifier, peErrEntry]
 }
 
-func (pc *peCache) init() {
+func (pc *peCache) init() error {
 	peInfoCache, err := freelru.New[peHash, *peInfo](peInfoCacheSize, peHash.Hash32)
 	if err != nil {
-		panic(fmt.Errorf("unable to create peInfoCache: %v", err))
+		return fmt.Errorf("unable to create peInfoCache: %v", err)
 	}
 	peInfoCache.SetLifetime(peInfoCacheTTL)
 	pc.peInfoCache = peInfoCache
@@ -1322,10 +1324,11 @@ func (pc *peCache) init() {
 	peInfoErrCache, err := freelru.New[util.OnDiskFileIdentifier, peErrEntry](
 		peInfoErrCacheSize, util.OnDiskFileIdentifier.Hash32)
 	if err != nil {
-		panic(fmt.Errorf("unable to create peInfoErrCache: %v", err))
+		return fmt.Errorf("unable to create peInfoErrCache: %v", err)
 	}
 	peInfoErrCache.SetLifetime(peInfoCacheTTL)
 	pc.peInfoErrCache = peInfoErrCache
+	return nil
 }
 
 func (pc *peCache) Get(pr process.Process, mapping *process.RawMapping) *peInfo {
@@ -1384,12 +1387,6 @@ func (pc *peCache) Get(pr process.Process, mapping *process.RawMapping) *peInfo 
 	info.mapping = libpf.NewFrameMapping(libpf.FrameMappingData{File: mf})
 	pc.peInfoCache.Add(key, info)
 	return info
-}
-
-var globalPeCache peCache
-
-func init() {
-	globalPeCache.init()
 }
 
 // GetAndResetMetrics returns the current counters of the global PE info cache


### PR DESCRIPTION
Replace the init() function with sync.OnceValue and also the panic with proper error handling.

The globalPeCache is now initialized at the first time a donet executable matches. So for environments without dotnet applications, this reduces the (unused) memory overhead, while still being able to handle dotnet once it is detected.

FYI: @danielpacak 