### PR TITLE
symblib: add null pointer check

### DIFF
--- a/rust-crates/symblib-capi/c/symblib.h
+++ b/rust-crates/symblib-capi/c/symblib.h
@@ -22,6 +22,8 @@ typedef enum SymblibStatus {
     SYMBLIB_ERR_RETPAD = 6,
     SYMBLIB_ERR_BADUTF8 = 7,
     SYMBLIB_ERR_ALREADYCLOSED = 8,
+    SYMBLIB_ERR_POINTRESOLVER = 9,
+    SYMBLIB_ERR_NULLARG = 10,
 } SymblibStatus;
 
 // Opaque handle to a return pad extractor.

--- a/rust-crates/symblib-capi/src/rangeextr.rs
+++ b/rust-crates/symblib-capi/src/rangeextr.rs
@@ -41,7 +41,9 @@ unsafe fn rangeextr_impl(
     visitor: SymblibRangeVisitor,
     user_data: *mut c_void,
 ) -> FfiResult {
-    assert!(!executable.is_null());
+    if executable.is_null() {
+        return Err(StatusCode::NullArg);
+    }
 
     let executable = Path::new(unsafe { CStr::from_ptr(executable).to_str()? });
 

--- a/rust-crates/symblib-capi/src/retpadextr.rs
+++ b/rust-crates/symblib-capi/src/retpadextr.rs
@@ -37,7 +37,9 @@ unsafe fn retpadextr_new_impl(
     executable: *const c_char,
     extr: *mut *mut SymblibRetPadExtractor, // out arg
 ) -> FfiResult {
-    assert!(!executable.is_null());
+    if executable.is_null() {
+        return Err(StatusCode::NullArg);
+    }
     let executable = CStr::from_ptr(executable)
         .to_str()
         .map(Path::new)
@@ -121,7 +123,9 @@ unsafe fn retpadextr_submit_impl(
     visitor: RetPadVisitor,
     user_data: *mut c_void,
 ) -> FfiResult {
-    assert!(!extr.is_null());
+    if extr.is_null() {
+        return Err(StatusCode::NullArg);
+    }
     let extr: &mut SymblibRetPadExtractor = &mut *extr;
 
     // Wrap visitor to make it rustier.

--- a/rust-crates/symblib-capi/src/status.rs
+++ b/rust-crates/symblib-capi/src/status.rs
@@ -45,6 +45,9 @@ pub enum StatusCode {
 
     #[error("Point resolver error")]
     PointResolver = 9,
+
+    #[error("NULL pointer passed for a required argument")]
+    NullArg = 10,
 }
 
 impl From<StatusCode> for FfiResult {


### PR DESCRIPTION
Avoid undefined behavior/segfaults if a null pointer/invalid argument is passed as argument from the C caller/wrapper, by returning a proper error.