### PR TITLE
libpf: reorder fields in struct to reduce struct pointer bytes

### DIFF
--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -30,4 +30,4 @@ type SourceLineno uint64
 type SourceColumn uint64
 
 // Origin determines the source of a trace.
-type Origin int
+type Origin uint16

--- a/libpf/libpf_test.go
+++ b/libpf/libpf_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestTraceType(t *testing.T) {
 	tests := []struct {
+		str    string
+		interp InterpreterType
 		ty     FrameType
 		isErr  bool
-		interp InterpreterType
-		str    string
 	}{
 		{
 			ty:     abortFrame,

--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -69,23 +69,23 @@ func (fmf FrameMapping) Value() FrameMappingData {
 
 // Frame represents one frame in a stack trace.
 type Frame struct {
-	// Type is the frame type.
-	Type FrameType
-	// FunctionOffset is the line offset from function start line for the frame.
-	FunctionOffset uint32
 	// FunctionName is the name of the function for the frame.
 	FunctionName String
 	// SourceFile is the source code file name for the frame.
 	SourceFile String
+	// Mapping is a reference to the mapping data to which this Frame corresponds to.
+	// Available only for frames executing on a file backed memory mapping.
+	Mapping FrameMapping
 	// SourceLine is the source code level line number of this frame.
 	SourceLine SourceLineno
 	// SourceColumn is the source code level column number of this frame.
 	SourceColumn SourceColumn
 	// An address in ELF VA space (native frame) or line number (interpreted frame).
 	AddressOrLineno AddressOrLineno
-	// Mapping is a reference to the mapping data to which this Frame corresponds to.
-	// Available only for frames executing on a file backed memory mapping.
-	Mapping FrameMapping
+	// FunctionOffset is the line offset from function start line for the frame.
+	FunctionOffset uint32
+	// Type is the frame type.
+	Type FrameType
 }
 
 // Frames is a list of interned frames.
@@ -98,31 +98,31 @@ func (frames *Frames) Append(frame *Frame) {
 
 // Trace represents a stack trace.
 type Trace struct {
+	CustomLabels map[String]String
 	Frames       Frames
 	Hash         TraceHash
-	CustomLabels map[String]String
 }
 
 // EbpfTrace represents a stack trace from Ebpf code.
 type EbpfTrace struct {
-	Comm             String
+	EnvVars          map[String]String
 	ProcessName      String
 	ExecutablePath   String
 	ContainerID      String
-	KTime            int64
-	PID              PID
-	TID              PID
-	Origin           Origin
+	CustomLabels     map[String]String
+	Comm             String
+	FrameData        []uint64
+	KernelFrames     Frames
+	FrameDataBuf     [3072]uint64
 	Value            int64
+	KTime            int64
+	CpuID            uint32
+	TID              PID
+	PID              PID
+	NumFrames        uint16
+	Origin           Origin
 	APMTraceID       APMTraceID
 	APMTransactionID APMTransactionID
-	CpuID            int
-	NumFrames        int
-	EnvVars          map[String]String
-	CustomLabels     map[String]String
-	KernelFrames     Frames
-	FrameData        []uint64
-	FrameDataBuf     [3072]uint64
 }
 
 type EbpfFrame []uint64

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -333,7 +333,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	pid := bpfTrace.PID
 	kernelFramesLen := len(bpfTrace.KernelFrames)
 	trace := &libpf.Trace{
-		Frames:       make(libpf.Frames, kernelFramesLen, kernelFramesLen+bpfTrace.NumFrames),
+		Frames:       make(libpf.Frames, kernelFramesLen, kernelFramesLen+int(bpfTrace.NumFrames)),
 		CustomLabels: bpfTrace.CustomLabels,
 	}
 	copy(trace.Frames, bpfTrace.KernelFrames)

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -15,7 +15,7 @@ type TraceEventMeta struct {
 	EnvVars        map[libpf.String]libpf.String
 	APMServiceName string
 	Timestamp      libpf.UnixTime64
-	CPU            int
+	CPU            uint32
 	Origin         libpf.Origin
 	Value          int64
 	PID, TID       libpf.PID

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1042,7 +1042,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 		Origin:           libpf.Origin(ptr.Origin),
 		Value:            int64(ptr.Value),
 		KTime:            int64(ptr.Ktime),
-		CpuID:            int(ptr.Cpu_id),
+		CpuID:            ptr.Cpu_id,
 		EnvVars:          procMeta.EnvVariables,
 	}
 
@@ -1064,7 +1064,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 		}
 	}
 
-	trace.NumFrames = int(ptr.Num_frames)
+	trace.NumFrames = ptr.Num_frames
 
 	// Symbolize kernel frames directly from the raw BPF data before copying
 	// userspace frame data, so we only copy what's needed.


### PR DESCRIPTION
As `libpf.Frame` and `libpf.EbpfTrace` constantly allocated and freeed, reorder their fields to reduce their struct size.
Also align field types, like CPU ID and NumFrames, with the field type of the eBPF side to avoid type casting and further reduce the struct sizes.

[fieldalignment](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment) was used to identify and reorder these fieds.