### PR TITLE
test: fail fast in pfelf test helper

### DIFF
--- a/libpf/pfelf/file_test.go
+++ b/libpf/pfelf/file_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 func getPFELF(path string, t *testing.T) *File {
+	t.Helper()
 	file, err := Open(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return file
 }
 


### PR DESCRIPTION
Tiny test-only fix.

`getPFELF()` used `assert.NoError`, but still returned a nil `*File`.
If the local fixtures are missing, `go test ./libpf/pfelf` can panic in `TestPFELFIsGolang` instead of just failing on the real open error. Kinda noisy, not great.

Repro:
1. `make -C libpf/pfelf/testdata clean`
2. `go test ./libpf/pfelf`
3. before this patch, `TestPFELFIsGolang` can blow up with a nil deref
4. with this patch, the package fails cleanly with `open testdata/...: no such file or directory`, no panic

Checked:
- `make -C libpf/pfelf/testdata && go test ./libpf/pfelf`
- reproduced the old panic in a clean worktree from current `main`, then re-ran with this patch. looks good.
