### PR TITLE
Extract cgroup path and attach it to ProcessMeta

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -108,6 +108,7 @@ type EbpfTrace struct {
 	Comm             String
 	ProcessName      String
 	ExecutablePath   String
+	CgroupPath       String
 	ContainerID      String
 	KTime            int64
 	PID              PID

--- a/process/process.go
+++ b/process/process.go
@@ -130,20 +130,37 @@ func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {
 		}
 	}
 
-	containerID, err := extractContainerID(sp.pid)
+	cgroupPath, err := extractCgroupPath(sp.pid)
 	if err != nil {
+		log.Debugf("Failed extracting cgroup path for %d: %v", sp.pid, err)
+	}
+
+	containerID := extractContainerID(cgroupPath.String())
+	if containerID == libpf.NullString {
 		log.Debugf("Failed extracting containerID for %d: %v", sp.pid, err)
 	}
 	return ProcessMeta{
 		Name:         processName,
 		Executable:   exePath,
+		CgroupPath:   cgroupPath,
 		ContainerID:  containerID,
 		EnvVariables: envVarMap,
 	}
 }
 
-// parseContainerID parses cgroup v1 and v2 container IDs
-func parseContainerID(cgroupFile io.Reader) libpf.String {
+// extractCgroupPath extracts cgroup path (excluding controller for v1)
+func extractCgroupPath(pid libpf.PID) (libpf.String, error) {
+	cgroupFile, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return libpf.NullString, err
+	}
+	defer cgroupFile.Close()
+
+	return libpf.Intern(parseCgroupPath(cgroupFile)), nil
+}
+
+// parseCgroupPath parses cgroup v1 and v2 from `/proc/<pid>/cgroup`
+func parseCgroupPath(cgroupFile io.Reader) string {
 	scanner := bufio.NewScanner(cgroupFile)
 	buf := make([]byte, 512)
 	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
@@ -151,35 +168,35 @@ func parseContainerID(cgroupFile io.Reader) libpf.String {
 	// With a maximum of 4096 characters path in the kernel, 8192 should be fine here. We don't
 	// expect lines in /proc/<PID>/cgroup to be longer than that.
 	scanner.Buffer(buf, 8192)
+	cgroupPath := ""
 	for scanner.Scan() {
 		b := scanner.Bytes()
-		if bytes.Equal(b, []byte("0::/")) {
-			continue // Skip a common case
-		}
 		line := pfunsafe.ToString(b)
 		m := expLine.FindStringSubmatchIndex(line)
 		if len(m) == 4 {
-			sub := line[m[2]:m[3]]
-			if parts := expContainerID.FindStringSubmatchIndex(sub); len(parts) == 4 {
-				return libpf.Intern(sub[parts[2]:parts[3]])
+			path := line[m[2]:m[3]]
+			if cgroupPath == "" {
+				cgroupPath = strings.Clone(path)
 			}
+			// Try to pick the path with container id present for cgroup v1.
+			if extractContainerID(path) != libpf.NullString {
+				return path
+			}
+			continue
 		}
-		log.Debugf("Could not extract container ID from line: %s", line)
+		log.Debugf("Could not extract cgroup path from line: %s", line)
 	}
 
-	// No containerID could be extracted
-	return libpf.NullString
+	return cgroupPath
 }
 
-// extractContainerID returns the containerID for pid (supports both cgroup v1 and v2)
-func extractContainerID(pid libpf.PID) (libpf.String, error) {
-	cgroupFile, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
-	if err != nil {
-		return libpf.NullString, err
+// extractContainerID returns the containerID for cgroup path
+func extractContainerID(path string) libpf.String {
+	if parts := expContainerID.FindStringSubmatchIndex(path); len(parts) == 4 {
+		return libpf.Intern(path[parts[2]:parts[3]])
 	}
-	defer cgroupFile.Close()
 
-	return parseContainerID(cgroupFile), nil
+	return libpf.NullString
 }
 
 // CgroupRootInode returns the inode of /proc/<pid>/root/sys/fs/cgroup, which identifies

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -180,55 +180,90 @@ func TestNewPIDOfSelf(t *testing.T) {
 func TestExtractContainerID(t *testing.T) {
 	tests := []struct {
 		line                string
+		expectedCgroupPath  string
 		expectedContainerID string
 	}{
 		// cgroup v2
 		{
+			line:               "0::/",
+			expectedCgroupPath: "/",
+		},
+		{
 			line:                "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa-95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope",
+			expectedCgroupPath:  "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa-95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope",
 			expectedContainerID: "b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc",
 		},
 		{
 			line:                "0::/kubepods/besteffort/pod05e102bf-8744-4942-a241-9b6f07983a53/f52a212505a606972cf8614c3cb856539e71b77ecae33436c5ac442232fbacf8",
+			expectedCgroupPath:  "/kubepods/besteffort/pod05e102bf-8744-4942-a241-9b6f07983a53/f52a212505a606972cf8614c3cb856539e71b77ecae33436c5ac442232fbacf8",
 			expectedContainerID: "f52a212505a606972cf8614c3cb856539e71b77ecae33436c5ac442232fbacf8",
 		},
 		{
 			line:                "0::/kubepods/besteffort/pod897277d4-5e6f-4999-a976-b8340e8d075e/crio-a4d6b686848a610472a2eed3ae20d4d64b6b4819feb9fdfc7fd7854deaf59ef3",
+			expectedCgroupPath:  "/kubepods/besteffort/pod897277d4-5e6f-4999-a976-b8340e8d075e/crio-a4d6b686848a610472a2eed3ae20d4d64b6b4819feb9fdfc7fd7854deaf59ef3",
 			expectedContainerID: "a4d6b686848a610472a2eed3ae20d4d64b6b4819feb9fdfc7fd7854deaf59ef3",
 		},
 		{
 			line:                "0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod4c9f1974_5c46_44c2_b42f_3bbf0e98eef9.slice/cri-containerd-bacb920470900725e0aa7d914fee5eb0854315448b024b6b8420ad8429c607ba.scope",
+			expectedCgroupPath:  "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod4c9f1974_5c46_44c2_b42f_3bbf0e98eef9.slice/cri-containerd-bacb920470900725e0aa7d914fee5eb0854315448b024b6b8420ad8429c607ba.scope",
 			expectedContainerID: "bacb920470900725e0aa7d914fee5eb0854315448b024b6b8420ad8429c607ba",
 		},
 		{
-			line: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-868f9513-eee8-457d-8e36-1b37ae8ae622.scope",
+			line:               "0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-868f9513-eee8-457d-8e36-1b37ae8ae622.scope",
+			expectedCgroupPath: "/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-868f9513-eee8-457d-8e36-1b37ae8ae622.scope",
 		},
 		{
-			line: "0::/../../user.slice/user-501.slice/session-3.scope",
+			line:               "0::/../../user.slice/user-501.slice/session-3.scope",
+			expectedCgroupPath: "/../../user.slice/user-501.slice/session-3.scope",
 		},
 		{
 			line:                "0::/system.slice/docker-b1eba9dfaeba29d8b80532a574a03ea3cac29384327f339c26da13649e2120df.scope/init",
+			expectedCgroupPath:  "/system.slice/docker-b1eba9dfaeba29d8b80532a574a03ea3cac29384327f339c26da13649e2120df.scope/init",
 			expectedContainerID: "b1eba9dfaeba29d8b80532a574a03ea3cac29384327f339c26da13649e2120df",
 		},
 		// cgroup v1
 		{
 			line:                "11:memory:/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+			expectedCgroupPath:  "/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
 			expectedContainerID: "ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
 		},
 		{
 			line:                "11:cpucpuacct:/system.slice/containerd.service/kubepods-besteffort-pod86811ae3_b633_4eb8_a508_e3eae190f6ce.slice:cri-containerd:da1bdd84c8b25938081afe48da7075e2a211d2b1a62e01c894b4e5f3ffab670a",
+			expectedCgroupPath:  "/system.slice/containerd.service/kubepods-besteffort-pod86811ae3_b633_4eb8_a508_e3eae190f6ce.slice:cri-containerd:da1bdd84c8b25938081afe48da7075e2a211d2b1a62e01c894b4e5f3ffab670a",
 			expectedContainerID: "da1bdd84c8b25938081afe48da7075e2a211d2b1a62e01c894b4e5f3ffab670a",
 		},
 		{
 			line:                "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa_95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope",
+			expectedCgroupPath:  "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf6f2d169_f2ae_4afa_95ed_06ff2ed6b288.slice/cri-containerd-b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc.scope",
 			expectedContainerID: "b4d6d161c62525d726fa394b27df30e14f8ea5646313ada576b390de70cfc8cc",
+		},
+		{
+			line:                "12:cpuset:/\n11:memory:/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+			expectedCgroupPath:  "/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+			expectedContainerID: "ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+		},
+		{
+			line:                "0::/\n11:memory:/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+			expectedCgroupPath:  "/kubepods/besteffort/poda9c80282-3f6b-4d5b-84d5-a137a6668011/ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
+			expectedContainerID: "ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.expectedContainerID, func(t *testing.T) {
 			reader := strings.NewReader(tc.line)
-			gotContainerID := parseContainerID(reader)
+			gotCgroupPath := parseCgroupPath(reader)
+			gotContainerID := extractContainerID(gotCgroupPath)
+			assert.Equal(t, tc.expectedCgroupPath, gotCgroupPath)
 			assert.Equal(t, tc.expectedContainerID, gotContainerID.String())
 		})
 	}
+}
+
+func TestParseCgroupPathClonesFallbackPath(t *testing.T) {
+	firstPath := "/user.slice/" + strings.Repeat("z", 600)
+	secondPath := "/system.slice/" + strings.Repeat("y", 600)
+	line := "12:cpuset:" + firstPath + "\n11:memory:" + secondPath
+
+	assert.Equal(t, firstPath, parseCgroupPath(strings.NewReader(line)))
 }

--- a/process/types.go
+++ b/process/types.go
@@ -117,7 +117,9 @@ type ProcessMeta struct {
 	Executable libpf.String
 	// process env vars from /proc/PID/environ
 	EnvVariables map[libpf.String]libpf.String
-	// container ID retrieved from /proc/PID/cgroup
+	// path to the cgroup (excluding controller for v1)
+	CgroupPath libpf.String
+	// container ID extracted from `CgroupPath`
 	ContainerID libpf.String
 	// process context
 	ProcessContextInfo processcontext.Info

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -322,6 +322,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 		CPU:            bpfTrace.CpuID,
 		ProcessName:    bpfTrace.ProcessName,
 		ExecutablePath: bpfTrace.ExecutablePath,
+		CgroupPath:     bpfTrace.CgroupPath,
 		ContainerID:    bpfTrace.ContainerID,
 		Origin:         bpfTrace.Origin,
 		Value:          bpfTrace.Value,

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -11,6 +11,7 @@ type TraceEventMeta struct {
 	Comm           libpf.String
 	ProcessName    libpf.String
 	ExecutablePath libpf.String
+	CgroupPath     libpf.String
 	ContainerID    libpf.String
 	EnvVars        map[libpf.String]libpf.String
 	APMServiceName string

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1033,6 +1033,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 	*trace = libpf.EbpfTrace{
 		Comm:             goString(ptr.Comm[:]),
 		ExecutablePath:   procMeta.Executable,
+		CgroupPath:       procMeta.CgroupPath,
 		ContainerID:      procMeta.ContainerID,
 		ProcessName:      procMeta.Name,
 		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.Apm_trace_id)),


### PR DESCRIPTION
It is often read by consumers, and it's often missed for short lived processes that exit by the time the consumers get the event in `ReportTraceEvent`. Saving it in `ProcessMeta` removes duplicate work.

Closes #1412.