### PR TITLE
Open mappings without a fallback in IterateMappings

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -394,6 +394,10 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 	defer mapsFile.Close()
 
 	fileToMapping := make(map[string]*RawMapping)
+	// OpenELF may be called from inside the IterateMappings callback. Publish
+	// the in-progress map before scanning so callbacks can open the current
+	// mapping via /proc/PID/map_files instead of falling back to /proc/PID/root.
+	sp.fileToMapping = fileToMapping
 	gotMappings := false
 
 	collectForOpenELF := func(m RawMapping) bool {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -176,6 +176,36 @@ func TestNewPIDOfSelf(t *testing.T) {
 	assert.NotEmpty(t, mappings)
 }
 
+func TestIterateMappingsPublishesCurrentMappingBeforeCallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("unsupported os %s", runtime.GOOS)
+	}
+
+	pid := libpf.PID(os.Getpid())
+	pr := New(pid, pid)
+	sp, ok := pr.(*systemProcess)
+	require.True(t, ok)
+
+	checked := false
+	_, err := sp.IterateMappings(func(m RawMapping) bool {
+		if !m.IsExecutable() || !m.IsFileBacked() {
+			return true
+		}
+
+		stored, ok := sp.fileToMapping[m.Path]
+		require.True(t, ok)
+		require.Equal(t, m.Vaddr, stored.Vaddr)
+		require.Equal(t, m.Length, stored.Length)
+		require.Equal(t, m.Device, stored.Device)
+		require.Equal(t, m.Inode, stored.Inode)
+		checked = true
+		return false
+	})
+
+	require.ErrorIs(t, err, ErrCallbackStopped)
+	require.True(t, checked)
+}
+
 //nolint:lll
 func TestExtractContainerID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This fixes an issue where executables are unmapped from their mount namespaces.

`newFrameMapping()` calls `OpenELF()` from inside the `IterateMappings()` callback, but `systemProcess.IterateMappings()` only populated `sp.fileToMapping` after the full maps scan completed. So during the callback, `OpenELF()` could not find the current mapping in fileToMapping and fell back to `/proc/$pid/root`, producing:

```
openat2 /root/usr/local/bin/egress-analytics in /proc/2223231/root: no such file or directory
```