### PR TITLE
processmanager: log error returned by handleNewInterpreter

### DIFF
--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -387,7 +387,10 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapp
 	pm.assignLibcInfo(pr.PID(), ei.LibcInfo)
 	if ei.Data != nil {
 		bias := libpf.Address(m.Vaddr - elfSpaceVA)
-		pm.handleNewInterpreter(pr, bias, m.GetOnDiskFileIdentifier(), ei.Data)
+		if err := pm.handleNewInterpreter(pr, bias, m.GetOnDiskFileIdentifier(), ei.Data); err != nil {
+			log.Errorf("Failed to handle new interpreter for PID %d file %v: %v",
+				pr.PID(), m.Path, err)
+		}
 	}
 	pm.mu.Unlock()
 


### PR DESCRIPTION
## Summary
`newFrameMapping` discards the error returned by `handleNewInterpreter`, so any interpreter `Attach` failure becomes silent — no log line, no metric. The condition is recoverable (the rest of the mapping is still useful), but the silence makes regressions in interpreter loaders hard to detect.

This patch logs the error, mirroring the existing `"Failed to load executable info ..."` log a few lines up in the same function.
