### PR TITLE
coredump: add upload timestamp information to cleanup functionality

### DIFF
--- a/tools/coredump/clean.go
+++ b/tools/coredump/clean.go
@@ -80,12 +80,22 @@ func (cmd *cleanCmd) cleanLocal(referenced libpf.Set[modulestore.ID]) error {
 		return fmt.Errorf("failed to read local cache contents: %w", err)
 	}
 
+	remoteModules, err := cmd.store.ListRemoteModules()
+	if err != nil {
+		log.Warnf("Failed to fetch remote module list, upload timestamps unavailable: %v", err)
+		remoteModules = nil
+	}
+
 	for module := range localModules {
 		if _, exists := referenced[module]; exists {
 			continue
 		}
 
-		log.Infof("Removing local module `%s`", module.String())
+		if uploaded, ok := remoteModules[module]; ok {
+			log.Infof("Removing local module `%s` (uploaded: %s)", module.String(), uploaded)
+		} else {
+			log.Infof("Removing local module `%s`", module.String())
+		}
 		if !cmd.dry {
 			if err := cmd.store.RemoveLocalModule(module); err != nil {
 				return fmt.Errorf("failed to delete module: %w", err)


### PR DESCRIPTION
From the S3 ListObjectsV2 API we can't tell who uploaded a coredump module, but we can tell when it was uploaded.

```
$ ./coredump clean -dry-run=true
time=2026-06-01T13:54:19.389+02:00 level=INFO msg="Removing local module `631a67c8969bf7a9a3c739db4faa7a16bf4d713b0b5195131e8644656a91289d` (uploaded: 2025-08-19 15:25:02 +0000 UTC)"
time=2026-06-01T13:54:19.389+02:00 level=INFO msg="Removing local module `a68762c86d371e6041f03f03a33a78fa235809ae7d81c90185940c93c3535aed` (uploaded: 2025-06-20 08:17:35 +0000 UTC)"
time=2026-06-01T13:54:19.389+02:00 level=INFO msg="Removing local module `f1519249bc28a3d1e7c0366a6c066970816c5bb6d26891b85927ac33f57ecac6` (uploaded: 2025-08-19 15:24:15 +0000 UTC)"
[..]
```