### PR TITLE
stringutil: fix length issues

### DIFF
--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -9,16 +9,19 @@ import (
 
 var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
 
-// FieldsN splits the string s around each instance of one or more consecutive space
+// FieldsN splits the string s around each instance of one or more consecutive ASCII space
 // characters, filling f with substrings of s.
-// If s contains more fields than n, the last element of f is set to the
+// If s contains more fields than len(f), the last element of f is set to the
 // unparsed remainder of s starting with the first non-space character.
 // f will stay untouched if s is empty or contains only white space.
-// if n is greater than len(f), 0 is returned without doing any parsing.
+// Returns 0 if f is empty.
 //
 // Apart from the mentioned differences, FieldsN is like an allocation-free strings.Fields.
 func FieldsN(s string, f []string) int {
 	n := len(f)
+	if n == 0 {
+		return 0
+	}
 	si := 0
 	for i := 0; i < n-1; i++ {
 		// Find the start of the next field.
@@ -53,14 +56,16 @@ func FieldsN(s string, f []string) int {
 }
 
 // SplitN splits the string around each instance of sep, filling f with substrings of s.
-// If s contains more fields than n, the last element of f is set to the
-// unparsed remainder of s starting with the first non-space character.
-// f will stay untouched if s is empty or contains only white space.
-// if n is greater than len(f), 0 is returned without doing any parsing.
+// If s contains more fields than len(f), the last element of f is set to the
+// unparsed remainder of s.
+// Returns 0 if f is empty.
 //
 // Apart from the mentioned differences, SplitN is like an allocation-free strings.SplitN.
 func SplitN(s, sep string, f []string) int {
 	n := len(f)
+	if n == 0 {
+		return 0
+	}
 	i := 0
 	for ; i < n-1 && s != ""; i++ {
 		fieldEnd := strings.Index(s, sep)

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -36,6 +36,11 @@ func TestFieldsN(t *testing.T) {
 	}
 }
 
+func TestFieldsNZeroLengthSlice(t *testing.T) {
+	require.Equal(t, 0, FieldsN("hello world", []string{}))
+	require.Equal(t, 0, FieldsN("", []string{}))
+}
+
 func TestSplitN(t *testing.T) {
 	tests := map[string]struct {
 		input     string
@@ -61,4 +66,9 @@ func TestSplitN(t *testing.T) {
 			require.Equal(t, testcase.expected, fields[:n])
 		})
 	}
+}
+
+func TestSplitNZeroLengthSlice(t *testing.T) {
+	require.Equal(t, 0, SplitN("hello-world", "-", []string{}))
+	require.Equal(t, 0, SplitN("", "-", []string{}))
 }


### PR DESCRIPTION
Incorrect use of the API of stringutil can cause the package to trigger a panic.

```
--- FAIL: TestFieldsNZeroLengthSlice (0.00s)
panic: runtime error: index out of range [-1] [recovered, repanicked]

goroutine 20 [running]:
testing.tRunner.func1.2({0x651900, 0xb66b7520480})
	/usr/local/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1977 +0x349
panic({0x651900?, 0xb66b7520480?})
	/usr/local/go/src/runtime/panic.go:860 +0x13a
go.opentelemetry.io/ebpf-profiler/stringutil.FieldsN({0x66c194?, 0x82f4c0?}, {0xb66b7595760?, 0x0?, 0x0?})
	/home/flehner/go/src/github.com/open-telemetry/opentelemetry-ebpf-profiler/stringutil/stringutil.go:48 +0x167
go.opentelemetry.io/ebpf-profiler/stringutil.TestFieldsNZeroLengthSlice(0xb66b76b6008)
	/home/flehner/go/src/github.com/open-telemetry/opentelemetry-ebpf-profiler/stringutil/stringutil_test.go:40 +0x32
testing.tRunner(0xb66b76b6008, 0x680d28)
	/usr/local/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:2101 +0x4c5
FAIL	go.opentelemetry.io/ebpf-profiler/stringutil	0.035s
FAIL
```

Prevent this issue by checking values.