### PR TITLE
test: clarify generated test fixture setup failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ You can view and edit the source code by cloning this repository:
 git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
 ```
 
-Run `make test` to run the tests instead of `go test`.
+Run `make test` to run the full test suite. If you want to run package tests
+directly with `go test`, first run `make test-deps` to generate the required
+test fixtures.
 
 
 ## Pull Requests
@@ -197,7 +199,7 @@ be granted Code Ownership.
 #### How to become a Code Owner
 
 To become a Code Owner, add your GitHub username to the
-[CODEOWNERS](.github/CODEOWNERS)] file with an entry for all files related to
+[CODEOWNERS](.github/CODEOWNERS) file with an entry for all files related to
 the component code. Be sure to tag the existing Code Owners, if any, within
 the PR to ensure they receive a notification.
 

--- a/libpf/pfelf/file_test.go
+++ b/libpf/pfelf/file_test.go
@@ -20,6 +20,7 @@ import (
 
 func getPFELF(path string, t *testing.T) *File {
 	t.Helper()
+	testsupport.RequireGeneratedTestFile(t, path)
 	file, err := Open(path)
 	require.NoError(t, err)
 	return file
@@ -57,6 +58,7 @@ func TestPFELFSymbols(t *testing.T) {
 }
 
 func TestPFELFSections(t *testing.T) {
+	testsupport.RequireGeneratedTestFile(t, "testdata/fixed-address")
 	elfFile, err := Open("testdata/fixed-address")
 	require.NoError(t, err)
 	defer elfFile.Close()
@@ -105,6 +107,7 @@ func TestGetGoBuildID(t *testing.T) {
 
 	buildID, err := ef.GetGoBuildID()
 	require.NoError(t, err)
+	testsupport.RequireGeneratedTestFile(t, "testdata/go-binary")
 	out, err := exec.Command("go", "tool", "buildid", "testdata/go-binary").Output()
 	require.NoError(t, err)
 	expectedBuildID := strings.TrimRight(string(out), "\n")

--- a/nativeunwind/elfunwindinfo/elfgopclntab_test.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
+	"go.opentelemetry.io/ebpf-profiler/testsupport"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,7 @@ func TestParseGoPclntab(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			testsupport.RequireGeneratedTestFile(t, test.elfFile)
 			ef, err := pfelf.Open(test.elfFile)
 			require.NoError(t, err)
 
@@ -99,6 +101,7 @@ func TestParseGoPclntab(t *testing.T) {
 }
 
 func TestTextStart(t *testing.T) {
+	testsupport.RequireGeneratedTestFile(t, "testdata/helloworld.linkexternal")
 	ef, err := pfelf.Open("testdata/helloworld.linkexternal")
 	require.NoError(t, err)
 	defer ef.Close()
@@ -121,6 +124,7 @@ func TestTextStart(t *testing.T) {
 	require.Equal(t, runtimeTextAddr, g.textStart)
 
 	// stripped binary should have the same text start
+	testsupport.RequireGeneratedTestFile(t, "testdata/helloworld.linkexternal.stripped")
 	efStripped, err := pfelf.Open("testdata/helloworld.linkexternal.stripped")
 	require.NoError(t, err)
 	defer efStripped.Close()

--- a/testsupport/generated_files.go
+++ b/testsupport/generated_files.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testsupport // import "go.opentelemetry.io/ebpf-profiler/testsupport"
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// RequireGeneratedTestFile verifies that a generated test fixture exists and
+// provides an actionable failure message when it does not.
+func RequireGeneratedTestFile(t *testing.T, path string) {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing generated test fixture %q; run `make test-deps` from the repository root", path)
+	}
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+}


### PR DESCRIPTION
Summary
Fresh clone plus direct `go test` hits raw `open testdata/...: no such file or directory` errors. Tiny papercut, kinda annoying.

This adds explicit fixture checks that point to `make test-deps`, updates `CONTRIBUTING.md` for direct `go test`, and fixes the broken `CODEOWNERS` link.

Repro
1. Start from a fresh clone, or clean the generated fixtures:
`make -C libpf/pfelf/testdata clean`
`make -C nativeunwind/elfunwindinfo/testdata clean`

2. Run:
`go test ./libpf/pfelf -run 'TestPFELFSections|TestPFELFIsGolang|TestGoVersion|TestGetGoBuildID'`
`go test ./nativeunwind/elfunwindinfo -run 'TestParseGoPclntab|TestTextStart'`

Before this change you just get raw missing file errors.
After this change the tests fail fast and tell you to run `make test-deps`, so its obvious what to do.