### PR TITLE
Support PHP 8.5

### DIFF
--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -268,9 +268,9 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		return nil, err
 	}
 
-	// Only tested on PHP7.3-PHP8.4. Other similar versions probably only require
+	// Only tested on PHP7.3-PHP8.5. Other similar versions probably only require
 	// tweaking the offsets.
-	minVer, maxVer := phpVersion(7, 3, 0), phpVersion(8, 5, 0)
+	minVer, maxVer := phpVersion(7, 3, 0), phpVersion(8, 6, 0)
 	if version < minVer || version >= maxVer {
 		return nil, fmt.Errorf("PHP version %d.%d.%d (need >= %d.%d and < %d.%d)",
 			(version>>16)&0xff, (version>>8)&0xff, version&0xff,
@@ -342,6 +342,13 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	vms.zend_class_entry.name = 8
 	vms.zend_op.lineno = 24
 	switch {
+	case version >= phpVersion(8, 5, 0):
+		// PHP 8.5 added fields to zend_executor_globals before
+		// current_execute_data, shifting its offset from 488 to 512.
+		vms.zend_executor_globals.current_execute_data = 512
+		vms.zend_function.op_array_filename = 168
+		vms.zend_function.op_array_linestart = 176
+		vms.zend_function.Sizeof = 184
 	case version >= phpVersion(8, 4, 0):
 		vms.zend_function.op_array_filename = 168
 		vms.zend_function.op_array_linestart = 176

--- a/interpreter/php/php_test.go
+++ b/interpreter/php/php_test.go
@@ -35,6 +35,7 @@ func TestVersionExtract(t *testing.T) {
 	}{
 		"7.x":          {given: "7.4.19", expected: phpVersion(7, 4, 19), expectError: false},
 		"8.x":          {given: "8.2.7", expected: phpVersion(8, 2, 7), expectError: false},
+		"8.5":          {given: "8.5.7", expected: phpVersion(8, 5, 7), expectError: false},
 		"double-digit": {given: "8.0.27", expected: phpVersion(8, 0, 27), expectError: false},
 		"suffix": {
 			given:       "8.1.2-1ubuntu2.14",

--- a/tools/coredump/testdata/amd64/php-8.5.7-class-method.json
+++ b/tools/coredump/testdata/amd64/php-8.5.7-class-method.json
@@ -1,0 +1,212 @@
+{
+  "coredump-ref": "03324a72334b886d2682ce4eaaab34bf69c064b0a0d043190e55de0c8073c9ec",
+  "threads": [
+    {
+      "lwp": 9633,
+      "frames": [
+        "php+0x77e2fc",
+        "PrimeChecker::isPrime+11 in /agent/tools/coredump/testsources/php/class_method.php:16",
+        "<top-level>+29 in /agent/tools/coredump/testsources/php/class_method.php:30",
+        "php+0x7c2242",
+        "php+0x7c0292",
+        "php+0x82a83f",
+        "php+0x6bdc12",
+        "php+0x82c811",
+        "php+0x25cd0a",
+        "libc.so.6+0x29ca7",
+        "libc.so.6+0x29d64",
+        "php+0x25e110"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "85e2e494494f4f50c4b6d2b4ae90e885da1bfdefd52c4cc5767fd10abff62505",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "1257597210f43630e7c8a745ae95127e96b93a43515ac5163cab459ddc1664b3",
+      "local-path": "/usr/lib/locale/C.utf8/LC_CTYPE"
+    },
+    {
+      "ref": "2663d9bdca20ba67d2d72f1d4c24b6fd0a3e97d5ee23e7b739788176cf904380",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libhogweed.so.6.10"
+    },
+    {
+      "ref": "14c4418a06c5c2e30f5fb57bc8add93762236ae17898c6708984cf15e680ca71",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6"
+    },
+    {
+      "ref": "fae58327d2557631217a0c2f97db3da6bf9bfcd80a221d8d6d285acc0040df00",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "ce44b7a7cbb6acc82d27b4f05b7613559058655ff51125b49bc3d9acef6d9666",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "e4ae39be74740511cf8e49e80fdfc16aeee7b822ee313793da1b78ce148ba05f",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.4.1"
+    },
+    {
+      "ref": "37ecaa050c23fee92d563eec8701164505ef880c00a513cbd6d1d03beeb8fa29",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnghttp3.so.9.2.6"
+    },
+    {
+      "ref": "b35963d122e850c48dc42be640731f4a48c963938229c8b0b159d7d2b7f2fd3e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblzma.so.5.8.1"
+    },
+    {
+      "ref": "1f68d40835767b14cbbad5d3146dbc4ea372e916391b7387a35cbf6d8b179460",
+      "local-path": "/usr/local/lib/php/extensions/no-debug-non-zts-20250925/sodium.so"
+    },
+    {
+      "ref": "7b0b0de90d8d3d4f07b99738c0285c6a0dbb6611d774ca44e7ea53a19a01ea68",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0"
+    },
+    {
+      "ref": "4b14edde42e7cbeefd8a6d88d035e096f2e6412a535388bb1d073a1c196e2822",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgnutls.so.30.40.3"
+    },
+    {
+      "ref": "e8f34e65087f24f296fa7a65a8c65383f4a7e2b532c46e40463d4e59a206c20a",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libldap.so.2.0.200"
+    },
+    {
+      "ref": "299cdc741f1dd0834a49d5cb44f3da26b1960bb110c1f521a084400d9b603cbf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libidn2.so.0.4.0"
+    },
+    {
+      "ref": "207268890b5be3043575c97af4e08c8326a12321a8a83e7278681b6b6f7d5ea8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnghttp2.so.14.28.3"
+    },
+    {
+      "ref": "30c61ab012a4241bed033725a09b61f5fdd3bb7df95ee852d0b096520524c7af",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "607cfc87376433e81a612f2463d778793207e852db6e36cbc95498968d9531c8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "7d4c54c51f62085d79a4c96c7ad52f680f1f2e6d38ff7c8b8fa18d57f89df130",
+      "local-path": "/usr/lib/x86_64-linux-gnu/librtmp.so.1"
+    },
+    {
+      "ref": "6d567d53e895273ca14a1f9dc164fc6c8d39aed2f60aa46a733c2784228915f3",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "52c227df9d53248238602c1ddaccd2c8ddc4cc6a61aa45d7c425af590b8806a5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache"
+    },
+    {
+      "ref": "3f93968591811eb3972c3467c69c2968dd9cb2b51f7b7bb48de22ba8e17d13fd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25"
+    },
+    {
+      "ref": "dc4828400674492839b630c001db424cd38e5cecfcf46dbf705a637647e04bea",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1"
+    },
+    {
+      "ref": "ca319704dd4f58b5b3fc8510738850f03f18940544ba04bebf2fa8a23a798346",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblber.so.2.0.200"
+    },
+    {
+      "ref": "54d25da8307ee6e33854261304a6ef50e95a205cc042458569e4cd74340ebb19",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libonig.so.5.4.0"
+    },
+    {
+      "ref": "85590dd58edf5445e18bc7193e5ebc01ac5841f1ae187e97705a662e90c6421e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "922024ec5a23f7de1095b1cff2f6cbfb377b5d58cd51fd0ec2e8fe35427653e2",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libffi.so.8.1.4"
+    },
+    {
+      "ref": "d41dd4adacf5a35df426461dd8a92d7bdd5ba29bb61a1c3531bec0ada386f8dd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libresolv.so.2"
+    },
+    {
+      "ref": "e5d5a7450d08eff7d4bbcaac75ef2b94d3447c81a1b2ddf3ab85d2de4709a9a8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10"
+    },
+    {
+      "ref": "d15e1585c6c267296459570c8ac217ca9123044bcd4e896d2f686b32333445d2",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "06530583d5927000480f4214d80d0213fec3d34cc448527f932a6eceb50cefef",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0"
+    },
+    {
+      "ref": "4013e7651ac68f547d8333517def25b2366c97eec7de7f06e105dbf3444ffebf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtinfo.so.6.5"
+    },
+    {
+      "ref": "94b5c0be9d7f09f1b4550ff15422d2ac8a6392c3471c88b93ee0370698388097",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "a3334d88f3f6c6a25736667e0b39db0f68b4e7e6bf758a475aff681ddb33ad8b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libreadline.so.8.2"
+    },
+    {
+      "ref": "34ac695c167a593d3587bd88592d33d53e5dc4035984f84446100962f57376fd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnettle.so.8.10"
+    },
+    {
+      "ref": "d9a6975db1b66ed34bdc04195a92a77b7d29b8d6affe4c35c05d7eafe5424fef",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4"
+    },
+    {
+      "ref": "7182748572d6bec098366090537c164f86a5c20c403b109bdce63f1f13886632",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcurl.so.4.8.0"
+    },
+    {
+      "ref": "438c546d8e8cc48496bf3a95f753051afd9db66a629a74e31a9ded71586b56e0",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "6155eb8e9481dcb75650fe047fc60f725085155526501898653e56fa30f99dda",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.4"
+    },
+    {
+      "ref": "f559f051ee5d39f151a57d79f2cde475c484030098b0c73f9f7035b421b187c4",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1"
+    },
+    {
+      "ref": "c4c3221d0350f882cee0430b58d5fb289a5776c684d3156964864c8a9719dff1",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1"
+    },
+    {
+      "ref": "c4ab64e6bc2874a83e649e4439be752465da027a0041e2bb5343f81c80f0882d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5.so.3.3"
+    },
+    {
+      "ref": "9c200ec975ff24c0a259d4f6cf0d0fc1736d0c86da30fff3d499ad3d9a368b65",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libunistring.so.5.2.0"
+    },
+    {
+      "ref": "c290f761873ebeac539911010526e1c5db86218bfcb29672760da46841741de0",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2"
+    },
+    {
+      "ref": "c11e380d0a66e2d4fc484684df0ccd585041d93a640c67f1d751d6593326a560",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1"
+    },
+    {
+      "ref": "27f07c9a49c2c956bcfb64cd4712976586a66facbf15fc7f09bc37413b5f2b21",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libzstd.so.1.5.7"
+    },
+    {
+      "ref": "fa430b8f298f817a266046af84a77533185ad6fc4406c7d3787b5a0a0c207826",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "216ef08177feb82b00da0ec4adafdc2ae047e0a4faa24adede407570a9090abc",
+      "local-path": "/usr/local/bin/php"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/php-8.5.7-prime.json
+++ b/tools/coredump/testdata/amd64/php-8.5.7-prime.json
@@ -1,0 +1,212 @@
+{
+  "coredump-ref": "e6dee1d151633afd8146a9f6ff3635fc81ad9e73ec0bb68e8951d8cf4e138da3",
+  "threads": [
+    {
+      "lwp": 5111,
+      "frames": [
+        "php+0x78b8b5",
+        "is_prime+13 in /agent/tools/coredump/testsources/php/prime.php:16",
+        "<top-level>+33 in /agent/tools/coredump/testsources/php/prime.php:34",
+        "php+0x7c233a",
+        "php+0x7c0292",
+        "php+0x82a83f",
+        "php+0x6bdc12",
+        "php+0x82c811",
+        "php+0x25cd0a",
+        "libc.so.6+0x29ca7",
+        "libc.so.6+0x29d64",
+        "php+0x25e110"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "6155eb8e9481dcb75650fe047fc60f725085155526501898653e56fa30f99dda",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.4"
+    },
+    {
+      "ref": "dc4828400674492839b630c001db424cd38e5cecfcf46dbf705a637647e04bea",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1"
+    },
+    {
+      "ref": "2663d9bdca20ba67d2d72f1d4c24b6fd0a3e97d5ee23e7b739788176cf904380",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libhogweed.so.6.10"
+    },
+    {
+      "ref": "27f07c9a49c2c956bcfb64cd4712976586a66facbf15fc7f09bc37413b5f2b21",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libzstd.so.1.5.7"
+    },
+    {
+      "ref": "94b5c0be9d7f09f1b4550ff15422d2ac8a6392c3471c88b93ee0370698388097",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "1f68d40835767b14cbbad5d3146dbc4ea372e916391b7387a35cbf6d8b179460",
+      "local-path": "/usr/local/lib/php/extensions/no-debug-non-zts-20250925/sodium.so"
+    },
+    {
+      "ref": "7b0b0de90d8d3d4f07b99738c0285c6a0dbb6611d774ca44e7ea53a19a01ea68",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0"
+    },
+    {
+      "ref": "c4c3221d0350f882cee0430b58d5fb289a5776c684d3156964864c8a9719dff1",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1"
+    },
+    {
+      "ref": "37ecaa050c23fee92d563eec8701164505ef880c00a513cbd6d1d03beeb8fa29",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnghttp3.so.9.2.6"
+    },
+    {
+      "ref": "ce44b7a7cbb6acc82d27b4f05b7613559058655ff51125b49bc3d9acef6d9666",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "607cfc87376433e81a612f2463d778793207e852db6e36cbc95498968d9531c8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "216ef08177feb82b00da0ec4adafdc2ae047e0a4faa24adede407570a9090abc",
+      "local-path": "/usr/local/bin/php"
+    },
+    {
+      "ref": "d15e1585c6c267296459570c8ac217ca9123044bcd4e896d2f686b32333445d2",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "c290f761873ebeac539911010526e1c5db86218bfcb29672760da46841741de0",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2"
+    },
+    {
+      "ref": "d9a6975db1b66ed34bdc04195a92a77b7d29b8d6affe4c35c05d7eafe5424fef",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4"
+    },
+    {
+      "ref": "b35963d122e850c48dc42be640731f4a48c963938229c8b0b159d7d2b7f2fd3e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblzma.so.5.8.1"
+    },
+    {
+      "ref": "6d567d53e895273ca14a1f9dc164fc6c8d39aed2f60aa46a733c2784228915f3",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "06530583d5927000480f4214d80d0213fec3d34cc448527f932a6eceb50cefef",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0"
+    },
+    {
+      "ref": "c11e380d0a66e2d4fc484684df0ccd585041d93a640c67f1d751d6593326a560",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1"
+    },
+    {
+      "ref": "14c4418a06c5c2e30f5fb57bc8add93762236ae17898c6708984cf15e680ca71",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6"
+    },
+    {
+      "ref": "e8f34e65087f24f296fa7a65a8c65383f4a7e2b532c46e40463d4e59a206c20a",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libldap.so.2.0.200"
+    },
+    {
+      "ref": "52c227df9d53248238602c1ddaccd2c8ddc4cc6a61aa45d7c425af590b8806a5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache"
+    },
+    {
+      "ref": "e4ae39be74740511cf8e49e80fdfc16aeee7b822ee313793da1b78ce148ba05f",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.4.1"
+    },
+    {
+      "ref": "c4ab64e6bc2874a83e649e4439be752465da027a0041e2bb5343f81c80f0882d",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5.so.3.3"
+    },
+    {
+      "ref": "299cdc741f1dd0834a49d5cb44f3da26b1960bb110c1f521a084400d9b603cbf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libidn2.so.0.4.0"
+    },
+    {
+      "ref": "54d25da8307ee6e33854261304a6ef50e95a205cc042458569e4cd74340ebb19",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libonig.so.5.4.0"
+    },
+    {
+      "ref": "7182748572d6bec098366090537c164f86a5c20c403b109bdce63f1f13886632",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcurl.so.4.8.0"
+    },
+    {
+      "ref": "85590dd58edf5445e18bc7193e5ebc01ac5841f1ae187e97705a662e90c6421e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "922024ec5a23f7de1095b1cff2f6cbfb377b5d58cd51fd0ec2e8fe35427653e2",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libffi.so.8.1.4"
+    },
+    {
+      "ref": "d41dd4adacf5a35df426461dd8a92d7bdd5ba29bb61a1c3531bec0ada386f8dd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libresolv.so.2"
+    },
+    {
+      "ref": "e5d5a7450d08eff7d4bbcaac75ef2b94d3447c81a1b2ddf3ab85d2de4709a9a8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10"
+    },
+    {
+      "ref": "f559f051ee5d39f151a57d79f2cde475c484030098b0c73f9f7035b421b187c4",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1"
+    },
+    {
+      "ref": "207268890b5be3043575c97af4e08c8326a12321a8a83e7278681b6b6f7d5ea8",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnghttp2.so.14.28.3"
+    },
+    {
+      "ref": "4013e7651ac68f547d8333517def25b2366c97eec7de7f06e105dbf3444ffebf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtinfo.so.6.5"
+    },
+    {
+      "ref": "fae58327d2557631217a0c2f97db3da6bf9bfcd80a221d8d6d285acc0040df00",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "3f93968591811eb3972c3467c69c2968dd9cb2b51f7b7bb48de22ba8e17d13fd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25"
+    },
+    {
+      "ref": "34ac695c167a593d3587bd88592d33d53e5dc4035984f84446100962f57376fd",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnettle.so.8.10"
+    },
+    {
+      "ref": "fa430b8f298f817a266046af84a77533185ad6fc4406c7d3787b5a0a0c207826",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "4b14edde42e7cbeefd8a6d88d035e096f2e6412a535388bb1d073a1c196e2822",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgnutls.so.30.40.3"
+    },
+    {
+      "ref": "ca319704dd4f58b5b3fc8510738850f03f18940544ba04bebf2fa8a23a798346",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblber.so.2.0.200"
+    },
+    {
+      "ref": "7d4c54c51f62085d79a4c96c7ad52f680f1f2e6d38ff7c8b8fa18d57f89df130",
+      "local-path": "/usr/lib/x86_64-linux-gnu/librtmp.so.1"
+    },
+    {
+      "ref": "30c61ab012a4241bed033725a09b61f5fdd3bb7df95ee852d0b096520524c7af",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "a3334d88f3f6c6a25736667e0b39db0f68b4e7e6bf758a475aff681ddb33ad8b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libreadline.so.8.2"
+    },
+    {
+      "ref": "438c546d8e8cc48496bf3a95f753051afd9db66a629a74e31a9ded71586b56e0",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "9c200ec975ff24c0a259d4f6cf0d0fc1736d0c86da30fff3d499ad3d9a368b65",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libunistring.so.5.2.0"
+    },
+    {
+      "ref": "85e2e494494f4f50c4b6d2b4ae90e885da1bfdefd52c4cc5767fd10abff62505",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "1257597210f43630e7c8a745ae95127e96b93a43515ac5163cab459ddc1664b3",
+      "local-path": "/usr/lib/locale/C.utf8/LC_CTYPE"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/php-8.5.7-class-method.json
+++ b/tools/coredump/testdata/arm64/php-8.5.7-class-method.json
@@ -1,0 +1,208 @@
+{
+  "coredump-ref": "446deb5d2f0993481b7299d3f7d02e76e84cc1450c6904a4b0edc9f50b58d07c",
+  "threads": [
+    {
+      "lwp": 4187,
+      "frames": [
+        "sqrt+0 in :0",
+        "PrimeChecker::isPrime+9 in /agent/tools/coredump/testsources/php/class_method.php:14",
+        "<top-level>+29 in /agent/tools/coredump/testsources/php/class_method.php:30",
+        "php+0x6f0f90",
+        "php+0x6eab07",
+        "php+0x758787",
+        "php+0x5d815f",
+        "php+0x75a60f",
+        "php+0x1a909f",
+        "libc.so.6+0x2225b",
+        "libc.so.6+0x2233b",
+        "php+0x1a91af"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "988693d804594db1e63130a6aaee5d86b1acefb1de7f0cfb798be9cde604da00",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "a8afb2d1f4a0c5e14c0fc82f794ec839eafe29738907aa92895410f57630bbe2",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "6a3258ad8e42f54f4333b8a5b6c671922a4482d261a89f75114b0de3ef565013",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcom_err.so.2.1"
+    },
+    {
+      "ref": "52130bdf6f1abdd8b476193cfd532d8c9f3a6d57eeabe06e4edb65b1711be83c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libldap.so.2.0.200"
+    },
+    {
+      "ref": "a31e5c7b7308548443f210a8350056b9f1059b7189ced9c9a4a4c140e65ec964",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblzma.so.5.8.1"
+    },
+    {
+      "ref": "9865b5990181843284595a2c290e5aa9e1df1b3ee438ce7fc6cdc2ec1c411985",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsqlite3.so.0.8.6"
+    },
+    {
+      "ref": "1d8b77f28b7cec0329dca107a28fb0a850193b1dcce59be68fa0b06b514548cc",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "1257597210f43630e7c8a745ae95127e96b93a43515ac5163cab459ddc1664b3",
+      "local-path": "/usr/lib/locale/C.utf8/LC_CTYPE"
+    },
+    {
+      "ref": "1279c4edfbfb08878b5b7fb40d392c1bdc9b30100d9b7a019d4aefaf10d2046c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libzstd.so.1.5.7"
+    },
+    {
+      "ref": "87376cef9c124257cec7fc0b5eac1b4c8535f597c6ebae70ad9334385cfb14d3",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblber.so.2.0.200"
+    },
+    {
+      "ref": "52aab346adb8506ce39846ead65f99ee398142865a4185fd5a9a0aa8504b2d74",
+      "local-path": "/usr/lib/aarch64-linux-gnu/librtmp.so.1"
+    },
+    {
+      "ref": "6ce57885b9ff21ba3fa902c1c515050230d8d6703f12f9a7d1e3d4e27279966e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libidn2.so.0.4.0"
+    },
+    {
+      "ref": "cb9756963306434c0fbe3351ded4041a5cc6e6ce37efc175de1093e13b3747fc",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libresolv.so.2"
+    },
+    {
+      "ref": "8bfeedd24d410b345ac39c26dfa9970609fe0ca6738a20fd6ac154a232aec152",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsasl2.so.2.0.25"
+    },
+    {
+      "ref": "deb1db5877ee7535d8434003404b4a4e181ab660a9e5370ba66c4b8e759e1111",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkrb5.so.3.3"
+    },
+    {
+      "ref": "81f40d719e01fc7241e60eb8295aca2109cb15197c9080fa6d26175f6defc897",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnettle.so.8.10"
+    },
+    {
+      "ref": "047d4fde470f4664a0e84ce80c84c9b03672948214be50f51f3915070c9ca4b6",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libhogweed.so.6.10"
+    },
+    {
+      "ref": "c1e6ec0bd6437fd85a64bc1f6dc22ec290aa40f963ba39662a8ab8971197a096",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "729c2c3578b96763a2e7148ad5a26f0136958025dff0f309e4267f09b9f61a4a",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkeyutils.so.1.10"
+    },
+    {
+      "ref": "077a32bb1d3d9b50d74d03aec2758c6ef94a422f28baab5fa6f3c04f1a0bc69e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libbrotlicommon.so.1.1.0"
+    },
+    {
+      "ref": "3ac5116be503e51a11954f9b4dff0932319368501eb26be8ff06f0618eac624e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libbrotlidec.so.1.1.0"
+    },
+    {
+      "ref": "ec33bd7992b40410a4f0154217c6acfae984966484b9fa6360a25e4074219bd0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcurl.so.4.8.0"
+    },
+    {
+      "ref": "e2871d8144d45e6650db5c0758793c0fc11a22aff1ed5680731e885a56707819",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "c4c52c0df6f3809f1b85927a85f322d102cffebb6b517b44b37048f6fd620c01",
+      "local-path": "/usr/lib/aarch64-linux-gnu/gconv/gconv-modules.cache"
+    },
+    {
+      "ref": "950c7c9c2da1d5ebaae583a6c4da6b9b41bbbee6a4a8f848a868c0e106fe9335",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libk5crypto.so.3.1"
+    },
+    {
+      "ref": "967b9c108b49481f6cc1358d675a6c1b16754254c84c421c43a5814010e2a215",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgssapi_krb5.so.2.2"
+    },
+    {
+      "ref": "9a325944115b36e74077786b29531963d96cd55cd6c82f11750a352cdb58fab0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "5902020ce5251a5b3014a99fe784f260d979d45eb30bcf7eff8da7a955f661f7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "20a6aa3d1526507a1886366b37471d48c63b9bd4065e4fd1f64159fc84a14c08",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libtasn1.so.6.6.4"
+    },
+    {
+      "ref": "560c04722d04d0331b0eeda8a249491139ba46bf0e294897ebceb04993380596",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgnutls.so.30.40.3"
+    },
+    {
+      "ref": "582cac0f86e9eb52b4f10e1927c79b23310482c0e0323d201b1d11a1fd9d1db8",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpsl.so.5.3.4"
+    },
+    {
+      "ref": "cbee84479172acd6a667a58de811d9039eb03a6d1f6fce543fa9c7c9c3c07e46",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnghttp2.so.14.28.3"
+    },
+    {
+      "ref": "eb19d11db503c6f38963d3e46cd09046bdb2f7680ecb5eb9170f21196363bf5c",
+      "local-path": "/usr/local/bin/php"
+    },
+    {
+      "ref": "472da9d258c3e3ded1b7a7063bcf8df1da97d7d46030973e1fa5e116f497172f",
+      "local-path": "/usr/local/lib/php/extensions/no-debug-non-zts-20250925/sodium.so"
+    },
+    {
+      "ref": "265157c5541d3cc73f5bb5cf43e8a58e996a25211d716a9ab2ba65b1a787633a",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkrb5support.so.0.1"
+    },
+    {
+      "ref": "26bda6bd707b57c7d02bb6331adda65906950d4ef8ad7ed82901a7cf81a4d44f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libunistring.so.5.2.0"
+    },
+    {
+      "ref": "82319f388b327a204047d2de787decbd9f592f81e23984d4a1b166306e69667c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnghttp3.so.9.2.6"
+    },
+    {
+      "ref": "2a2afe82ea68df8ab5a5804a8e0fa5f75b23f9a44aaa48836df94bf7a57a106f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libonig.so.5.4.0"
+    },
+    {
+      "ref": "6fe00acadf8119ff245855e5dcc7f26c6c0ffaf4bfa2baa88feab58f23727d65",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "41eaf42757798c29d7dd13f519f76a91cd06847a068ed29a7912b343b60c48b3",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libreadline.so.8.2"
+    },
+    {
+      "ref": "f0527ef7efeaf85fc2f5855d68fddb63bf7b3b90f1228c6b49fb6020b0dca490",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libffi.so.8.1.4"
+    },
+    {
+      "ref": "6664704a1baa3f6541a7a3af752ab2c008256d56438f70ba18acc59aee3978c7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libp11-kit.so.0.4.1"
+    },
+    {
+      "ref": "8858b931d041b74a8ce9dcb16d9912eb431c4f55b97ca2e58646a1c1bd991852",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "88e96dec88023455a09c1907ea7f79bb346c97ac80b11efecaf7a55629cfd6e4",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssh2.so.1.0.1"
+    },
+    {
+      "ref": "57cda9469aa613f8ab25b21af56867d5a01d19c0a91fda6965aa6501ea98cfcf",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libtinfo.so.6.5"
+    },
+    {
+      "ref": "c69705fed4898799589787aaef047eacbc0138e43cb03300be9f4f834a0ee094",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/php-8.5.7-prime.json
+++ b/tools/coredump/testdata/arm64/php-8.5.7-prime.json
@@ -1,0 +1,208 @@
+{
+  "coredump-ref": "e8df78de2ad9d62bc5fdb6ca193e3e1c3f476477f2e0a42585a18eb4750e7331",
+  "threads": [
+    {
+      "lwp": 4187,
+      "frames": [
+        "php+0x6add90",
+        "is_prime+13 in /agent/tools/coredump/testsources/php/prime.php:16",
+        "<top-level>+33 in /agent/tools/coredump/testsources/php/prime.php:34",
+        "php+0x6ed047",
+        "php+0x6eab07",
+        "php+0x758787",
+        "php+0x5d815f",
+        "php+0x75a60f",
+        "php+0x1a909f",
+        "libc.so.6+0x2225b",
+        "libc.so.6+0x2233b",
+        "php+0x1a91af"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "729c2c3578b96763a2e7148ad5a26f0136958025dff0f309e4267f09b9f61a4a",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkeyutils.so.1.10"
+    },
+    {
+      "ref": "deb1db5877ee7535d8434003404b4a4e181ab660a9e5370ba66c4b8e759e1111",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkrb5.so.3.3"
+    },
+    {
+      "ref": "8858b931d041b74a8ce9dcb16d9912eb431c4f55b97ca2e58646a1c1bd991852",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "81f40d719e01fc7241e60eb8295aca2109cb15197c9080fa6d26175f6defc897",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnettle.so.8.10"
+    },
+    {
+      "ref": "eb19d11db503c6f38963d3e46cd09046bdb2f7680ecb5eb9170f21196363bf5c",
+      "local-path": "/usr/local/bin/php"
+    },
+    {
+      "ref": "f0527ef7efeaf85fc2f5855d68fddb63bf7b3b90f1228c6b49fb6020b0dca490",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libffi.so.8.1.4"
+    },
+    {
+      "ref": "6664704a1baa3f6541a7a3af752ab2c008256d56438f70ba18acc59aee3978c7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libp11-kit.so.0.4.1"
+    },
+    {
+      "ref": "26bda6bd707b57c7d02bb6331adda65906950d4ef8ad7ed82901a7cf81a4d44f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libunistring.so.5.2.0"
+    },
+    {
+      "ref": "3ac5116be503e51a11954f9b4dff0932319368501eb26be8ff06f0618eac624e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libbrotlidec.so.1.1.0"
+    },
+    {
+      "ref": "2a2afe82ea68df8ab5a5804a8e0fa5f75b23f9a44aaa48836df94bf7a57a106f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libonig.so.5.4.0"
+    },
+    {
+      "ref": "988693d804594db1e63130a6aaee5d86b1acefb1de7f0cfb798be9cde604da00",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libxml2.so.2.9.14"
+    },
+    {
+      "ref": "c4c52c0df6f3809f1b85927a85f322d102cffebb6b517b44b37048f6fd620c01",
+      "local-path": "/usr/lib/aarch64-linux-gnu/gconv/gconv-modules.cache"
+    },
+    {
+      "ref": "87376cef9c124257cec7fc0b5eac1b4c8535f597c6ebae70ad9334385cfb14d3",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblber.so.2.0.200"
+    },
+    {
+      "ref": "57cda9469aa613f8ab25b21af56867d5a01d19c0a91fda6965aa6501ea98cfcf",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libtinfo.so.6.5"
+    },
+    {
+      "ref": "9a325944115b36e74077786b29531963d96cd55cd6c82f11750a352cdb58fab0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "41eaf42757798c29d7dd13f519f76a91cd06847a068ed29a7912b343b60c48b3",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libreadline.so.8.2"
+    },
+    {
+      "ref": "1257597210f43630e7c8a745ae95127e96b93a43515ac5163cab459ddc1664b3",
+      "local-path": "/usr/lib/locale/C.utf8/LC_CTYPE"
+    },
+    {
+      "ref": "6ce57885b9ff21ba3fa902c1c515050230d8d6703f12f9a7d1e3d4e27279966e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libidn2.so.0.4.0"
+    },
+    {
+      "ref": "265157c5541d3cc73f5bb5cf43e8a58e996a25211d716a9ab2ba65b1a787633a",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libkrb5support.so.0.1"
+    },
+    {
+      "ref": "6a3258ad8e42f54f4333b8a5b6c671922a4482d261a89f75114b0de3ef565013",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcom_err.so.2.1"
+    },
+    {
+      "ref": "c1e6ec0bd6437fd85a64bc1f6dc22ec290aa40f963ba39662a8ab8971197a096",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsodium.so.23.3.0"
+    },
+    {
+      "ref": "077a32bb1d3d9b50d74d03aec2758c6ef94a422f28baab5fa6f3c04f1a0bc69e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libbrotlicommon.so.1.1.0"
+    },
+    {
+      "ref": "a31e5c7b7308548443f210a8350056b9f1059b7189ced9c9a4a4c140e65ec964",
+      "local-path": "/usr/lib/aarch64-linux-gnu/liblzma.so.5.8.1"
+    },
+    {
+      "ref": "a8afb2d1f4a0c5e14c0fc82f794ec839eafe29738907aa92895410f57630bbe2",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "8bfeedd24d410b345ac39c26dfa9970609fe0ca6738a20fd6ac154a232aec152",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsasl2.so.2.0.25"
+    },
+    {
+      "ref": "560c04722d04d0331b0eeda8a249491139ba46bf0e294897ebceb04993380596",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgnutls.so.30.40.3"
+    },
+    {
+      "ref": "88e96dec88023455a09c1907ea7f79bb346c97ac80b11efecaf7a55629cfd6e4",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssh2.so.1.0.1"
+    },
+    {
+      "ref": "1279c4edfbfb08878b5b7fb40d392c1bdc9b30100d9b7a019d4aefaf10d2046c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libzstd.so.1.5.7"
+    },
+    {
+      "ref": "5902020ce5251a5b3014a99fe784f260d979d45eb30bcf7eff8da7a955f661f7",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libargon2.so.1"
+    },
+    {
+      "ref": "6fe00acadf8119ff245855e5dcc7f26c6c0ffaf4bfa2baa88feab58f23727d65",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3.1"
+    },
+    {
+      "ref": "e2871d8144d45e6650db5c0758793c0fc11a22aff1ed5680731e885a56707819",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libssl.so.3"
+    },
+    {
+      "ref": "472da9d258c3e3ded1b7a7063bcf8df1da97d7d46030973e1fa5e116f497172f",
+      "local-path": "/usr/local/lib/php/extensions/no-debug-non-zts-20250925/sodium.so"
+    },
+    {
+      "ref": "cb9756963306434c0fbe3351ded4041a5cc6e6ce37efc175de1093e13b3747fc",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libresolv.so.2"
+    },
+    {
+      "ref": "20a6aa3d1526507a1886366b37471d48c63b9bd4065e4fd1f64159fc84a14c08",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libtasn1.so.6.6.4"
+    },
+    {
+      "ref": "582cac0f86e9eb52b4f10e1927c79b23310482c0e0323d201b1d11a1fd9d1db8",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libpsl.so.5.3.4"
+    },
+    {
+      "ref": "cbee84479172acd6a667a58de811d9039eb03a6d1f6fce543fa9c7c9c3c07e46",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnghttp2.so.14.28.3"
+    },
+    {
+      "ref": "82319f388b327a204047d2de787decbd9f592f81e23984d4a1b166306e69667c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libnghttp3.so.9.2.6"
+    },
+    {
+      "ref": "9865b5990181843284595a2c290e5aa9e1df1b3ee438ce7fc6cdc2ec1c411985",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libsqlite3.so.0.8.6"
+    },
+    {
+      "ref": "1d8b77f28b7cec0329dca107a28fb0a850193b1dcce59be68fa0b06b514548cc",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "52aab346adb8506ce39846ead65f99ee398142865a4185fd5a9a0aa8504b2d74",
+      "local-path": "/usr/lib/aarch64-linux-gnu/librtmp.so.1"
+    },
+    {
+      "ref": "c69705fed4898799589787aaef047eacbc0138e43cb03300be9f4f834a0ee094",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "950c7c9c2da1d5ebaae583a6c4da6b9b41bbbee6a4a8f848a868c0e106fe9335",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libk5crypto.so.3.1"
+    },
+    {
+      "ref": "047d4fde470f4664a0e84ce80c84c9b03672948214be50f51f3915070c9ca4b6",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libhogweed.so.6.10"
+    },
+    {
+      "ref": "52130bdf6f1abdd8b476193cfd532d8c9f3a6d57eeabe06e4edb65b1711be83c",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libldap.so.2.0.200"
+    },
+    {
+      "ref": "967b9c108b49481f6cc1358d675a6c1b16754254c84c421c43a5814010e2a215",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgssapi_krb5.so.2.2"
+    },
+    {
+      "ref": "ec33bd7992b40410a4f0154217c6acfae984966484b9fa6360a25e4074219bd0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcurl.so.4.8.0"
+    }
+  ]
+}


### PR DESCRIPTION
PHP 8.5 inserts two new fields (`fatal_error_backtrace_on` and `last_fatal_error_backtrace`) into `zend_executor_globals` before `current_execute_data`, shifting its offset from 488 to 512. Every other Zend struct offset the profiler reads is unchanged from 8.4.

