### PR TITLE
support Go cgo stack unwinding on x86-64

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -645,7 +645,7 @@ func getSourceFileStrategy(arch elf.Machine, sourceFile string, defaultStrategy 
 	}
 }
 
-// getFunctionDelta determines if the special unwind opcode if needed
+// getFunctionDelta determines the special unwind opcode if needed
 func getFunctionUnwindInfo(sourceFile string, arch elf.Machine, framePointerReliable bool) *sdtypes.UnwindInfo {
 	switch sourceFile {
 	case "runtime.goexit", "runtime.mstart":

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -26,21 +26,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/support"
 )
 
-// Go runtime functions for which we should not attempt to unwind further
-var goFunctionsStopDelta = map[string]*sdtypes.UnwindInfo{
-	"runtime.mstart": &sdtypes.UnwindInfoStop, // topmost for the go runtime main stacks
-	"runtime.goexit": &sdtypes.UnwindInfoStop, // return address in all goroutine stacks
-
-	// systemstack preserves the frame pointer chain across
-	// the g0/user stack boundary, so standard FP unwinding traverses it naturally.
-	"runtime.systemstack": &sdtypes.UnwindInfoFramePointer,
-	"runtime.mcall":       &sdtypes.UnwindInfoStop,
-
-	// signal return frame
-	"runtime.sigreturn":            &sdtypes.UnwindInfoSignal,
-	"runtime.sigreturn__sigaction": &sdtypes.UnwindInfoSignal,
-}
-
 const (
 	// maximum pclntab (or rodata segment) size to inspect. The .gopclntab is
 	// often huge. Host agent binaries have about 32M .rodata, so allow for more.
@@ -660,6 +645,35 @@ func getSourceFileStrategy(arch elf.Machine, sourceFile string, defaultStrategy 
 	}
 }
 
+// getFunctionDelta determines if the special unwind opcode if needed
+func getFunctionUnwindInfo(sourceFile string, arch elf.Machine, framePointerReliable bool) *sdtypes.UnwindInfo {
+	switch sourceFile {
+	case "runtime.goexit", "runtime.mstart":
+		// goexit - return address in all goroutine stacks
+		// mstart - topmost for the go runtime main stacks
+		return &sdtypes.UnwindInfoStop
+	case "runtime.mcall": // unsupported at this time
+		return &sdtypes.UnwindInfoStop
+	case "runtime.asmcgocall":
+		// asmcgocall FP is valid only on x86-64
+		if arch != elf.EM_X86_64 {
+			return &sdtypes.UnwindInfoStop
+		}
+		fallthrough
+	case "runtime.systemstack":
+		// functions which preserve the frame pointer chain across the g0/user stack boundary
+		// so that the standard FP unwinding traverses it naturally.
+		if !framePointerReliable {
+			return &sdtypes.UnwindInfoStop
+		}
+		return &sdtypes.UnwindInfoFramePointer
+	case "runtime.sigreturn", "runtime.sigreturn__sigaction":
+		// signal frame restorers
+		return &sdtypes.UnwindInfoSignal
+	}
+	return nil
+}
+
 // parseX86pclntabFunc extracts interval information from x86_64 based pclntabFunc.
 func parseX86pclntabFunc(deltas *sdtypes.StackDeltaArray, p pcval, s strategy) error {
 	hints := sdtypes.UnwindHintKeep
@@ -777,14 +791,10 @@ func (ee *elfExtractor) parseGoPclntab() error {
 
 		// First, check for functions with special handling.
 		funcName := getString(g.funcnametab, int(fun.nameOff))
-		if info, found := goFunctionsStopDelta[funcName]; found {
-			unwindInfo := *info
-			if unwindInfo == sdtypes.UnwindInfoFramePointer && !isFramePointerReliable {
-				unwindInfo = sdtypes.UnwindInfoStop
-			}
+		if info := getFunctionUnwindInfo(funcName, arch, isFramePointerReliable); info != nil {
 			ee.deltas.Add(sdtypes.StackDelta{
 				Address: uint64(funcPc),
-				Info:    unwindInfo,
+				Info:    *info,
 			})
 			continue
 		}

--- a/tools/coredump/testdata/amd64/go-cgo.json
+++ b/tools/coredump/testdata/amd64/go-cgo.json
@@ -1,0 +1,103 @@
+{
+  "coredump-ref": "ebe40ab6dfa2a1e3122cdf0639bf65d9aeb4e860f5b5fe547f402cac73997f79",
+  "threads": [
+    {
+      "lwp": 27129,
+      "frames": [
+        "ld-musl-x86_64.so.1+0x68dbb",
+        "ld-musl-x86_64.so.1+0x6672e",
+        "ld-musl-x86_64.so.1+0x6949b",
+        "ld-musl-x86_64.so.1+0x69851",
+        "ld-musl-x86_64.so.1+0x6b22e",
+        "runtime.asmcgocall+0 in /usr/lib/go/src/runtime/asm_amd64.s:999",
+        "runtime.cgocall+0 in /usr/lib/go/src/runtime/cgocall.go:185",
+        "main._Cfunc_c_outer+0 in _cgo_gotypes.go:47",
+        "main.goCallC+0 in /home/tteras/work/elastic/opentelemetry-ebpf-profiler/tools/coredump/testsources/go/cgo/main.go:26",
+        "main.goMiddle+0 in /home/tteras/work/elastic/opentelemetry-ebpf-profiler/tools/coredump/testsources/go/cgo/main.go:32",
+        "main.goOuter+0 in /home/tteras/work/elastic/opentelemetry-ebpf-profiler/tools/coredump/testsources/go/cgo/main.go:37",
+        "main.main+0 in /home/tteras/work/elastic/opentelemetry-ebpf-profiler/tools/coredump/testsources/go/cgo/main.go:41",
+        "runtime.main+0 in /usr/lib/go/src/internal/runtime/atomic/types.go:194",
+        "runtime.goexit+0 in /usr/lib/go/src/runtime/asm_amd64.s:1772"
+      ]
+    },
+    {
+      "lwp": 27134,
+      "frames": [
+        "runtime.futex+0 in /usr/lib/go/src/runtime/sys_linux_amd64.s:570",
+        "runtime.futexsleep+0 in /usr/lib/go/src/runtime/os_linux.go:73",
+        "runtime.notesleep+0 in /usr/lib/go/src/runtime/lock_futex.go:48",
+        "runtime.templateThread+0 in /usr/lib/go/src/runtime/lock_spinbit.go:152",
+        "runtime.mstart1+0 in /usr/lib/go/src/runtime/proc.go:1935",
+        "runtime.mstart0+0 in /usr/lib/go/src/runtime/proc.go:1897",
+        "runtime.mstart+0 in /usr/lib/go/src/runtime/asm_amd64.s:427"
+      ]
+    },
+    {
+      "lwp": 27133,
+      "frames": [
+        "runtime.futex+0 in /usr/lib/go/src/runtime/sys_linux_amd64.s:570",
+        "runtime.futexsleep+0 in /usr/lib/go/src/runtime/os_linux.go:73",
+        "runtime.notesleep+0 in /usr/lib/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/lib/go/src/runtime/proc.go:1968",
+        "runtime.findRunnable+0 in /usr/lib/go/src/runtime/proc.go:3400",
+        "runtime.schedule+0 in /usr/lib/go/src/runtime/proc.go:4164",
+        "runtime.mstart1+0 in /usr/lib/go/src/runtime/proc.go:1943",
+        "runtime.mstart0+0 in /usr/lib/go/src/runtime/proc.go:1897",
+        "runtime.mstart+0 in /usr/lib/go/src/runtime/asm_amd64.s:427"
+      ]
+    },
+    {
+      "lwp": 27132,
+      "frames": [
+        "runtime.futex+0 in /usr/lib/go/src/runtime/sys_linux_amd64.s:570",
+        "runtime.futexsleep+0 in /usr/lib/go/src/runtime/os_linux.go:73",
+        "runtime.notesleep+0 in /usr/lib/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/lib/go/src/runtime/proc.go:1968",
+        "runtime.startlockedm+0 in /usr/lib/go/src/runtime/proc.go:3292",
+        "runtime.schedule+0 in /usr/lib/go/src/runtime/proc.go:4154",
+        "runtime.park_m+0 in /usr/lib/go/src/runtime/proc.go:4305",
+        "runtime.mcall+0 in /usr/lib/go/src/runtime/asm_amd64.s:500"
+      ]
+    },
+    {
+      "lwp": 27131,
+      "frames": [
+        "runtime.futex+0 in /usr/lib/go/src/runtime/sys_linux_amd64.s:570",
+        "runtime.futexsleep+0 in /usr/lib/go/src/runtime/os_linux.go:73",
+        "runtime.notesleep+0 in /usr/lib/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/lib/go/src/runtime/proc.go:1968",
+        "runtime.findRunnable+0 in /usr/lib/go/src/runtime/proc.go:3400",
+        "runtime.schedule+0 in /usr/lib/go/src/runtime/proc.go:4164",
+        "runtime.park_m+0 in /usr/lib/go/src/runtime/proc.go:4305",
+        "runtime.mcall+0 in /usr/lib/go/src/runtime/asm_amd64.s:500"
+      ]
+    },
+    {
+      "lwp": 27130,
+      "frames": [
+        "runtime.futex+0 in /usr/lib/go/src/runtime/sys_linux_amd64.s:570",
+        "runtime.futexsleep+0 in /usr/lib/go/src/runtime/os_linux.go:79",
+        "runtime.notetsleep_internal+0 in /usr/lib/go/src/runtime/lock_futex.go:90",
+        "runtime.notetsleep+0 in /usr/lib/go/src/runtime/lock_futex.go:112",
+        "runtime.sysmon+0 in /usr/lib/go/src/runtime/proc.go:6542",
+        "runtime.mstart1+0 in /usr/lib/go/src/runtime/proc.go:1935",
+        "runtime.mstart0+0 in /usr/lib/go/src/runtime/proc.go:1897",
+        "runtime.mstart+0 in /usr/lib/go/src/runtime/asm_amd64.s:427"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "46ee6c6a28c943c00ba0b0fa3d18d4f45cf4a3c45b7092b941054caee5c20b02",
+      "local-path": "/root/cgo"
+    },
+    {
+      "ref": "99eab0629ed5e6bc258bea735a128d1de30c5a8b52f39eed4919452d03c6c4ee",
+      "local-path": "/lib/ld-musl-x86_64.so.1"
+    },
+    {
+      "ref": "2ffe774a5473420a9093b21b9f96a2f9c38c0ba6a29b26f447370fafc8323d3f",
+      "local-path": "/usr/lib/debug/lib/ld-musl-x86_64.so.1.debug"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/stackdeltas.11629.json
+++ b/tools/coredump/testdata/amd64/stackdeltas.11629.json
@@ -83,7 +83,6 @@
         "stackdeltas+0x4eb2da",
         "stackdeltas+0x4eb230",
         "stackdeltas+0x467ccf",
-        "stackdeltas+0x462784",
         "stackdeltas+0x4e9b87",
         "stackdeltas+0x4e9c84",
         "stackdeltas+0x4e94f3",

--- a/tools/coredump/testsources/go/cgo/main.go
+++ b/tools/coredump/testsources/go/cgo/main.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+/*
+#include <unistd.h>
+
+// A chain of C functions to create a visible C stack.
+void c_leaf(void) {
+	sleep(3600);
+}
+
+void c_inner(void) {
+	c_leaf();
+}
+
+void c_outer(void) {
+	c_inner();
+}
+*/
+import "C"
+
+//go:noinline
+func goCallC() {
+	C.c_outer()
+}
+
+//go:noinline
+func goMiddle() {
+	goCallC()
+}
+
+//go:noinline
+func goOuter() {
+	goMiddle()
+}
+
+func main() {
+	goOuter()
+}


### PR DESCRIPTION
Go maintains the frame pointer when switching stacks in this function, so use it.

Taken over from https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1331. The profiler change is new and the coredump is regenerated. The coredump test case source code is copied over.