### PR TITLE
Remove Hash from Trace and compute it when needed

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -100,7 +100,6 @@ func (frames *Frames) Append(frame *Frame) {
 type Trace struct {
 	CustomLabels map[String]String
 	Frames       Frames
-	Hash         TraceHash
 }
 
 // EbpfTrace represents a stack trace from Ebpf code.

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -273,7 +273,7 @@ func (pm *ProcessManager) convertFrame(pid libpf.PID, ef libpf.EbpfFrame, dst *l
 }
 
 func (pm *ProcessManager) maybeNotifyAPMAgent(
-	rawTrace *libpf.EbpfTrace, umTraceHash libpf.TraceHash, count uint16,
+	rawTrace *libpf.EbpfTrace, trace *libpf.Trace, count uint16,
 ) string {
 	pm.mu.RLock()
 	// Keeping the lock until end of the function is needed because inner map can be modified
@@ -284,9 +284,15 @@ func (pm *ProcessManager) maybeNotifyAPMAgent(
 		return ""
 	}
 	var serviceName string
+	var traceHash libpf.TraceHash
+	traceHashComputed := false
 	for _, mapping := range pidInterp {
 		if apm, ok := mapping.(*apmint.Instance); ok {
-			apm.NotifyAPMAgent(rawTrace.PID, rawTrace, umTraceHash, count)
+			if !traceHashComputed {
+				traceHash = traceutil.HashTrace(trace)
+				traceHashComputed = true
+			}
+			apm.NotifyAPMAgent(rawTrace.PID, rawTrace, traceHash, count)
 			if serviceName != "" {
 				log.Warnf("Overwriting APM service name from '%s' to '%s' for PID %d",
 					serviceName,
@@ -386,8 +392,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	}
 	pm.mu.RUnlock()
 
-	trace.Hash = traceutil.HashTrace(trace)
-	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace.Hash, 1)
+	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace, 1)
 
 	if err := pm.traceReporter.ReportTraceEvent(trace, meta); err != nil {
 		log.Errorf("Failed to report trace event: %v", err)

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/reporter/internal/pdata"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/support"
+	"go.opentelemetry.io/ebpf-profiler/traceutil"
 )
 
 // baseReporter encapsulates shared behavior between all the available reporters.
@@ -67,6 +68,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		PID:            int64(meta.PID),
 		ExecutablePath: meta.ExecutablePath,
 	}
+	traceHash := traceutil.HashTrace(trace)
 
 	eventsTree := b.traceEvents.WLock()
 	defer b.traceEvents.WUnlock(&eventsTree)
@@ -84,7 +86,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	sampleKey := samples.SampleKey{
-		Hash:      trace.Hash,
+		Hash:      traceHash,
 		Comm:      meta.Comm,
 		TID:       int64(meta.TID),
 		CPU:       int64(meta.CPU),

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -47,7 +47,6 @@ func TestBaseReporterGenerate(t *testing.T) {
 	reporter := createTestBaseReporter(t, nil)
 
 	trace1 := &libpf.Trace{
-		Hash: libpf.NewTraceHash(0x0102030400000000, 0x0000000000000000),
 		Frames: func() libpf.Frames {
 			frames := make(libpf.Frames, 0, 3)
 			frames.Append(&libpf.Frame{
@@ -70,7 +69,6 @@ func TestBaseReporterGenerate(t *testing.T) {
 	}
 
 	trace2 := &libpf.Trace{
-		Hash: libpf.NewTraceHash(0x0506070800000000, 0x0000000000000000),
 		Frames: func() libpf.Frames {
 			frames := make(libpf.Frames, 0, 2)
 			frames.Append(&libpf.Frame{


### PR DESCRIPTION
APM is getting removed in #1153. The only other use is base reporter, which can be unused, which makes computing and storing hash pointless.

Closes #1513