### PR TITLE
Use a specialized Comm type to avoid eager interning

### DIFF
--- a/libpf/comm_test.go
+++ b/libpf/comm_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package tracer
+package libpf
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGoString(t *testing.T) {
+func TestCommString(t *testing.T) {
 	tests := map[string]struct {
 		input     []byte
 		wantValue string
@@ -23,7 +23,7 @@ func TestGoString(t *testing.T) {
 			wantValue: "héllo",
 		},
 		"empty buffer": {
-			input:     make([]byte, 16),
+			input:     make([]byte, commLen),
 			wantValue: "",
 		},
 		"no nul terminator uses whole buffer": {
@@ -37,8 +37,8 @@ func TestGoString(t *testing.T) {
 			wantValue: "tier",
 		},
 		"invalid utf8 is passed through unvalidated": {
-			// goString is used for comm, which is kernel-supplied and trusted
-			// as-is; validation happens only for label strings.
+			// Comm is kernel-supplied and trusted as-is; validation happens only
+			// for label strings.
 			input:     []byte{'b', 'a', 'd', 0x80, 0x00},
 			wantValue: "bad\x80",
 		},
@@ -46,8 +46,16 @@ func TestGoString(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := goString(tc.input)
+			var buffer [commLen]uint8
+			copy(buffer[:], tc.input)
+
+			got := NewComm(buffer)
 			require.Equal(t, tc.wantValue, got.String())
 		})
 	}
+}
+
+func TestNewCommFromString(t *testing.T) {
+	require.Equal(t, "comm", NewCommFromString("comm").String())
+	require.Equal(t, "exactlysixteenb!", NewCommFromString("exactlysixteenb!tail").String())
 }

--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -5,7 +5,33 @@ package libpf // import "go.opentelemetry.io/ebpf-profiler/libpf"
 
 import (
 	"unique"
+
+	"go.opentelemetry.io/ebpf-profiler/stringutil"
 )
+
+const commLen = 16
+
+// Comm is the fixed-size process command name buffer supplied by the kernel.
+type Comm struct {
+	buffer [commLen]uint8
+}
+
+// NewComm returns a Comm that preserves the full fixed-size kernel buffer.
+func NewComm(buffer [commLen]uint8) Comm {
+	return Comm{buffer: buffer}
+}
+
+// NewCommFromString returns a Comm initialized from str.
+func NewCommFromString(str string) Comm {
+	var buffer [commLen]uint8
+	copy(buffer[:], str)
+	return NewComm(buffer)
+}
+
+// String converts Comm's NUL-terminated fixed-size buffer into a Go string.
+func (c Comm) String() string {
+	return string(stringutil.CString(c.buffer[:]))
+}
 
 // FrameMappingFileData represents a backing file for a memory mapping.
 type FrameMappingFileData struct {
@@ -110,7 +136,7 @@ type EbpfTrace struct {
 	ExecutablePath   String
 	ContainerID      String
 	CustomLabels     map[String]String
-	Comm             String
+	Comm             Comm
 	FrameData        []uint64
 	KernelFrames     Frames
 	FrameDataBuf     [3072]uint64

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -90,7 +90,7 @@ func TestBaseReporterGenerate(t *testing.T) {
 	now := time.Now()
 	meta1 := &samples.TraceEventMeta{
 		Timestamp:      libpf.UnixTime64(now.UnixNano()),
-		Comm:           libpf.Intern("app1"),
+		Comm:           libpf.NewCommFromString("app1"),
 		ProcessName:    libpf.Intern("app1"),
 		ExecutablePath: libpf.Intern("/usr/bin/app1"),
 		APMServiceName: "service1",
@@ -103,7 +103,7 @@ func TestBaseReporterGenerate(t *testing.T) {
 
 	meta2 := &samples.TraceEventMeta{
 		Timestamp:      libpf.UnixTime64(now.Add(time.Second).UnixNano()),
-		Comm:           libpf.Intern("app2"),
+		Comm:           libpf.NewCommFromString("app2"),
 		ProcessName:    libpf.Intern("app2"),
 		ExecutablePath: libpf.Intern("/usr/bin/app2"),
 		APMServiceName: "service2",

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -595,7 +595,7 @@ func TestGenerate_NativeFrame(t *testing.T) {
 		support.TraceOriginSampling: {
 			{
 				Hash:   libpf.NewTraceHash(0, 1),
-				Comm:   libpf.Intern("abc"),
+				Comm:   libpf.NewCommFromString("abc"),
 				TID:    42,
 				CPU:    73,
 				SpanID: libpf.APMSpanID{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7},
@@ -815,7 +815,7 @@ func TestGenerate_Validate(t *testing.T) {
 		support.TraceOriginSampling: {
 			{
 				Hash:   libpf.NewTraceHash(0, 1),
-				Comm:   libpf.Intern("abc"),
+				Comm:   libpf.NewCommFromString("abc"),
 				TID:    42,
 				CPU:    73,
 				SpanID: libpf.APMSpanID{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7},

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TraceEventMeta struct {
-	Comm           libpf.String
+	Comm           libpf.Comm
 	ProcessName    libpf.String
 	ExecutablePath libpf.String
 	ContainerID    libpf.String
@@ -74,7 +74,7 @@ type SampleKey struct {
 	ExtraMeta any
 
 	// Comm is provided by the eBPF programs
-	Comm libpf.String
+	Comm libpf.Comm
 
 	Hash libpf.TraceHash
 

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -4,10 +4,21 @@
 package stringutil // import "go.opentelemetry.io/ebpf-profiler/stringutil"
 
 import (
+	"bytes"
 	"strings"
 )
 
 var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+
+// CString returns the prefix of buf up to (but not including) the first NUL
+// byte, or all of buf if no NUL is present. Suitable for fixed-size buffers
+// populated from eBPF.
+func CString(buf []byte) []byte {
+	if i := bytes.IndexByte(buf, 0); i >= 0 {
+		return buf[:i]
+	}
+	return buf
+}
 
 // FieldsN splits the string s around each instance of one or more consecutive ASCII space
 // characters, filling f with substrings of s.

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -36,6 +36,25 @@ func TestFieldsN(t *testing.T) {
 	}
 }
 
+func TestCString(t *testing.T) {
+	tests := map[string]struct {
+		input []byte
+		want  []byte
+	}{
+		"empty":        {input: []byte{}, want: []byte{}},
+		"no nul":       {input: []byte("hello"), want: []byte("hello")},
+		"first nul":    {input: []byte("\x00hello"), want: []byte{}},
+		"trailing nul": {input: []byte("hello\x00"), want: []byte("hello")},
+		"stale bytes":  {input: []byte("hello\x00world"), want: []byte("hello")},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, CString(tc.input))
+		})
+	}
+}
+
 func TestFieldsNZeroLengthSlice(t *testing.T) {
 	require.Equal(t, 0, FieldsN("hello world", []string{}))
 	require.Equal(t, 0, FieldsN("", []string{}))

--- a/tracer/labels.go
+++ b/tracer/labels.go
@@ -4,11 +4,11 @@
 package tracer // import "go.opentelemetry.io/ebpf-profiler/tracer"
 
 import (
-	"bytes"
 	"sync/atomic"
 	"unicode/utf8"
 
 	"go.opentelemetry.io/ebpf-profiler/metrics"
+	"go.opentelemetry.io/ebpf-profiler/stringutil"
 )
 
 // customLabelValidator validates custom label keys and values extracted from
@@ -20,23 +20,13 @@ type customLabelValidator struct {
 	droppedInvalidValue atomic.Int64
 }
 
-// cstring returns the prefix of buf up to (but not including) the first NUL
-// byte, or all of buf if no NUL is present. Suitable for fixed-size buffers
-// populated from eBPF.
-func cstring(buf []byte) []byte {
-	if i := bytes.IndexByte(buf, 0); i >= 0 {
-		return buf[:i]
-	}
-	return buf
-}
-
 // validateKey enforces strict UTF-8 validity on a custom label key. Any invalid
 // byte (or an empty key) returns ok=false and bumps the drop counter, signaling
 // the caller to drop the label. A corrupted key would silently group unrelated
 // samples under a garbage name, so strictness is intentional here. The returned
 // slice aliases buf; copy or intern before the buffer is reused.
 func (v *customLabelValidator) validateKey(buf []byte) ([]byte, bool) {
-	b := cstring(buf)
+	b := stringutil.CString(buf)
 	if len(b) == 0 || !utf8.Valid(b) {
 		v.droppedInvalidName.Add(1)
 		return nil, false
@@ -51,7 +41,7 @@ func (v *customLabelValidator) validateKey(buf []byte) ([]byte, bool) {
 // the input was non-empty garbage rather than mid-rune truncation. The returned
 // slice aliases buf; copy or intern before the buffer is reused.
 func (v *customLabelValidator) validateValue(buf []byte) ([]byte, bool) {
-	b := cstring(buf)
+	b := stringutil.CString(buf)
 	pos := len(b)
 	if !utf8.Valid(b) {
 		// Walk forward; stop at the first invalid byte. This recovers the entire

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -216,12 +216,6 @@ type progLoaderHelper struct {
 	noTailCallTarget bool
 }
 
-// goString converts a fixed-size NUL-terminated buffer into an interned string,
-// ignoring everything from the first NUL byte onward.
-func goString(buf []byte) libpf.String {
-	return libpf.Intern(pfunsafe.ToString(cstring(buf)))
-}
-
 // schedProcessFreeHookName returns the name of the tracepoint hook to use.
 // This function requires that only one of (schedProcessFreeV1, schedProcessFreeV2)
 // be present in progNames.
@@ -1031,7 +1025,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 	procMeta := t.processManager.MetaForPID(pid)
 	trace := t.tracePool.Get().(*libpf.EbpfTrace)
 	*trace = libpf.EbpfTrace{
-		Comm:             goString(ptr.Comm[:]),
+		Comm:             libpf.NewComm(ptr.Comm),
 		ExecutablePath:   procMeta.Executable,
 		ContainerID:      procMeta.ContainerID,
 		ProcessName:      procMeta.Name,


### PR DESCRIPTION
While `comm` can be unused by consumers, it is eagerly interned, which can be expensive. Instead of doing that, let's have a specialezed `Comm` type that stores the buffer from the kernel directly and that can turn into a string.