### PR TITLE
fix: fall back to Go build info in vc

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -4,6 +4,16 @@
 // Package vc provides buildtime information.
 package vc // import "go.opentelemetry.io/ebpf-profiler/vc"
 
+import (
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/mod/module"
+)
+
 var (
 	// The following variables are going to be set at link time using ldflags
 	// and can be referenced later in the program.
@@ -14,19 +24,130 @@ var (
 	buildTimestamp = ""
 	// version in vX.Y.Z{-N-abbrev} format (via git-describe --tags)
 	version = ""
+
+	buildInfoOnce sync.Once
+	fallbackVC    struct {
+		revision       string
+		buildTimestamp string
+		version        string
+	}
+	readBuildInfo = debug.ReadBuildInfo
 )
+
+const modulePath = "go.opentelemetry.io/ebpf-profiler"
 
 // Revision of the service.
 func Revision() string {
+	loadBuildInfoFallback()
+	if revision == "" {
+		return fallbackVC.revision
+	}
 	return revision
 }
 
 // BuildTimestamp returns the timestamp of the build.
 func BuildTimestamp() string {
+	loadBuildInfoFallback()
+	if buildTimestamp == "" {
+		return fallbackVC.buildTimestamp
+	}
 	return buildTimestamp
 }
 
 // Version in vX.Y.Z{-N-abbrev} format.
 func Version() string {
+	loadBuildInfoFallback()
+	if version == "" {
+		return fallbackVC.version
+	}
 	return version
+}
+
+func loadBuildInfoFallback() {
+	buildInfoOnce.Do(func() {
+		buildInfo, ok := readBuildInfo()
+		if !ok {
+			return
+		}
+
+		selfModule := &buildInfo.Main
+		if buildInfo.Main.Path != modulePath {
+			if dep := findModule(buildInfo.Deps, modulePath); dep != nil {
+				selfModule = dep
+			}
+		}
+
+		if version := moduleVersion(selfModule); version != "" && version != "(devel)" {
+			fallbackVC.version = version
+		}
+
+		if buildInfo.Main.Path == modulePath {
+			for _, setting := range buildInfo.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					fallbackVC.revision = setting.Value
+				case "vcs.time":
+					if t, err := time.Parse(time.RFC3339, setting.Value); err == nil {
+						fallbackVC.buildTimestamp = strconv.FormatInt(t.Unix(), 10)
+						continue
+					}
+					fallbackVC.buildTimestamp = setting.Value
+				case "vcs.modified":
+					if setting.Value == "true" && fallbackVC.version != "" &&
+						!strings.Contains(fallbackVC.version, "dirty") {
+						fallbackVC.version += "-dirty"
+					}
+				}
+			}
+		}
+
+		fillFromPseudoVersion(fallbackVC.version)
+
+		if fallbackVC.version == "" && fallbackVC.revision != "" {
+			fallbackVC.version = "devel"
+		}
+	})
+}
+
+func findModule(modules []*debug.Module, path string) *debug.Module {
+	for _, mod := range modules {
+		if mod == nil {
+			continue
+		}
+		if mod.Path == path {
+			return mod
+		}
+	}
+	return nil
+}
+
+func moduleVersion(mod *debug.Module) string {
+	if mod == nil {
+		return ""
+	}
+	if mod.Version != "" && mod.Version != "(devel)" {
+		return mod.Version
+	}
+	if mod.Replace != nil && mod.Replace.Version != "" && mod.Replace.Version != "(devel)" {
+		return mod.Replace.Version
+	}
+	return mod.Version
+}
+
+func fillFromPseudoVersion(version string) {
+	if version == "" || !module.IsPseudoVersion(version) {
+		return
+	}
+
+	if fallbackVC.revision == "" {
+		if rev, err := module.PseudoVersionRev(version); err == nil {
+			fallbackVC.revision = rev
+		}
+	}
+
+	if fallbackVC.buildTimestamp == "" {
+		if t, err := module.PseudoVersionTime(version); err == nil {
+			fallbackVC.buildTimestamp = strconv.FormatInt(t.Unix(), 10)
+		}
+	}
 }

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -1,0 +1,176 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vc
+
+import (
+	"runtime/debug"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFallsBackToBuildInfo(t *testing.T) {
+	resetVCForTest(t)
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    modulePath,
+				Version: "v1.2.3",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef123456"},
+				{Key: "vcs.time", Value: "2026-06-10T06:25:13Z"},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "v1.2.3", Version())
+	assert.Equal(t, "abcdef123456", Revision())
+	assert.Equal(t, "1781072713", BuildTimestamp())
+}
+
+func TestLdflagsOverrideBuildInfoFallback(t *testing.T) {
+	resetVCForTest(t)
+
+	version = "v9.9.9"
+	revision = "ldflags-revision"
+	buildTimestamp = "123"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    modulePath,
+				Version: "v1.2.3",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef123456"},
+				{Key: "vcs.time", Value: "2026-06-10T06:25:13Z"},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "v9.9.9", Version())
+	assert.Equal(t, "ldflags-revision", Revision())
+	assert.Equal(t, "123", BuildTimestamp())
+}
+
+func TestMarksFallbackVersionDirty(t *testing.T) {
+	resetVCForTest(t)
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    modulePath,
+				Version: "v1.2.3",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.modified", Value: "true"},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "v1.2.3-dirty", Version())
+}
+
+func TestUsesDevelVersionWhenOnlyRevisionIsAvailable(t *testing.T) {
+	resetVCForTest(t)
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path: modulePath,
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef123456"},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "devel", Version())
+	assert.Equal(t, "abcdef123456", Revision())
+}
+
+func TestFallsBackToDependencyBuildInfo(t *testing.T) {
+	resetVCForTest(t)
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "example.com/collector",
+				Version: "v1.0.0",
+			},
+			Deps: []*debug.Module{
+				{
+					Path:    modulePath,
+					Version: "v0.0.0-20260610062513-1aa2cb8c5f92",
+				},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "v0.0.0-20260610062513-1aa2cb8c5f92", Version())
+	assert.Equal(t, "1aa2cb8c5f92", Revision())
+	assert.Equal(t, "1781072713", BuildTimestamp())
+}
+
+func TestPrefersDependencyVersionOverLocalReplaceDevel(t *testing.T) {
+	resetVCForTest(t)
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "example.com/collector",
+				Version: "v1.0.0",
+			},
+			Deps: []*debug.Module{
+				{
+					Path:    modulePath,
+					Version: "v0.0.0-20260610062513-1aa2cb8c5f92",
+					Replace: &debug.Module{
+						Path:    "/tmp/local-ebpf-profiler",
+						Version: "(devel)",
+					},
+				},
+			},
+		}, true
+	}
+
+	assert.Equal(t, "v0.0.0-20260610062513-1aa2cb8c5f92", Version())
+	assert.Equal(t, "1aa2cb8c5f92", Revision())
+	assert.Equal(t, "1781072713", BuildTimestamp())
+}
+
+func resetVCForTest(t *testing.T) {
+	t.Helper()
+
+	originalVersion := version
+	originalRevision := revision
+	originalBuildTimestamp := buildTimestamp
+	originalReadBuildInfo := readBuildInfo
+
+	version = ""
+	revision = ""
+	buildTimestamp = ""
+	buildInfoOnce = sync.Once{}
+	fallbackVC = struct {
+		revision       string
+		buildTimestamp string
+		version        string
+	}{}
+	readBuildInfo = debug.ReadBuildInfo
+
+	t.Cleanup(func() {
+		version = originalVersion
+		revision = originalRevision
+		buildTimestamp = originalBuildTimestamp
+		readBuildInfo = originalReadBuildInfo
+		buildInfoOnce = sync.Once{}
+		fallbackVC = struct {
+			revision       string
+			buildTimestamp string
+			version        string
+		}{}
+	})
+}


### PR DESCRIPTION
Fixes #531

`vc` only had data when the repo Makefile injected ldflags.
Plain `go build` and versioned dependency builds came out empty, which is kinda rough.

This keeps ldflags first.
If they are empty, `vc` falls back to Go build info and pseudo version metadata.

Repro before this change:
`go build -o /tmp/ebpf-profiler .`
`/tmp/ebpf-profiler -version`
prints just an empty line.

Dependency repro before this change:
build a small module that requires `go.opentelemetry.io/ebpf-profiler v0.0.202624-0.20260610062513-1aa2cb8c5f92`
and print `vc.Version()`, `vc.Revision()`, `vc.BuildTimestamp()`.
it prints empty strings.

After this change those values are filled, and ldflags still win.
