### PR TITLE
dont preallocate bpf maps to avoid mem peak at init

### DIFF
--- a/support/ebpf/native_stack_trace.ebpf.c
+++ b/support/ebpf/native_stack_trace.ebpf.c
@@ -34,6 +34,7 @@ BPF_RODATA_VAR(u32, stack_ptregs_offset, 0)
     __type(key, u64);                                                                              \
     __type(value, u32);                                                                            \
     __uint(max_entries, 4096);                                                                     \
+    __uint(map_flags, BPF_F_NO_PREALLOC);                                                          \
     __array(                                                                                       \
       values, struct {                                                                             \
         __uint(type, BPF_MAP_TYPE_ARRAY);                                                          \

--- a/support/ebpf/native_stack_trace.ebpf.c
+++ b/support/ebpf/native_stack_trace.ebpf.c
@@ -34,7 +34,6 @@ BPF_RODATA_VAR(u32, stack_ptregs_offset, 0)
     __type(key, u64);                                                                              \
     __type(value, u32);                                                                            \
     __uint(max_entries, 4096);                                                                     \
-    __uint(map_flags, BPF_F_NO_PREALLOC);                                                          \
     __array(                                                                                       \
       values, struct {                                                                             \
         __uint(type, BPF_MAP_TYPE_ARRAY);                                                          \

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -22,6 +22,7 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/link"
 	"github.com/elastic/go-perf"
 	"go.opentelemetry.io/ebpf-profiler/internal/linux"
@@ -597,6 +598,43 @@ func syncVariablesToMapSpecs(coll *cebpf.CollectionSpec) error {
 	return nil
 }
 
+// probeNoPrealloc tests if the kernel allows perf_event programs to use
+// non-preallocated hash maps. This requires both creating the map and
+// verifying a perf_event program that references it.
+func probeNoPrealloc() bool {
+	m, err := cebpf.NewMap(&cebpf.MapSpec{
+		Type:       cebpf.Hash,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		Flags:      features.BPF_F_NO_PREALLOC,
+	})
+	if err != nil {
+		return false
+	}
+	defer m.Close()
+
+	prog, err := cebpf.NewProgram(&cebpf.ProgramSpec{
+		Type: cebpf.PerfEvent,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R2, 0),
+			asm.StoreMem(asm.RFP, -4, asm.R2, asm.Word),
+			asm.Mov.Reg(asm.R2, asm.RFP),
+			asm.Add.Imm(asm.R2, -4),
+			asm.LoadMapPtr(asm.R1, m.FD()),
+			asm.FnMapLookupElem.Call(),
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		return false
+	}
+	prog.Close()
+	return true
+}
+
 // loadAllMaps loads all eBPF maps that are used in our eBPF programs.
 func loadAllMaps(coll *cebpf.CollectionSpec, cfg *Config,
 	ebpfMaps map[string]*cebpf.Map,
@@ -635,6 +673,8 @@ func loadAllMaps(coll *cebpf.CollectionSpec, cfg *Config,
 		adaption[mapName] = 1 << uint32(exeIDToStackDeltasSize+cfg.MapScaleFactor)
 	}
 
+	noPrealloc := probeNoPrealloc()
+
 	for mapName, mapSpec := range coll.Maps {
 		if mapName == "sched_times" && cfg.OffCPUThreshold == 0 {
 			// Off CPU Profiling is disabled. So do not load this map.
@@ -666,6 +706,10 @@ func loadAllMaps(coll *cebpf.CollectionSpec, cfg *Config,
 		if newSize, ok := adaption[mapName]; ok {
 			log.Debugf("Size of eBPF map %s: %v", mapName, newSize)
 			mapSpec.MaxEntries = newSize
+		}
+		if noPrealloc && strings.HasPrefix(mapName, "exe_id_to_") &&
+			strings.HasSuffix(mapName, "_stack_deltas") {
+			mapSpec.Flags |= features.BPF_F_NO_PREALLOC
 		}
 		ebpfMap, err := cebpf.NewMap(mapSpec)
 		if err != nil {


### PR DESCRIPTION
## Context

We're running the profiler on hosts with large binaries under cgroup memory limits. During startup, the Go heap peaks at ~293 MB during `.eh_frame` parsing, which overlaps with ~67 MB of kernel memory pre-allocated for the 16 `exe_id_to_{8..23}_stack_deltas` outer hash maps:

    16 maps × 65536 entries × ~64 bytes ≈ 67 MB

This combination causes OOM kills before the profiler finishes initialization.

## Proposed change

Dynamically set `BPF_F_NO_PREALLOC` on the outer hash-of-maps at load time when the kernel version is >= 6.1 (the first version that supports this flag for perf/tracing programs). On older kernels, the maps load without the flag, preserving compatibility with the project's 5.10 minimum.

This follows the existing pattern of kernel-version-gated features (e.g. `python_frames_per_program` on 6.6+, tracepoint format on 6.16+).

In our testing this drops cgroup peak from 290 MB to 229 MB with no observable regressions over 30+ minutes.

The inner maps remain `BPF_MAP_TYPE_ARRAY` (always pre-allocated), so the per-sample eBPF lookup path is unaffected. Insertions into the outer hash only happen from userspace on binary discovery.

## Questions for maintainers

1. Has `BPF_F_NO_PREALLOC` been considered and rejected for these maps previously?

2. In practice we see <1% of the 65536 outer hash capacity populated on typical hosts. Are there deployment scenarios where these maps fill significantly higher?

3. Are there concerns about the non-prealloc allocation path (irq_work refill, interrupt disabling during kmalloc) that we're underweighting? Our read is that these only affect the userspace insertion path for new binaries, not the eBPF read path.

4. Would a different approach be preferred — e.g. reducing `max_entries` instead, or making this configurable via a flag?

