### PR TITLE
pfelf: prevent uint32 overflow in DT_GNU_HASH offset arithmetic

### DIFF
--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -1118,7 +1118,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		}
 
 		// Search the hash bucket
-		offs += int64(4)*int64(hdr.numBuckets) + int64(4)*int64(i-hdr.symbolOffset)
+		offs += 4*int64(hdr.numBuckets) + 4*int64(i-hdr.symbolOffset)
 		h |= 1
 		for {
 			var h2 uint32

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -1118,7 +1118,7 @@ func (f *File) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error) {
 		}
 
 		// Search the hash bucket
-		offs += int64(4*hdr.numBuckets + 4*(i-hdr.symbolOffset))
+		offs += int64(4)*int64(hdr.numBuckets) + int64(4)*int64(i-hdr.symbolOffset)
 		h |= 1
 		for {
 			var h2 uint32


### PR DESCRIPTION
`4*hdr.numBuckets` computed in uint32 wraps at `numBuckets>=0x40000000`, yielding a wrong file offset that reads attacker-controlled symbol data.