### PR TITLE
Format codegenned errors.json

### DIFF
--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -62,6 +62,7 @@ arm64:
 
 errors.h: ../../tools/errors-codegen/errors.json
 	go run ../../tools/errors-codegen/main.go bpf $@
+	$(CLANG_FORMAT) -i -style=file $@
 
 %.ebpf.$(TARGET_ARCH).o: %.ebpf.c errors.h
 	$(BPF_CLANG) $(FLAGS) -MMD -MP -o $@


### PR DESCRIPTION
When this file is regenerated as part of "make -C support/ebpf", the formatting is out of sync with what's produced by clang-format. This patch causes it to be correctly formatted after generation.