### PR TITLE
Check all notes in search of build-id

### DIFF
--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -604,15 +604,23 @@ func (f *File) EHFrame() (*Prog, error) {
 // VisitNotes iterates the ELF notes.
 // The visitor must make copies of the 'data' it keeps after return.
 func (f *File) VisitNotes(visitor func(uint64, []byte) bool) error {
-	notes := f.findProg(elf.PT_NOTE)
-	if notes == nil {
-		return nil
-	}
-
-	rdr := pfbufio.NewReader(f.elfReader, int64(notes.Off), int64(notes.Filesz))
+	rdr := pfbufio.GetReader()
 	defer pfbufio.PutReader(rdr)
 
-	return visitNotes(rdr, visitor)
+	for i := range f.Progs {
+		notes := &f.Progs[i]
+		if notes.Type != elf.PT_NOTE {
+			continue
+		}
+
+		rdr.Init(f.elfReader, int64(notes.Off), int64(notes.Filesz))
+		stopped, err := visitNotes(rdr, visitor)
+		if err != nil || stopped {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // parseNotes parses and caches the ELF notes for the File.

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -67,6 +67,9 @@ var (
 	// ErrNoBuildID is returned if build ID is not present in notes.
 	ErrNoBuildID = errors.New("no build ID")
 
+	// ErrNoteNotFound is returned by VisitNotes when no note made the visitor stop.
+	ErrNoteNotFound = errors.New("note not found")
+
 	// errNotProcessed is internal placeholder to mark not yet parsed data.
 	errNotProcessed = errors.New("not yet processed")
 )
@@ -603,6 +606,7 @@ func (f *File) EHFrame() (*Prog, error) {
 
 // VisitNotes iterates the ELF notes.
 // The visitor must make copies of the 'data' it keeps after return.
+// It returns ErrNoteNotFound if all notes are visited without the visitor stopping iteration.
 func (f *File) VisitNotes(visitor func(uint64, []byte) bool) error {
 	rdr := pfbufio.GetReader()
 	defer pfbufio.PutReader(rdr)
@@ -614,13 +618,14 @@ func (f *File) VisitNotes(visitor func(uint64, []byte) bool) error {
 		}
 
 		rdr.Init(f.elfReader, int64(notes.Off), int64(notes.Filesz))
-		stopped, err := visitNotes(rdr, visitor)
-		if err != nil || stopped {
-			return err
+		err := visitNotes(rdr, visitor)
+		if errors.Is(err, ErrNoteNotFound) {
+			continue
 		}
+		return err
 	}
 
-	return nil
+	return ErrNoteNotFound
 }
 
 // parseNotes parses and caches the ELF notes for the File.
@@ -635,6 +640,11 @@ func (f *File) parseNotes() error {
 			}
 			return true
 		})
+		if errors.Is(f.notesError, ErrNoteNotFound) {
+			// Visiting every note is expected here because parseNotes caches all
+			// build ID notes, which results in terminating with ErrNoteNotFound.
+			f.notesError = nil
+		}
 	}
 	return f.notesError
 }

--- a/libpf/pfelf/notes.go
+++ b/libpf/pfelf/notes.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -38,8 +39,7 @@ const (
 
 // visitNotes parses and visits all notes from pfbufio.Reader.
 // The visitor must make copies of the 'data' it keeps after return.
-// The returned bool is true if the visitor stopped iteration.
-func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) (bool, error) {
+func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) error {
 	var note note64
 	var buf []byte
 	for {
@@ -48,9 +48,9 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) (bool, e
 		// be kept together to parse the notes correctly.
 		if n, err := rdr.Read(pfunsafe.FromPointer(&note)); err != nil {
 			if n == 0 && err == io.EOF {
-				err = nil
+				return ErrNoteNotFound
 			}
-			return false, err
+			return err
 		}
 
 		id := NamespaceUnknown
@@ -70,10 +70,10 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) (bool, e
 			}
 		case pfbufio.ErrBufferTooSmall:
 			if _, err = rdr.Discard(alignedSize); err != nil {
-				return false, err
+				return err
 			}
 		default:
-			return false, err
+			return err
 		}
 
 		alignedSize = alignNoteSize(int(note.Descsz))
@@ -87,14 +87,14 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) (bool, e
 			}
 			buf = buf[:alignedSize]
 			if _, err = rdr.Read(buf); err != nil {
-				return false, err
+				return err
 			}
 			desc = buf
 		default:
-			return false, err
+			return err
 		}
 		if !visitor(id+uint64(note.Type), desc[:note.Descsz]) {
-			return true, nil
+			return nil
 		}
 	}
 }
@@ -109,14 +109,21 @@ func getBuildIDFromNotesFile(r io.ReaderAt) (string, error) {
 	defer pfbufio.PutReader(rdr)
 
 	var buildId string
-	_, err := visitNotes(rdr, func(note uint64, desc []byte) bool {
+	err := visitNotes(rdr, func(note uint64, desc []byte) bool {
 		if note == NoteGnuBuildId {
 			buildId = hex.EncodeToString(desc)
 			return false
 		}
 		return true
 	})
-	return buildId, err
+	switch {
+	case errors.Is(err, nil):
+		return buildId, nil
+	case errors.Is(err, ErrNoteNotFound):
+		return "", ErrNoBuildID
+	default:
+		return "", err
+	}
 }
 
 // GetBuildIDFromNotesFile returns the build ID contained in a file with

--- a/libpf/pfelf/notes.go
+++ b/libpf/pfelf/notes.go
@@ -38,7 +38,8 @@ const (
 
 // visitNotes parses and visits all notes from pfbufio.Reader.
 // The visitor must make copies of the 'data' it keeps after return.
-func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) error {
+// The returned bool is true if the visitor stopped iteration.
+func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) (bool, error) {
 	var note note64
 	var buf []byte
 	for {
@@ -49,11 +50,11 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) error {
 			if n == 0 && err == io.EOF {
 				err = nil
 			}
-			return err
+			return false, err
 		}
 
 		id := NamespaceUnknown
-		alignedSize := int((note.Namesz + 3) &^ 3)
+		alignedSize := alignNoteSize(int(note.Namesz))
 		namespace, err := rdr.ReadN(alignedSize)
 		switch err {
 		case nil:
@@ -69,13 +70,13 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) error {
 			}
 		case pfbufio.ErrBufferTooSmall:
 			if _, err = rdr.Discard(alignedSize); err != nil {
-				return err
+				return false, err
 			}
 		default:
-			return err
+			return false, err
 		}
 
-		alignedSize = int((note.Descsz + 3) &^ 3)
+		alignedSize = alignNoteSize(int(note.Descsz))
 		desc, err := rdr.ReadN(alignedSize)
 		switch err {
 		case nil:
@@ -86,16 +87,21 @@ func visitNotes(rdr *pfbufio.Reader, visitor func(uint64, []byte) bool) error {
 			}
 			buf = buf[:alignedSize]
 			if _, err = rdr.Read(buf); err != nil {
-				return err
+				return false, err
 			}
 			desc = buf
 		default:
-			return err
+			return false, err
 		}
 		if !visitor(id+uint64(note.Type), desc[:note.Descsz]) {
-			return nil
+			return true, nil
 		}
 	}
+}
+
+// alignNoteSize rounds size up to the nearest multiple of 4.
+func alignNoteSize(size int) int {
+	return (size + 3) &^ 3
 }
 
 func getBuildIDFromNotesFile(r io.ReaderAt) (string, error) {
@@ -103,7 +109,7 @@ func getBuildIDFromNotesFile(r io.ReaderAt) (string, error) {
 	defer pfbufio.PutReader(rdr)
 
 	var buildId string
-	err := visitNotes(rdr, func(note uint64, desc []byte) bool {
+	_, err := visitNotes(rdr, func(note uint64, desc []byte) bool {
 		if note == NoteGnuBuildId {
 			buildId = hex.EncodeToString(desc)
 			return false

--- a/libpf/pfelf/notes_test.go
+++ b/libpf/pfelf/notes_test.go
@@ -5,6 +5,8 @@ package pfelf
 
 import (
 	"bytes"
+	"debug/elf"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -17,4 +19,40 @@ func TestGetBuildIDFromNotesFile(t *testing.T) {
 	buildID, err := getBuildIDFromNotesFile(r)
 	require.NoError(t, err)
 	assert.Equal(t, hex.EncodeToString([]byte("_notorious_build_id_")), buildID)
+}
+
+func TestGetBuildIDVisitsAllProgramNoteSegments(t *testing.T) {
+	expected := "5883092a3cf39b3f4a8b5289b409829651c3ada3"
+	desc, err := hex.DecodeString(expected)
+	require.NoError(t, err)
+
+	first := testELFNote("LINUX", 0, []byte("not a build ID"))
+	second := testELFNote("GNU", 3, desc)
+	data := append(append([]byte{}, first...), second...)
+
+	f := &File{
+		elfReader: bytes.NewReader(data),
+		Progs: []Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: 0, Filesz: uint64(len(first))}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: uint64(len(first)), Filesz: uint64(len(second))}},
+		},
+		notesError: errNotProcessed,
+	}
+
+	buildID, err := f.GetBuildID()
+	require.NoError(t, err)
+	assert.Equal(t, expected, buildID)
+}
+
+func testELFNote(name string, noteType uint32, desc []byte) []byte {
+	nameBytes := append([]byte(name), 0)
+	note := make([]byte, 12)
+	binary.LittleEndian.PutUint32(note[0:], uint32(len(nameBytes)))
+	binary.LittleEndian.PutUint32(note[4:], uint32(len(desc)))
+	binary.LittleEndian.PutUint32(note[8:], noteType)
+	note = append(note, nameBytes...)
+	note = append(note, make([]byte, alignNoteSize(len(note))-len(note))...)
+	note = append(note, desc...)
+	note = append(note, make([]byte, alignNoteSize(len(note))-len(note))...)
+	return note
 }

--- a/libpf/pfelf/notes_test.go
+++ b/libpf/pfelf/notes_test.go
@@ -21,6 +21,52 @@ func TestGetBuildIDFromNotesFile(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString([]byte("_notorious_build_id_")), buildID)
 }
 
+func TestGetBuildIDFromNotesFileReturnsErrNoBuildID(t *testing.T) {
+	r := bytes.NewReader(testELFNote("LINUX", 0, []byte("not a build ID")))
+	buildID, err := getBuildIDFromNotesFile(r)
+	require.ErrorIs(t, err, ErrNoBuildID)
+	assert.Empty(t, buildID)
+}
+
+func TestVisitNotesReturnsErrNoteNotFound(t *testing.T) {
+	data := testELFNote("LINUX", 0, []byte("not a build ID"))
+	f := &File{
+		elfReader: bytes.NewReader(data),
+		Progs: []Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Filesz: uint64(len(data))}},
+		},
+	}
+
+	visited := 0
+	err := f.VisitNotes(func(_ uint64, _ []byte) bool {
+		visited++
+		return true
+	})
+	require.ErrorIs(t, err, ErrNoteNotFound)
+	assert.Equal(t, 1, visited)
+}
+
+func TestVisitNotesReturnsNilWhenVisitorStops(t *testing.T) {
+	first := testELFNote("LINUX", 0, []byte("not a build ID"))
+	second := testELFNote("GNU", 3, []byte("_notorious_build_id_"))
+	data := append(append([]byte{}, first...), second...)
+	f := &File{
+		elfReader: bytes.NewReader(data),
+		Progs: []Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: 0, Filesz: uint64(len(first))}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: uint64(len(first)), Filesz: uint64(len(second))}},
+		},
+	}
+
+	var visited []uint64
+	err := f.VisitNotes(func(note uint64, _ []byte) bool {
+		visited = append(visited, note)
+		return note != NoteGnuBuildId
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{NamespaceLinux, NoteGnuBuildId}, visited)
+}
+
 func TestGetBuildIDVisitsAllProgramNoteSegments(t *testing.T) {
 	expected := "5883092a3cf39b3f4a8b5289b409829651c3ada3"
 	desc, err := hex.DecodeString(expected)

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -178,6 +178,9 @@ func OpenCoredumpFile(f *pfelf.File) (*CoredumpProcess, error) {
 		noteErrors = errors.Join(noteErrors, err)
 		return noteErrors == nil
 	})
+	if errors.Is(err, pfelf.ErrNoteNotFound) {
+		err = nil
+	}
 	err = errors.Join(noteErrors, err)
 	if err != nil {
 		_ = f.Close()


### PR DESCRIPTION
On Debian Trixie it's not the first note, so it fails:

```
$ readelf -n /usr/bin/stress-ng

Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_PROPERTY_TYPE_0
      Properties: AArch64 feature: BTI, PAC

Displaying notes found in: .note.gnu.build-id
  Owner                Data size        Description
  GNU                  0x00000014       NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: 5883092a3cf39b3f4a8b5289b409829651c3ada3

Displaying notes found in: .note.ABI-tag
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_ABI_TAG (ABI version tag)
    OS: Linux, ABI: 3.7.0
```

It looks like #1479 broke this by replacing `f.Section(".note.go.buildid")` with `f.findProg(elf.PT_NOTE)`, which only finds the first note.