### PR TITLE
Add NoInterpreters to enable easier opt-in

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -15,18 +15,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/collector/config"
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
-	"go.opentelemetry.io/ebpf-profiler/interpreter"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/beam"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
-	golang "go.opentelemetry.io/ebpf-profiler/interpreter/go"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/golabels"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/hotspot"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/nodev8"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/perl"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/php"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/python"
-	"go.opentelemetry.io/ebpf-profiler/interpreter/ruby"
 	"go.opentelemetry.io/ebpf-profiler/tracer"
 )
 
@@ -212,18 +201,7 @@ func parseTracers(tracers string) (interpreterconfig.Config, error) {
 	}
 
 	// Start with all interpreters disabled; enable only the ones listed.
-	cfg := interpreterconfig.Config{
-		Python:  python.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Perl:    perl.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		PHP:     php.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Hotspot: hotspot.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Ruby:    ruby.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		V8:      nodev8.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Dotnet:  dotnet.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Go:      golang.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		Labels:  golabels.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-		BEAM:    beam.Config{BaseConfig: interpreter.BaseConfig{Disabled: true}},
-	}
+	cfg := interpreterconfig.NoInterpreters()
 
 	for name := range strings.SplitSeq(tracers, ",") {
 		name = strings.ToLower(strings.TrimSpace(name))

--- a/interpreter/interpreterconfig/config.go
+++ b/interpreter/interpreterconfig/config.go
@@ -5,6 +5,7 @@
 package interpreterconfig // import "go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
 
 import (
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/apmint"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/beam"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/dotnet"
@@ -35,6 +36,23 @@ type Config struct {
 
 // AllInterpreters returns a Config with all interpreters enabled.
 func AllInterpreters() Config { return Config{} }
+
+// NoInterpreters returns a Config with all interpreters disabled.
+func NoInterpreters() Config {
+	disabled := interpreter.BaseConfig{Disabled: true}
+	return Config{
+		Python:  python.Config{BaseConfig: disabled},
+		Perl:    perl.Config{BaseConfig: disabled},
+		PHP:     php.Config{BaseConfig: disabled},
+		Hotspot: hotspot.Config{BaseConfig: disabled},
+		Ruby:    ruby.Config{BaseConfig: disabled},
+		V8:      nodev8.Config{BaseConfig: disabled},
+		Dotnet:  dotnet.Config{BaseConfig: disabled},
+		Go:      golang.Config{BaseConfig: disabled},
+		Labels:  golabels.Config{BaseConfig: disabled},
+		BEAM:    beam.Config{BaseConfig: disabled},
+	}
+}
 
 // IsMapEnabled returns true if for the given mapName the respective
 // configuration is enabled.

--- a/interpreter/interpreterconfig/config_test.go
+++ b/interpreter/interpreterconfig/config_test.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package interpreterconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoInterpreters(t *testing.T) {
+	cfg := reflect.ValueOf(NoInterpreters())
+	cfgType := cfg.Type()
+
+	for i := range cfg.NumField() {
+		field := cfg.Field(i)
+		fieldType := cfgType.Field(i)
+
+		interpreter, ok := field.Interface().(interface{ IsDisabled() bool })
+		require.Truef(t, ok, "Config.%s does not implement IsDisabled", fieldType.Name)
+		require.Truef(t, interpreter.IsDisabled(), "Config.%s is enabled", fieldType.Name)
+	}
+}


### PR DESCRIPTION
Previously we were starting from scratch and enabling what we wanted. After migrating to `interpreterconfig`, this ability disappeared, and I'm reintroducing it here for consumers that want explicit opt-in.