### PR TITLE
fix(elfunwindinfo): bound CIE augmentation string scan in .eh_frame parsing

### DIFF
--- a/nativeunwind/elfunwindinfo/elfehframe.go
+++ b/nativeunwind/elfunwindinfo/elfehframe.go
@@ -242,12 +242,21 @@ func (r *reader) sleb() sleb128 {
 	return val
 }
 
-// str reads one zero-terminated string value
+// str reads one zero-terminated string value. The scan is bounded by r.end so
+// that input which is not NUL-terminated within the reader's region does not
+// index r.data out of bounds. On such an overread the reader is advanced past
+// r.end (mirroring get()), so the caller's isValid() check rejects the record
+// instead of the process panicking.
 func (r *reader) str() []byte {
 	cur := r.pos
 	end := r.pos
-	for r.data[end] != 0 {
+	for end < r.end && r.data[end] != 0 {
 		end++
+	}
+	if end >= r.end {
+		// No NUL terminator within bounds: signal overread to the caller.
+		r.pos = r.end + 1
+		return r.data[cur:end]
 	}
 	r.pos = end + 1
 	return r.data[cur:end]

--- a/nativeunwind/elfunwindinfo/elfehframe.go
+++ b/nativeunwind/elfunwindinfo/elfehframe.go
@@ -256,7 +256,7 @@ func (r *reader) str() []byte {
 	if end >= r.end {
 		// No NUL terminator within bounds: signal overread to the caller.
 		r.pos = r.end + 1
-		return r.data[cur:end]
+		return nil
 	}
 	r.pos = end + 1
 	return r.data[cur:end]

--- a/nativeunwind/elfunwindinfo/elfehframe_test.go
+++ b/nativeunwind/elfunwindinfo/elfehframe_test.go
@@ -246,3 +246,38 @@ func TestGetUnwindInfoX86_RegisterRA(t *testing.T) {
 		})
 	}
 }
+
+// TestReaderStrUnterminated verifies that reader.str() does not index its
+// backing slice out of bounds when the input contains no NUL terminator within
+// the reader's bounds (e.g. a CIE augmentation string at the tail of a
+// truncated/crafted .eh_frame section). Such input must be reported as an
+// overread (isValid() == false) so the caller rejects the record, rather than
+// panicking and crashing the profiler. Regression test for the unbounded scan
+// in (*reader).str().
+func TestReaderStrUnterminated(t *testing.T) {
+	t.Run("unterminated does not panic and signals overread", func(t *testing.T) {
+		// No 0x00 byte anywhere in the region.
+		data := []byte{'z', 'R', 0xff, 0xff}
+		r := &reader{data: data, pos: 0, end: uintptr(len(data))}
+		require.NotPanics(t, func() { _ = r.str() })
+		assert.False(t, r.isValid(),
+			"reader must be marked invalid (overread) when no terminator is found")
+	})
+
+	t.Run("terminated string still parses normally", func(t *testing.T) {
+		data := []byte{'z', 'R', 0x00, 0x42}
+		r := &reader{data: data, pos: 0, end: uintptr(len(data))}
+		var s []byte
+		require.NotPanics(t, func() { s = r.str() })
+		assert.Equal(t, []byte("zR"), s)
+		assert.True(t, r.isValid())
+		assert.Equal(t, uintptr(3), r.pos, "pos must advance past the NUL")
+	})
+
+	t.Run("terminator at last byte is in-bounds", func(t *testing.T) {
+		data := []byte{'a', 0x00}
+		r := &reader{data: data, pos: 0, end: uintptr(len(data))}
+		require.NotPanics(t, func() { _ = r.str() })
+		assert.True(t, r.isValid())
+	})
+}


### PR DESCRIPTION
## What

`(*reader).str()` in `nativeunwind/elfunwindinfo/elfehframe.go` scanned for a
NUL terminator without bounding the index by `r.end`, indexing the backing slice
directly:

```go
for r.data[end] != 0 {   // no upper bound on end
    end++
}
```

A `.eh_frame` CIE whose augmentation string is not NUL-terminated before the end
of the section drives `end` to `len(r.data)`, so `r.data[end]` triggers an
out-of-bounds panic. There is no `recover()` in the unwind-info extraction path,
so the panic crashes the whole profiler process.

## Why it matters

The profiler parses the `.eh_frame` of ELF binaries belonging to profiled
processes, including those an unprivileged user can map. When profiling an
untrusted workload, a user who runs a crafted ELF can crash the agent — an
unprivileged denial of service. Reported privately as GHSA-q339-h695-fwmv (same
class as CVE-2026-48496).

## Fix

Bound the scan by `r.end`, and when no terminator is found within bounds advance
the reader past `r.end` (mirroring `get()`'s overread handling) so the existing
`isValid()` check in `parseCIE()` rejects the record instead of panicking. This
keeps the change idiomatic to the reader's existing overread-tolerant accessors;
no behavioural change for well-formed input.

Adds a regression test (`TestReaderStrUnterminated`) covering the unterminated,
terminated, and terminator-at-last-byte cases.

## Testing

- `go test ./nativeunwind/elfunwindinfo/` — the new test and the existing
  `.eh_frame` tests pass (the only failures in the package are pre-existing
  `testdata/helloworld*` fixtures that require `make test-deps`).
- `go vet ./nativeunwind/elfunwindinfo/` — clean.

## Notes

Scoped to the minimal, targeted `str()` fix. Happy to follow up with an optional
`recover()` wrapper around per-ELF extraction as defense-in-depth (covers the
related parser leads from the advisory thread) if the maintainers prefer that
broader scope.
