### PR TITLE
README: remove stale build commands and fix config link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,11 @@ supported in any way, can be dropped in the future and should not be deployed in
 The agent can be built with the provided make targets. Docker is required for containerized builds, and both amd64 and arm64 architectures are supported.
 
  For **Linux**, the following steps apply:
-  1. Build the agent for your current machine's architecture:
+ 1. Build the agent for your current machine's architecture:
      ```sh
      make agent
      ```
-     Or `make debug-agent` for debug build.
-  2. To cross-compile for a different architecture (e.g. arm64):
+ 2. To cross-compile for a different architecture (e.g. arm64):
      ```sh
      make agent TARGET_ARCH=arm64
      ```
@@ -74,10 +73,6 @@ You can build the agent without Docker by directly installing the dependencies l
 ```sh
 make
 ```
-or
-```sh
-make debug
-```
 This will build the profiler natively on your machine.
 
 ## Building `otelcol-ebpf-profiler` locally (Without Docker)
@@ -90,7 +85,7 @@ or to cross-compile for a different architecture (e.g. arm64):
 make otelcol-ebpf-profiler TARGET_ARCH=arm64
 ```
 
-See [local.example.yml](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/cmd/otelcol-ebpf-profiler/local.example.yaml) for an example configuration.
+See [local.example.yaml](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/cmd/otelcol-ebpf-profiler/local.example.yaml) for an example configuration.
 
 ## Running
 


### PR DESCRIPTION
Fix a couple stale README bits.

`make debug-agent` and `make debug` are gone, so following the current docs just blows up.

The README also points to `local.example.yml`, but the real file is `local.example.yaml`, so that link is a 404 right now.

This patch removes the dead commands and fixes the link. Small thing, but it saves people a weird first run.

Repro:
1. Run `make -n debug-agent`
2. Run `make -n debug`
3. Open the old `local.example.yml` README link
4. See the failures and the 404

Related: #704