### PR TITLE
Cache resolution of kernel frames

### DIFF
--- a/kallsyms/bpf.go
+++ b/kallsyms/bpf.go
@@ -33,7 +33,8 @@ type bpfSymbol struct {
 // bpfSymbolTable is a sorted (by address) snapshot of all known BPF program
 // symbols. It is stored atomically so readers never block writers.
 type bpfSymbolTable struct {
-	symbols []bpfSymbol
+	generation Generation
+	symbols    []bpfSymbol
 }
 
 // lookup returns the symbol containing addr, or ("", false) if none does.
@@ -64,6 +65,13 @@ func (t *bpfSymbolTable) lookup(addr libpf.Address) (string, uint, bool) {
 	return sym.name, uint(addr - sym.address), true
 }
 
+func (t *bpfSymbolTable) symbolGeneration() Generation {
+	if t == nil {
+		return makeBPFGeneration(0)
+	}
+	return t.generation
+}
+
 // bpfSymbolizer is responsible for getting updates from `PERF_RECORD_KSYMBOL`.
 // The symbolizer is not ready to use until startMonitor is called to load the symbols.
 type bpfSymbolizer struct {
@@ -72,17 +80,6 @@ type bpfSymbolizer struct {
 	cancel  context.CancelFunc
 	table   atomic.Pointer[bpfSymbolTable]
 	wg      sync.WaitGroup
-}
-
-// LookupSymbol resolves addr to a BPF program symbol name and offset.
-// Returns ("", 0, false) if no BPF program covers addr.
-func (s *bpfSymbolizer) LookupSymbol(addr libpf.Address) (string, uint, bool) {
-	t := s.table.Load()
-	if t == nil {
-		return "", 0, false
-	}
-
-	return t.lookup(addr)
 }
 
 // loadBPFPrograms enumerates all loaded BPF programs via the bpf syscall and
@@ -141,7 +138,11 @@ func (s *bpfSymbolizer) loadBPFPrograms() error {
 		return cmp.Compare(a.address, b.address)
 	})
 
-	s.table.Store(&bpfSymbolTable{symbols: symbols})
+	old := s.table.Load()
+	s.table.Store(&bpfSymbolTable{
+		generation: old.symbolGeneration().next(),
+		symbols:    symbols,
+	})
 
 	return nil
 }
@@ -306,7 +307,10 @@ func (s *bpfSymbolizer) addBPFSymbol(addr libpf.Address, name string, size uint3
 	newSymbols[idx] = newSym
 	copy(newSymbols[idx+1:], oldSymbols[idx:])
 
-	s.table.Store(&bpfSymbolTable{symbols: newSymbols})
+	s.table.Store(&bpfSymbolTable{
+		generation: old.symbolGeneration().next(),
+		symbols:    newSymbols,
+	})
 }
 
 // removeBPFSymbol removes a BPF program symbol from the table by address.
@@ -327,11 +331,14 @@ func (s *bpfSymbolizer) removeBPFSymbol(addr libpf.Address) {
 	copy(newSymbols, old.symbols[:idx])
 	copy(newSymbols[idx:], old.symbols[idx+1:])
 
-	s.table.Store(&bpfSymbolTable{symbols: newSymbols})
+	s.table.Store(&bpfSymbolTable{
+		generation: old.symbolGeneration().next(),
+		symbols:    newSymbols,
+	})
 }
 
-// Close frees resources associated with bpfSymbolizer.
-func (s *bpfSymbolizer) Close() {
+// close frees resources associated with bpfSymbolizer.
+func (s *bpfSymbolizer) close() {
 	// Cancel the context first so reader goroutines and reloadWorker
 	// observe ctx.Done() and exit before we close the perf events.
 	if s.cancel != nil {

--- a/kallsyms/bpf_integration_test.go
+++ b/kallsyms/bpf_integration_test.go
@@ -94,12 +94,13 @@ func assertBPFSymbolFound(t *testing.T, s *Symbolizer, progName string) (string,
 
 	t.Logf("Found BPF program %q at address 0x%x", fullName, progAddr)
 
-	funcName, offset, ok := s.LookupBPFSymbol(progAddr)
+	snapshot := s.Snapshot()
+	funcName, offset, ok := snapshot.LookupBPFSymbol(progAddr)
 	require.True(t, ok, "LookupBPFSymbol failed for address 0x%x", progAddr)
 	assert.Equal(t, fullName, funcName)
 	assert.Equal(t, uint(0), offset)
 
-	funcName, offset, ok = s.LookupBPFSymbol(progAddr + 1)
+	funcName, offset, ok = snapshot.LookupBPFSymbol(progAddr + 1)
 	require.True(t, ok, "LookupBPFSymbol failed for address 0x%x", progAddr+1)
 	assert.Equal(t, fullName, funcName)
 	assert.Equal(t, uint(1), offset)
@@ -134,7 +135,7 @@ func TestBPFSymbolizerDynamic(t *testing.T) {
 
 	err = s.bpf.startMonitor(t.Context(), linearCPUs())
 	require.NoError(t, err)
-	defer s.bpf.Close()
+	defer s.bpf.close()
 
 	// The program hasn't been loaded yet, so the symbolizer must not know about it.
 	name, _ := findBPFSymbol(s.bpf, dynamicProgName)
@@ -165,7 +166,7 @@ func TestBPFSymbolizerPreexisting(t *testing.T) {
 
 	err = s.bpf.startMonitor(t.Context(), linearCPUs())
 	require.NoError(t, err)
-	defer s.bpf.Close()
+	defer s.bpf.close()
 
 	// The program was loaded before the monitor started, so it must be
 	// discovered from /proc/kallsyms during the initial load.

--- a/kallsyms/kallsyms.go
+++ b/kallsyms/kallsyms.go
@@ -78,6 +78,66 @@ type Module struct {
 	symbols []symbol
 }
 
+type moduleTable struct {
+	generation Generation
+	modules    []Module
+}
+
+func (t *moduleTable) Modules() []Module {
+	if t == nil {
+		return nil
+	}
+	return t.modules
+}
+
+func (t *moduleTable) symbolGeneration() Generation {
+	if t == nil {
+		return makeModuleGeneration(0)
+	}
+	return t.generation
+}
+
+// Generation identifies the symbol table revision used to resolve an address.
+// The concrete bit layout is internal to kallsyms.
+type Generation uint64
+
+const generationBPFBit Generation = 1
+
+func makeModuleGeneration(generation uint64) Generation {
+	return Generation(generation << 1)
+}
+
+func makeBPFGeneration(generation uint64) Generation {
+	return Generation(generation<<1) | generationBPFBit
+}
+
+func (g Generation) isBPF() bool {
+	return g&generationBPFBit != 0
+}
+
+func (g Generation) next() Generation {
+	// Generation values use the low bit to encode the symbol source.
+	// Adding 2 here does not affect the source bit.
+	return g + 2
+}
+
+// SymbolSource identifies which kernel symbol source resolved an address.
+type SymbolSource uint8
+
+const (
+	SymbolSourceBPF SymbolSource = iota + 1
+	SymbolSourceModule
+)
+
+// AddressResolution is the symbol source and generation covering an address.
+type AddressResolution struct {
+	Source     SymbolSource
+	Generation Generation
+	BPFName    string
+	BPFOffset  uint
+	Module     *Module
+}
+
 func compareModule(a, b Module) int {
 	if a.start > b.start {
 		return -1
@@ -91,7 +151,7 @@ func compareModule(a, b Module) int {
 // Symbolizer provides the main API for reading, updating and querying
 // the kernel symbols.
 type Symbolizer struct {
-	modules atomic.Value
+	modules atomic.Pointer[moduleTable]
 
 	bpf *bpfSymbolizer
 
@@ -286,7 +346,8 @@ func (s *Symbolizer) updateSymbolsFrom(r io.Reader) error {
 	var names []byte
 
 	noSymbols := true
-	modules, _ := s.modules.Load().([]Module)
+	oldTable := s.modules.Load()
+	modules := oldTable.Modules()
 
 	// The kallsyms symbol order is the following:
 	// 1. kernel symbols (from compressed kallsyms)
@@ -477,7 +538,10 @@ func (s *Symbolizer) updateSymbolsFrom(r io.Reader) error {
 
 	// Heap allocate the exact amount needed. This also makes the initial
 	// buffer stack allocated.
-	s.modules.Store(slices.Clone(mods))
+	s.modules.Store(&moduleTable{
+		generation: oldTable.symbolGeneration().next(),
+		modules:    slices.Clone(mods),
+	})
 	return nil
 }
 
@@ -506,7 +570,8 @@ func (s *Symbolizer) loadModules() (bool, error) {
 	defer dir.Close()
 
 	needReloadSymbols := false
-	modules, _ := s.modules.Load().([]Module)
+	oldTable := s.modules.Load()
+	modules := oldTable.Modules()
 	mods := make([]Module, 0, 400)
 
 	// Copy the modules not present in sysfs
@@ -554,7 +619,10 @@ func (s *Symbolizer) loadModules() (bool, error) {
 	slices.SortFunc(mods, compareModule)
 	// Heap allocate the exact amount needed. This also makes the initial
 	// buffer stack allocated.
-	s.modules.Store(slices.Clone(mods))
+	s.modules.Store(&moduleTable{
+		generation: oldTable.symbolGeneration().next(),
+		modules:    slices.Clone(mods),
+	})
 
 	return needReloadSymbols, nil
 }
@@ -619,7 +687,7 @@ func (s *Symbolizer) pollKobjectClient(_ context.Context, kobjectClient *kobject
 
 // Close frees resources associated with the Symbolizer.
 func (s *Symbolizer) Close() {
-	s.bpf.Close()
+	s.bpf.close()
 }
 
 // StartMonitor starts the update monitoring for kallsyms.
@@ -630,7 +698,7 @@ func (s *Symbolizer) StartMonitor(ctx context.Context, onlineCPUs []int) error {
 	}
 	err = s.bpf.startMonitor(ctx, onlineCPUs)
 	if err != nil {
-		s.bpf.Close()
+		s.bpf.close()
 		_ = kobjectClient.Close()
 		return err
 	}
@@ -655,14 +723,72 @@ func getModuleByAddress(modules []Module, pc libpf.Address) (*Module, error) {
 	return m, nil
 }
 
+// Snapshot is an immutable view of the kernel and BPF symbol tables.
+type Snapshot struct {
+	bpf     *bpfSymbolTable
+	modules *moduleTable
+}
+
+// Snapshot returns a consistent symbolizer view suitable for repeated lookups.
+func (s *Symbolizer) Snapshot() Snapshot {
+	snapshot := Snapshot{
+		modules: s.modules.Load(),
+	}
+	if s.bpf != nil {
+		snapshot.bpf = s.bpf.table.Load()
+	}
+	return snapshot
+}
+
+// IsGenerationValid reports whether generation is still current in this snapshot.
+func (s Snapshot) IsGenerationValid(generation Generation) bool {
+	if generation.isBPF() {
+		return s.bpf != nil && s.bpf.generation == generation
+	}
+	return s.modules != nil && s.modules.symbolGeneration() == generation
+}
+
+// ResolveAddress finds the symbol source containing addr. BPF symbols are
+// preferred over module symbols because they are tracked separately.
+func (s Snapshot) ResolveAddress(addr libpf.Address) (AddressResolution, bool) {
+	if s.bpf != nil {
+		name, offset, ok := s.bpf.lookup(addr)
+		if ok {
+			return AddressResolution{
+				Source:     SymbolSourceBPF,
+				Generation: s.bpf.symbolGeneration(),
+				BPFName:    name,
+				BPFOffset:  offset,
+			}, true
+		}
+	}
+	if s.modules != nil {
+		module, err := getModuleByAddress(s.modules.Modules(), addr)
+		if err == nil {
+			return AddressResolution{
+				Source:     SymbolSourceModule,
+				Generation: s.modules.symbolGeneration(),
+				Module:     module,
+			}, true
+		}
+	}
+	return AddressResolution{}, false
+}
+
 // GetModuleByAddress finds the Module containing the address 'pc'.
-func (s *Symbolizer) GetModuleByAddress(pc libpf.Address) (*Module, error) {
-	return getModuleByAddress(s.modules.Load().([]Module), pc)
+func (s Snapshot) GetModuleByAddress(pc libpf.Address) (*Module, error) {
+	if s.modules == nil {
+		return nil, ErrNoModule
+	}
+	return getModuleByAddress(s.modules.Modules(), pc)
 }
 
 // GetModuleByName finds the Module with the given name.
-func (s *Symbolizer) GetModuleByName(module string) (*Module, error) {
-	modules := s.modules.Load().([]Module)
+func (s Snapshot) GetModuleByName(module string) (*Module, error) {
+	if s.modules == nil {
+		return nil, ErrNoModule
+	}
+	modules := s.modules.Modules()
 	for i := range modules {
 		kmod := &modules[i]
 		if kmod.Name() == module {
@@ -674,9 +800,9 @@ func (s *Symbolizer) GetModuleByName(module string) (*Module, error) {
 
 // LookupBPFSymbol resolves addr to a BPF program symbol name and offset.
 // Returns ("", 0, false) if no BPF program covers addr.
-func (s *Symbolizer) LookupBPFSymbol(addr libpf.Address) (string, uint, bool) {
+func (s Snapshot) LookupBPFSymbol(addr libpf.Address) (string, uint, bool) {
 	if s.bpf == nil {
 		return "", 0, false
 	}
-	return s.bpf.LookupSymbol(addr)
+	return s.bpf.lookup(addr)
 }

--- a/kallsyms/kallsyms_test.go
+++ b/kallsyms/kallsyms_test.go
@@ -20,7 +20,7 @@ import (
 
 func assertSymbol(t *testing.T, s *Symbolizer, pc libpf.Address,
 	eModName, eFuncName string, eOffset uint) {
-	kmod, err := s.GetModuleByAddress(pc)
+	kmod, err := s.Snapshot().GetModuleByAddress(pc)
 	if assert.NoError(t, err) && assert.Equal(t, kmod.Name(), eModName) {
 		funcName, offset, err := kmod.LookupSymbolByAddress(pc)
 		if assert.NoError(t, err) {
@@ -32,7 +32,11 @@ func assertSymbol(t *testing.T, s *Symbolizer, pc libpf.Address,
 
 func TestKallSyms(t *testing.T) {
 	// override the metadata loading to avoid mixing data from running system
+	oldLoadModuleMetadata := loadModuleMetadata
 	loadModuleMetadata = func(_ *Module, _ string, _ int64) bool { return true }
+	t.Cleanup(func() {
+		loadModuleMetadata = oldLoadModuleMetadata
+	})
 
 	s := &Symbolizer{}
 
@@ -64,13 +68,14 @@ ffffffffc03cc9d0 t perf_trace_xfs_fs_class	[xfs]
 ffffffffc03ccb20 t perf_trace_xfs_inodegc_shrinker_scan	[xfs]`))
 	require.NoError(t, err)
 
-	_, err = s.GetModuleByName("foo")
+	snap := s.Snapshot()
+	_, err = snap.GetModuleByName("foo")
 	assert.Equal(t, err, ErrNoModule)
 
-	_, err = s.GetModuleByAddress(0x1010)
+	_, err = snap.GetModuleByAddress(0x1010)
 	assert.Equal(t, err, ErrNoModule)
 
-	_, err = s.GetModuleByAddress(0xffffffffffff0000)
+	_, err = snap.GetModuleByAddress(0xffffffffffff0000)
 	assert.Equal(t, err, ErrNoModule)
 
 	assertSymbol(t, s, 0xffffffffb5000470, Kernel, "startup_64_setup_gdt_idt", 0)
@@ -99,14 +104,124 @@ ffffffffc1400000 t foo	[foo]
 ffffffffc13fcb20 t init_xfs_fs	[xfs]`))
 	require.NoError(t, err)
 
-	_, err = s.GetModuleByAddress(0xffffffffc03cc610 + 1)
+	snap = s.Snapshot()
+	_, err = snap.GetModuleByAddress(0xffffffffc03cc610 + 1)
 	assert.Equal(t, ErrNoModule, err)
 
-	_, err = s.GetModuleByAddress(0xffffffffc13fcb20)
+	_, err = snap.GetModuleByAddress(0xffffffffc13fcb20)
 	assert.Equal(t, ErrNoModule, err)
 
 	assertSymbol(t, s, 0xffffffffb5000470, "vmlinux", "startup_64_setup_gdt_idt", 0)
 	assertSymbol(t, s, 0xffffffffc13cc610+1, "xfs", "perf_trace_xfs_attr_list_class", 1)
+}
+
+func TestModuleSnapshotGenerations(t *testing.T) {
+	oldLoadModuleMetadata := loadModuleMetadata
+	loadModuleMetadata = func(_ *Module, _ string, _ int64) bool { return true }
+	t.Cleanup(func() {
+		loadModuleMetadata = oldLoadModuleMetadata
+	})
+
+	s := &Symbolizer{}
+
+	err := s.updateSymbolsFrom(strings.NewReader(`ffffffffb5000000 T _text
+ffffffffb5000123 T startup_64
+ffffffffb6000000 T _etext
+ffffffffc03cc610 t perf_trace_xfs_attr_list_class	[xfs]
+ffffffffc03cc770 t perf_trace_xfs_perag_class	[xfs]`))
+	require.NoError(t, err)
+
+	snap1 := s.Snapshot()
+	require.NotNil(t, snap1.modules)
+	assert.Equal(t, makeModuleGeneration(1), snap1.modules.generation)
+	kmod, err := snap1.GetModuleByAddress(0xffffffffc03cc610)
+	require.NoError(t, err)
+	assert.Equal(t, "xfs", kmod.Name())
+
+	err = s.updateSymbolsFrom(strings.NewReader(`ffffffffb5000000 T _text
+ffffffffb5000123 T startup_64
+ffffffffb6000000 T _etext
+ffffffffc13cc610 t perf_trace_xfs_attr_list_class	[xfs]
+ffffffffc13cc770 t perf_trace_xfs_perag_class	[xfs]`))
+	require.NoError(t, err)
+
+	snap2 := s.Snapshot()
+	require.NotNil(t, snap2.modules)
+	assert.Equal(t, makeModuleGeneration(2), snap2.modules.generation)
+
+	kmod, err = snap1.GetModuleByAddress(0xffffffffc03cc610)
+	require.NoError(t, err)
+	assert.Equal(t, "xfs", kmod.Name())
+
+	_, err = snap2.GetModuleByAddress(0xffffffffc03cc610)
+	assert.ErrorIs(t, err, ErrNoModule)
+	kmod, err = snap2.GetModuleByAddress(0xffffffffc13cc610)
+	require.NoError(t, err)
+	assert.Equal(t, "xfs", kmod.Name())
+}
+
+func TestSnapshotResolveAddressGenerationValidity(t *testing.T) {
+	oldLoadModuleMetadata := loadModuleMetadata
+	loadModuleMetadata = func(_ *Module, _ string, _ int64) bool { return true }
+	t.Cleanup(func() {
+		loadModuleMetadata = oldLoadModuleMetadata
+	})
+
+	s := &Symbolizer{
+		bpf: &bpfSymbolizer{},
+	}
+
+	const (
+		moduleAddr = libpf.Address(0xffffffffc03cc610)
+		bpfAddr    = moduleAddr + 1
+	)
+
+	err := s.updateSymbolsFrom(strings.NewReader(`ffffffffb5000000 T _text
+ffffffffb5000123 T startup_64
+ffffffffb6000000 T _etext
+ffffffffc03cc610 t perf_trace_xfs_attr_list_class	[xfs]
+ffffffffc03cc770 t perf_trace_xfs_perag_class	[xfs]`))
+	require.NoError(t, err)
+
+	setBPFSymbols(s.bpf, []bpfSymbol{
+		{address: bpfAddr, size: 512, name: "bpf_prog_test"},
+	})
+
+	snap1 := s.Snapshot()
+	moduleResolution, ok := snap1.ResolveAddress(moduleAddr)
+	require.True(t, ok)
+	assert.Equal(t, SymbolSourceModule, moduleResolution.Source)
+	require.NotNil(t, moduleResolution.Module)
+	assert.Equal(t, "xfs", moduleResolution.Module.Name())
+	assert.True(t, snap1.IsGenerationValid(moduleResolution.Generation))
+
+	bpfResolution, ok := snap1.ResolveAddress(bpfAddr)
+	require.True(t, ok)
+	assert.Equal(t, SymbolSourceBPF, bpfResolution.Source)
+	assert.Equal(t, "bpf_prog_test", bpfResolution.BPFName)
+	assert.Equal(t, uint(0), bpfResolution.BPFOffset)
+	assert.True(t, snap1.IsGenerationValid(bpfResolution.Generation))
+
+	err = s.bpf.handleBPFUpdate(&perf.KSymbolRecord{
+		Addr:  uint64(bpfAddr),
+		Name:  "bpf_prog_test",
+		Flags: unix.PERF_RECORD_KSYMBOL_FLAGS_UNREGISTER,
+	})
+	require.NoError(t, err)
+
+	snap2 := s.Snapshot()
+	assert.False(t, snap2.IsGenerationValid(bpfResolution.Generation))
+	assert.True(t, snap2.IsGenerationValid(moduleResolution.Generation))
+
+	err = s.updateSymbolsFrom(strings.NewReader(`ffffffffb5000000 T _text
+ffffffffb5000123 T startup_64
+ffffffffb6000000 T _etext
+ffffffffc13cc610 t perf_trace_xfs_attr_list_class	[xfs]
+ffffffffc13cc770 t perf_trace_xfs_perag_class	[xfs]`))
+	require.NoError(t, err)
+
+	snap3 := s.Snapshot()
+	assert.False(t, snap3.IsGenerationValid(moduleResolution.Generation))
 }
 
 // setBPFSymbols stores the given symbols in the bpfSymbolizer as a sorted
@@ -117,14 +232,17 @@ func setBPFSymbols(s *bpfSymbolizer, symbols []bpfSymbol) {
 	slices.SortFunc(sorted, func(a, b bpfSymbol) int {
 		return cmp.Compare(a.address, b.address)
 	})
-	s.table.Store(&bpfSymbolTable{symbols: sorted})
+	s.table.Store(&bpfSymbolTable{
+		generation: makeBPFGeneration(1),
+		symbols:    sorted,
+	})
 }
 
 // assertBPFSymbol checks that the BPF symbolizer resolves addr to the expected
 // function name and offset.
 func assertBPFSymbol(t *testing.T, s *Symbolizer, addr libpf.Address, eFuncName string, eOffset uint) {
 	t.Helper()
-	funcName, off, ok := s.LookupBPFSymbol(addr)
+	funcName, off, ok := s.Snapshot().LookupBPFSymbol(addr)
 	if assert.True(t, ok, "expected BPF symbol at 0x%x", addr) {
 		assert.Equal(t, eFuncName, funcName)
 		assert.Equal(t, eOffset, off)
@@ -134,7 +252,7 @@ func assertBPFSymbol(t *testing.T, s *Symbolizer, addr libpf.Address, eFuncName 
 // assertNoBPFSymbol checks that the BPF symbolizer does not resolve addr.
 func assertNoBPFSymbol(t *testing.T, s *Symbolizer, addr libpf.Address) {
 	t.Helper()
-	_, _, ok := s.LookupBPFSymbol(addr)
+	_, _, ok := s.Snapshot().LookupBPFSymbol(addr)
 	assert.False(t, ok, "expected no BPF symbol at 0x%x", addr)
 }
 
@@ -257,6 +375,46 @@ func TestBPFUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assertNoBPFSymbol(t, s, 0xffffffc080f26000)
+}
+
+func TestBPFSnapshotGenerations(t *testing.T) {
+	s := &Symbolizer{
+		bpf: &bpfSymbolizer{},
+	}
+
+	const addr = libpf.Address(0xffffffc080f26228)
+	setBPFSymbols(s.bpf, []bpfSymbol{
+		{address: addr, size: 512, name: "bpf_prog_00354c172d366337_sd_devices"},
+	})
+
+	snap1 := s.Snapshot()
+	require.NotNil(t, snap1.bpf)
+	bpfGen1 := snap1.bpf.generation
+	assert.Equal(t, makeBPFGeneration(1), bpfGen1)
+	assertBPFSymbol(t, s, addr, "bpf_prog_00354c172d366337_sd_devices", 0)
+
+	err := s.bpf.handleBPFUpdate(nil)
+	assert.Error(t, err)
+	snapAfterLost := s.Snapshot()
+	require.NotNil(t, snapAfterLost.bpf)
+	assert.Equal(t, bpfGen1, snapAfterLost.bpf.generation)
+
+	err = s.bpf.handleBPFUpdate(&perf.KSymbolRecord{
+		Addr:  uint64(addr),
+		Name:  "bpf_prog_00354c172d366337_sd_devices",
+		Flags: unix.PERF_RECORD_KSYMBOL_FLAGS_UNREGISTER,
+	})
+	require.NoError(t, err)
+
+	snap2 := s.Snapshot()
+	require.NotNil(t, snap2.bpf)
+	assert.Equal(t, makeBPFGeneration(2), snap2.bpf.generation)
+	assertNoBPFSymbol(t, s, addr)
+
+	funcName, off, ok := snap1.LookupBPFSymbol(addr)
+	require.True(t, ok)
+	assert.Equal(t, "bpf_prog_00354c172d366337_sd_devices", funcName)
+	assert.Equal(t, uint(0), off)
 }
 
 func BenchmarkSort(b *testing.B) {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -18,12 +18,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/link"
+	lru "github.com/elastic/go-freelru"
 	"github.com/elastic/go-perf"
 	"go.opentelemetry.io/ebpf-profiler/internal/linux"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
@@ -52,6 +54,9 @@ const (
 	// ProbabilisticThresholdMax defines the upper bound of the probabilistic profiling
 	// threshold.
 	ProbabilisticThresholdMax = 100
+
+	// Maximum size of the LRU cache for symbolized kernel frames.
+	kernelFrameCacheSize = 16384
 )
 
 // Constants that define the status of probabilistic profiling.
@@ -84,6 +89,11 @@ type Intervals interface {
 // onlineCPUs once resolves and caches the list of online CPUs.
 var onlineCPUsOnce = sync.OnceValues(getOnlineCPUIDs)
 
+type kernelFrameCacheValue struct {
+	generation kallsyms.Generation
+	frame      unique.Handle[libpf.Frame]
+}
+
 // Tracer provides an interface for loading and initializing the eBPF components as
 // well as for monitoring the output maps for new traces and count updates.
 type Tracer struct {
@@ -94,6 +104,10 @@ type Tracer struct {
 
 	// kernelSymbolizer does kernel fallback symbolization
 	kernelSymbolizer *kallsyms.Symbolizer
+
+	// kernelFrameCache stores kernel address to symbolized frame mappings.
+	// Values carry the symbol source generation used to produce the frame.
+	kernelFrameCache *lru.LRU[libpf.Address, kernelFrameCacheValue]
 
 	// perfEntrypoints holds a list of frequency based perf events that are opened on the system.
 	perfEntrypoints xsync.RWMutex[[]*perf.Event]
@@ -242,7 +256,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to read kernel symbols: %v", err)
 	}
 
-	kmod, err := kernelSymbolizer.GetModuleByName(kallsyms.Kernel)
+	kmod, err := kernelSymbolizer.Snapshot().GetModuleByName(kallsyms.Kernel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kernel symbols: %v", err)
 	}
@@ -266,10 +280,17 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}
 
+	kernelFrameCache, err := lru.New[libpf.Address, kernelFrameCacheValue](
+		kernelFrameCacheSize, libpf.Address.Hash32)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create kernelFrameCache: %v", err)
+	}
+
 	perfEventList := []*perf.Event{}
 
 	tracer := &Tracer{
 		kernelSymbolizer:       kernelSymbolizer,
+		kernelFrameCache:       kernelFrameCache,
 		processManager:         processManager,
 		triggerPIDProcessing:   make(chan bool, 1),
 		tracePool:              newTracePool(),
@@ -916,31 +937,69 @@ func loadProgram(ebpfProgs map[string]*cebpf.Program, tailcallMap *cebpf.Map,
 	return nil
 }
 
+func symbolizeBPFFrame(name string, offset uint) unique.Handle[libpf.Frame] {
+	return unique.Make(libpf.Frame{
+		Type:            libpf.KernelFrame,
+		AddressOrLineno: libpf.AddressOrLineno(offset),
+		FunctionName:    libpf.Intern(name),
+	})
+}
+
+func symbolizeKernelFrame(
+	address libpf.Address,
+	resolution kallsyms.AddressResolution,
+) unique.Handle[libpf.Frame] {
+	if resolution.Source == kallsyms.SymbolSourceBPF {
+		return symbolizeBPFFrame(resolution.BPFName, resolution.BPFOffset)
+	}
+
+	frame := libpf.Frame{
+		Type:            libpf.KernelFrame,
+		AddressOrLineno: libpf.AddressOrLineno(address - 1),
+	}
+
+	if kmod := resolution.Module; kmod != nil {
+		frame.Mapping = kmod.Mapping()
+		frame.AddressOrLineno -= libpf.AddressOrLineno(kmod.Start())
+		if funcName, _, err := kmod.LookupSymbolByAddress(address); err == nil {
+			frame.FunctionName = libpf.Intern(funcName)
+		}
+	}
+
+	return unique.Make(frame)
+}
+
 // symbolizeKernelFrames converts raw kernel addresses into symbolized frames.
 func (t *Tracer) symbolizeKernelFrames(addrs []uint64, oldFrames libpf.Frames) libpf.Frames {
-	frames := oldFrames
-	if len(addrs) > len(frames) {
+	frames := oldFrames[:0]
+	if len(addrs) > cap(frames) {
 		frames = make(libpf.Frames, 0, len(addrs))
 	}
+
+	snapshot := t.kernelSymbolizer.Snapshot()
+
 	for _, addr := range addrs {
 		address := libpf.Address(addr)
-		frame := libpf.Frame{
-			Type:            libpf.KernelFrame,
-			AddressOrLineno: libpf.AddressOrLineno(address - 1),
+
+		if cached, ok := t.kernelFrameCache.Get(address); ok &&
+			snapshot.IsGenerationValid(cached.generation) {
+			frames = append(frames, cached.frame)
+			continue
 		}
-		if funcName, offset, ok := t.kernelSymbolizer.LookupBPFSymbol(address); ok {
-			// BPF program: use address relative to symbol start for deduplication.
-			frame.AddressOrLineno = libpf.AddressOrLineno(offset)
-			frame.FunctionName = libpf.Intern(funcName)
-		} else if kmod, err := t.kernelSymbolizer.GetModuleByAddress(address); err == nil {
-			frame.Mapping = kmod.Mapping()
-			frame.AddressOrLineno -= libpf.AddressOrLineno(kmod.Start())
-			if funcName, _, err := kmod.LookupSymbolByAddress(address); err == nil {
-				frame.FunctionName = libpf.Intern(funcName)
-			}
+
+		resolution, resolved := snapshot.ResolveAddress(address)
+		frame := symbolizeKernelFrame(address, resolution)
+		if resolved && (resolution.Source == kallsyms.SymbolSourceBPF ||
+			frame.Value().Mapping.Valid()) {
+			t.kernelFrameCache.Add(address, kernelFrameCacheValue{
+				generation: resolution.Generation,
+				frame:      frame,
+			})
 		}
-		frames.Append(&frame)
+
+		frames = append(frames, frame)
 	}
+
 	return frames
 }
 
@@ -1317,7 +1376,7 @@ func (t *Tracer) StartOffCPUProfiling() error {
 		return errors.New("off-cpu program finish_task_switch is not available")
 	}
 
-	kmod, err := t.kernelSymbolizer.GetModuleByName(kallsyms.Kernel)
+	kmod, err := t.kernelSymbolizer.Snapshot().GetModuleByName(kallsyms.Kernel)
 	if err != nil {
 		return err
 	}

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -4,10 +4,48 @@
 package tracer // import "go.opentelemetry.io/ebpf-profiler/tracer"
 
 import (
+	"testing"
+	"unique"
+
 	cebpf "github.com/cilium/ebpf"
+	lru "github.com/elastic/go-freelru"
+
+	"go.opentelemetry.io/ebpf-profiler/kallsyms"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
 // Make accessible for testing
 func (t *Tracer) GetEbpfMaps() map[string]*cebpf.Map {
 	return t.ebpfMaps
+}
+
+func TestSymbolizeKernelFramesIgnoresInvalidCacheEntries(t *testing.T) {
+	kernelFrameCache, err := lru.New[libpf.Address, kernelFrameCacheValue](
+		kernelFrameCacheSize, libpf.Address.Hash32)
+	if err != nil {
+		t.Fatalf("failed to create kernel frame cache: %v", err)
+	}
+
+	cachedFrame := unique.Make(libpf.Frame{
+		Type:            libpf.KernelFrame,
+		AddressOrLineno: 0,
+		FunctionName:    libpf.Intern("cached"),
+	})
+	kernelFrameCache.Add(0x1234, kernelFrameCacheValue{
+		generation: kallsyms.Generation(2),
+		frame:      cachedFrame,
+	})
+
+	tracer := &Tracer{
+		kernelSymbolizer: &kallsyms.Symbolizer{},
+		kernelFrameCache: kernelFrameCache,
+	}
+
+	frames := tracer.symbolizeKernelFrames([]uint64{0x1234}, nil)
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+	if frames[0] == cachedFrame {
+		t.Fatalf("expected stale cache entry to be ignored")
+	}
 }


### PR DESCRIPTION
We see ~13.5% of ebpf-profiler's CPU time spent in `symbolizeKernelFrames`, largely in interning. Having a cache here makes perfect sense.

Unlike with the frame cache in `ProcessManager`, we don't need a TTL here and we can depend on symbolizer generations. The key is different depending on whether the address belongs to any of ebpf ranges or not, which reduces cache churn in cases where bpf programs are loaded frequently.

With these changes in place the cost is down to under 3% of CPU, with 2% of it spent in LRU cache itself.

This makes a significant dent in #1515.

<img width="1512" height="661" alt="image" src="https://github.com/user-attachments/assets/79714bf5-81b4-415a-94fb-a7fa7f9fbe69" />
