### PR TITLE
Cache native frames without interpreters indefinitely

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -76,11 +76,10 @@ func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monit
 	}
 	elfInfoCache.SetLifetime(elfInfoCacheTTL)
 
-	frameCache, err := lru.New[frameCacheKey, libpf.Frames](frameCacheSize, hashFrameCacheKey)
+	frameCache, err := newFrameCache(frameCacheSize, frameCacheLifetime)
 	if err != nil {
 		return nil, err
 	}
-	frameCache.SetLifetime(frameCacheLifetime)
 
 	em, err := eim.NewExecutableInfoManager(sdp, ebpf, interpretersConfig)
 	if err != nil {
@@ -192,6 +191,12 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 }
 
 func (pm *ProcessManager) Close() {
+}
+
+func (pm *ProcessManager) hasInterpreters(pid libpf.PID) bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return len(pm.interpreters[pid]) != 0
 }
 
 func (pm *ProcessManager) symbolizeFrame(pid libpf.PID, data []uint64, frames *libpf.Frames, mapping libpf.FrameMapping) error {
@@ -311,8 +316,54 @@ func (pm *ProcessManager) maybeNotifyAPMAgent(
 
 func hashFrameCacheKey(fk frameCacheKey) uint32 {
 	h := fnv.New32a()
-	h.Write(pfunsafe.FromSlice(fk.data[:]))
+	hasInterpreters := uint64(0)
+	if fk.hasInterpreters {
+		hasInterpreters = 1
+	}
+	data := [5]uint64{
+		uint64(fk.pid),
+		hasInterpreters,
+		fk.data[0],
+		fk.data[1],
+		fk.data[2],
+	}
+	h.Write(pfunsafe.FromSlice(data[:]))
 	return h.Sum32()
+}
+
+type frameCache struct {
+	lru      *lru.LRU[frameCacheKey, libpf.Frames]
+	lifetime time.Duration
+}
+
+func newFrameCache(size uint32, lifetime time.Duration) (*frameCache, error) {
+	cache, err := lru.New[frameCacheKey, libpf.Frames](size, hashFrameCacheKey)
+	if err != nil {
+		return nil, err
+	}
+	return &frameCache{
+		lru:      cache,
+		lifetime: lifetime,
+	}, nil
+}
+
+func (c *frameCache) get(key frameCacheKey) (libpf.Frames, bool) {
+	if key.hasInterpreters {
+		// If there are interpreters, we fetch a key that has a TTL.
+		return c.lru.GetAndRefresh(key, c.lifetime)
+	}
+	// If there are no interpreters, then the frame cannot really change,
+	// so there's no point in putting an expiration time on it and paying
+	// the CPU tax for keeping it updated.
+	return c.lru.Get(key)
+}
+
+func (c *frameCache) add(key frameCacheKey, frames libpf.Frames) {
+	lifetime := c.lifetime
+	if !key.hasInterpreters {
+		lifetime = 0
+	}
+	c.lru.AddWithLifetime(key, frames, lifetime)
 }
 
 // HandleTrace processes and reports the given host.Trace. This function
@@ -347,6 +398,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 
 	cacheMiss := uint64(0)
 	cacheHit := uint64(0)
+	hasInterpreters := pm.hasInterpreters(pid)
 
 	for frames := libpf.EbpfFrame(bpfTrace.FrameData); len(frames) > 0; frames = frames[frames.Length():] {
 		frame := frames[:frames.Length()]
@@ -361,12 +413,14 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 		}
 
 		oldLen := len(trace.Frames)
-		key := frameCacheKey{}
+		key := frameCacheKey{
+			hasInterpreters: hasInterpreters,
+		}
 		if frame.Flags().PIDSpecific() {
 			key.pid = pid
 		}
 		copy(key.data[:], frame)
-		if cached, ok := pm.frameCache.GetAndRefresh(key, frameCacheLifetime); ok {
+		if cached, ok := pm.frameCache.get(key); ok {
 			// Fast path
 			cacheHit++
 			trace.Frames = append(trace.Frames, cached...)
@@ -374,7 +428,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 			// Slow path: convert trace.
 			if pm.convertFrame(pid, frame, &trace.Frames) {
 				cacheMiss++
-				pm.frameCache.Add(key, slices.Clone(trace.Frames[oldLen:len(trace.Frames)]))
+				pm.frameCache.add(key, slices.Clone(trace.Frames[oldLen:len(trace.Frames)]))
 			}
 		}
 	}

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -5,8 +5,8 @@ import (
 	"runtime"
 	"slices"
 	"testing"
+	"time"
 
-	lru "github.com/elastic/go-freelru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -67,9 +67,8 @@ func TestFrameCacheCrossProcessPollution(t *testing.T) {
 
 	goODID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 1}
 
-	frameCache, err := lru.New[frameCacheKey, libpf.Frames](1024, hashFrameCacheKey)
+	frameCache, err := newFrameCache(1024, frameCacheLifetime)
 	require.NoError(t, err)
-	frameCache.SetLifetime(frameCacheLifetime)
 
 	goMappings := []Mapping{
 		{FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
@@ -156,6 +155,11 @@ func TestFrameCacheCrossProcessPollution(t *testing.T) {
 	catFrame := catTrace.Frames[0].Value()
 	assert.Equal(t, libpf.NativeFrame, catFrame.Type)
 	assert.Equal(t, "", catFrame.FunctionName.String())
+
+	// The Go PID has an interpreter and the cat PID does not, so their native
+	// fallback frames must use distinct cache keys.
+	assert.Equal(t, uint64(2), pm.frameCacheMiss.Load())
+	assert.Equal(t, uint64(0), pm.frameCacheHit.Load())
 }
 
 func TestFrameCacheSharesNativeFallbackFramesAcrossProcesses(t *testing.T) {
@@ -165,9 +169,10 @@ func TestFrameCacheSharesNativeFallbackFramesAcrossProcesses(t *testing.T) {
 		[]byte{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE})
 	require.NoError(t, err)
 
-	frameCache, err := lru.New[frameCacheKey, libpf.Frames](1024, hashFrameCacheKey)
+	frameCache, err := newFrameCache(1024, time.Nanosecond)
 	require.NoError(t, err)
-	frameCache.SetLifetime(frameCacheLifetime)
+	// Make interpreter-aware entries expire immediately; no-interpreter entries
+	// should still survive because the wrapper inserts them with lifetime 0.
 
 	mappings := []Mapping{
 		{FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
@@ -198,6 +203,9 @@ func TestFrameCacheSharesNativeFallbackFramesAcrossProcesses(t *testing.T) {
 		NumFrames: 1,
 		FrameData: nativeFrame,
 	})
+	// No-interpreter native fallback frames are inserted with no per-entry
+	// expiration, even when the cache default lifetime is tiny.
+	time.Sleep(time.Millisecond)
 	pm.HandleTrace(&libpf.EbpfTrace{
 		PID:       secondPID,
 		TID:       secondPID,

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -36,6 +36,9 @@ type elfInfo struct {
 type frameCacheKey struct {
 	// pid is the PID of the process if the frame had FRAME_FLAG_PID_SPECIFIC set
 	pid libpf.PID
+	// hasInterpreters indicates whether the process had interpreter instances
+	// when the frame was cached.
+	hasInterpreters bool
 	// data is the frame data: frame header and the two first variable fields
 	data [3]uint64
 }
@@ -93,7 +96,7 @@ type ProcessManager struct {
 	// frameCache stores mappings from BPF frame to the symbolized frames.
 	// This allows avoiding the overhead of re-doing user-mode symbolization
 	// of frames that we have recently seen already.
-	frameCache *lru.LRU[frameCacheKey, libpf.Frames]
+	frameCache *frameCache
 
 	// traceReporter is the interface to report traces
 	traceReporter reporter.TraceReporter


### PR DESCRIPTION
We see about 2% of CPU spent in `github.com/elastic/go-freelru.expire`. This doesn't seem productive, as we pretty much only run native binaries, where it doesn't make sense to expire anything, so it feels wasteful to burn CPU on timekeeping.

<img width="1512" height="559" alt="image" src="https://github.com/user-attachments/assets/098d9bbc-3cc4-4973-80db-b067b1e39839" />

This change splits the keys into the ones that need a TTL (if a process has any interpreters) and the ones that don't (native ones).