### PR TITLE
Remove TTL from frameCache

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -45,9 +45,6 @@ const (
 
 	// Maximum size of the LRU cache for frames.
 	frameCacheSize = 16384
-
-	// TTL of entries in the frame cache.
-	frameCacheLifetime = 5 * time.Minute
 )
 
 // dummyPrefix is the LPM prefix installed to indicate the process is known
@@ -80,7 +77,6 @@ func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monit
 	if err != nil {
 		return nil, err
 	}
-	frameCache.SetLifetime(frameCacheLifetime)
 
 	em, err := eim.NewExecutableInfoManager(sdp, ebpf, interpretersConfig)
 	if err != nil {
@@ -366,7 +362,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 			key.pid = pid
 		}
 		copy(key.data[:], frame)
-		if cached, ok := pm.frameCache.GetAndRefresh(key, frameCacheLifetime); ok {
+		if cached, ok := pm.frameCache.Get(key); ok {
 			// Fast path
 			cacheHit++
 			trace.Frames = append(trace.Frames, cached...)

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -69,7 +69,6 @@ func TestFrameCacheCrossProcessPollution(t *testing.T) {
 
 	frameCache, err := lru.New[frameCacheKey, libpf.Frames](1024, hashFrameCacheKey)
 	require.NoError(t, err)
-	frameCache.SetLifetime(frameCacheLifetime)
 
 	goMappings := []Mapping{
 		{FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
@@ -167,7 +166,6 @@ func TestFrameCacheSharesNativeFallbackFramesAcrossProcesses(t *testing.T) {
 
 	frameCache, err := lru.New[frameCacheKey, libpf.Frames](1024, hashFrameCacheKey)
 	require.NoError(t, err)
-	frameCache.SetLifetime(frameCacheLifetime)
 
 	mappings := []Mapping{
 		{FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{


### PR DESCRIPTION
We see about 2% of CPU spent in `github.com/elastic/go-freelru.expire`. The outputs cannot change, so there's no point in having any TTL and especially no point in spending CPU to maintain it.

See: https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1574#discussion_r3503808771