### PR TITLE
elfgopclntab: rework file and function strategy handling

### DIFF
--- a/libpf/pfbufio/reader.go
+++ b/libpf/pfbufio/reader.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math"
 	"sync"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
@@ -236,6 +237,31 @@ func (r *Reader) ReadSlice(delim byte) ([]byte, error) {
 func (r *Reader) ReadString(delim byte) (string, error) {
 	slice, err := r.ReadSlice(delim)
 	return pfunsafe.ToString(slice), err
+}
+
+// WalkStrings reads up to 'n' strings and calls the callback for each string
+// with its offset from the original reader start.
+// The string points to the internal buffer and is invalid after callback returns.
+func (r *Reader) WalkStrings(n int, fn func (offset int64, s string) error) error {
+	for i := n; i > 0; i-- {
+		offset := r.Tell()
+		s, err := r.ReadString(0)
+		if err != nil {
+			return err
+		}
+		if err = fn(offset, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WalkAllStrings is similar to WalkStrings, but walks all strings until EOF.
+func (r *Reader) WalkAllStrings(fn func (offset int64, s string) error) error {
+	if err := r.WalkStrings(math.MaxInt, fn); err != io.EOF {
+		return err
+	}
+	return nil
 }
 
 // SearchSlice moves the reader position to immediately AFTER the pattern.

--- a/libpf/pfbufio/reader.go
+++ b/libpf/pfbufio/reader.go
@@ -242,7 +242,7 @@ func (r *Reader) ReadString(delim byte) (string, error) {
 // WalkStrings reads up to 'n' strings and calls the callback for each string
 // with its offset from the original reader start.
 // The string points to the internal buffer and is invalid after callback returns.
-func (r *Reader) WalkStrings(n int, fn func (offset int64, s string) error) error {
+func (r *Reader) WalkStrings(n int, fn func(offset int64, s string) error) error {
 	for i := n; i > 0; i-- {
 		offset := r.Tell()
 		s, err := r.ReadString(0)
@@ -257,7 +257,7 @@ func (r *Reader) WalkStrings(n int, fn func (offset int64, s string) error) erro
 }
 
 // WalkAllStrings is similar to WalkStrings, but walks all strings until EOF.
-func (r *Reader) WalkAllStrings(fn func (offset int64, s string) error) error {
+func (r *Reader) WalkAllStrings(fn func(offset int64, s string) error) error {
 	if err := r.WalkStrings(math.MaxInt, fn); err != io.EOF {
 		return err
 	}

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -519,8 +519,8 @@ func (f *File) Section(name string) *Section {
 	return nil
 }
 
-// findVirtualAddressProg determines the Prog header containing the virtual address.
-func (f *File) findVirtualAddressProg(addr uint64) *Prog {
+// ProgByVirtualAddress searches the Prog header containing the virtual address.
+func (f *File) ProgByVirtualAddress(addr uint64) *Prog {
 	// Search for the Program header that contains the start address.
 	for _, ph := range f.loadData {
 		if addr >= ph.Vaddr && addr < ph.Vaddr+ph.Memsz {
@@ -537,7 +537,7 @@ func (f *File) VirtualMemory(addr int64, sz, maxSize int) ([]byte, error) {
 	if sz == 0 {
 		return nil, nil
 	}
-	if ph := f.findVirtualAddressProg(uint64(addr)); ph != nil {
+	if ph := f.ProgByVirtualAddress(uint64(addr)); ph != nil {
 		offset := addr - int64(ph.Vaddr)
 		if offset+int64(sz) <= int64(ph.Filesz) {
 			if mapping, ok := ph.elfReader.(*mmap.ReaderAt); ok {
@@ -1032,7 +1032,7 @@ func (f *File) ReadAt(p []byte, addr int64) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if ph := f.findVirtualAddressProg(uint64(addr)); ph != nil {
+	if ph := f.ProgByVirtualAddress(uint64(addr)); ph != nil {
 		return ph.ReadAt(p, addr-int64(ph.Vaddr))
 	}
 	return 0, fmt.Errorf("no matching segment for 0x%x", uint64(addr))

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -331,7 +331,11 @@ func extractGoPclntab(ef *pfelf.File) (data []byte, offset int64, err error) {
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: %v", err)
 			}
-			offset = int64(start)
+			p := ef.ProgByVirtualAddress(uint64(start))
+			if p != nil {
+				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: unmappable virtual address")
+			}
+			offset = int64(start) - int64(p.Vaddr)
 		}
 	}
 	return data, offset, nil
@@ -421,15 +425,15 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 		funcMapSize:  hdr.ptrSize * 2,
 		numFuncs:     int(hdr.numFuncs),
 	}
-	if g.version == goInvalid || hdr.pad != 0 || hdr.ptrSize != 8 {
-		return nil, fmt.Errorf(".gopclntab header: %x, %x, %x", hdr.magic, hdr.pad, hdr.ptrSize)
+	if hdr.pad != 0 || hdr.ptrSize != 8 {
+		g.version = goInvalid
 	}
 
 	switch g.version {
 	case go1_16:
 		hdrSize = unsafe.Sizeof(pclntabHeader116{})
 		if dataLen < hdrSize {
-			return nil, fmt.Errorf(".gopclntab is too short (%v)", len(data))
+			return nil, fmt.Errorf("too short header (%v)", len(data))
 		}
 		hdr116 := (*pclntabHeader116)(unsafe.Pointer(&data[0]))
 		g.numFiles = hdr116.nfiles
@@ -441,7 +445,7 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 	case go1_18, go1_20:
 		hdrSize = unsafe.Sizeof(pclntabHeader118{})
 		if dataLen < hdrSize {
-			return nil, fmt.Errorf(".gopclntab is too short (%v)", dataLen)
+			return nil, fmt.Errorf("too short header (%v)", dataLen)
 		}
 		hdr118 := (*pclntabHeader118)(unsafe.Pointer(&data[0]))
 		g.numFiles = hdr118.nfiles
@@ -469,26 +473,24 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 		g.funcMapSize = 2 * 4
 		g.funSize = 4 + uint8(unsafe.Sizeof(pclntabFunc{}))
 	default:
-		return nil, fmt.Errorf("unsupported goplntab version (%x)", hdr.magic)
+		return nil, fmt.Errorf("unsupported header: %x, %x, %x", hdr.magic, hdr.pad, hdr.ptrSize)
 	}
 
 	if g.funcnameOffset >= g.cuOffset ||
 		g.cuOffset >= g.filetabOffset ||
 		g.filetabOffset >= g.pctabOffset ||
 		g.pctabOffset >= g.pclnOffset ||
-		g.pclnOffset >= dataLen {
-		return nil, fmt.Errorf("gopclntab is corrupt (%x, %x, %x, %x, %x)",
-			g.funcnameOffset, g.cuOffset,
-			g.filetabOffset, g.pctabOffset,
-			g.pclnOffset)
+		g.pclnOffset >= dataLen ||
+		int64(g.numFuncs)*int64(g.funcMapSize) > int64(len(data))-int64(g.pclnOffset) {
+		return nil, fmt.Errorf("corrupt header (%x < %x < %x < %x < %x)",
+			g.funcnameOffset, g.cuOffset, g.filetabOffset, g.pctabOffset, g.pclnOffset)
 	}
 
-	g.funcnametab = data[g.funcnameOffset:]
-	g.cutab = data[g.cuOffset:]
-	g.filetab = data[g.filetabOffset:]
-	g.pctab = data[g.pctabOffset:]
+	g.funcnametab = data[g.funcnameOffset:g.cuOffset]
+	g.cutab = data[g.cuOffset:g.filetabOffset]
+	g.filetab = data[g.filetabOffset:g.pctabOffset]
+	g.pctab = data[g.pctabOffset:g.pclnOffset]
 	g.functab = data[g.pclnOffset:]
-
 	g.dataRef = ef.Take()
 	g.setDontNeed = ef.SetDontNeed
 
@@ -648,7 +650,7 @@ func getSourceFileStrategyX86(sourceFile string) strategy {
 }
 
 // getFunctionDelta determines the special unwind opcode if needed
-func getFunctionUnwindInfo(sourceFile string, arch elf.Machine, framePointerReliable bool) *sdtypes.UnwindInfo {
+func getFunctionUnwindInfo(sourceFile string, arch elf.Machine, useFP bool) *sdtypes.UnwindInfo {
 	switch sourceFile {
 	case "runtime.goexit", "runtime.mstart":
 		// goexit - return address in all goroutine stacks
@@ -665,10 +667,10 @@ func getFunctionUnwindInfo(sourceFile string, arch elf.Machine, framePointerReli
 	case "runtime.systemstack", "runtime.nanotime1", "time.now", "runtime.walltime":
 		// functions which preserve the frame pointer chain across the g0/user stack boundary
 		// so that the standard FP unwinding traverses it naturally.
-		if !framePointerReliable {
-			return &sdtypes.UnwindInfoStop
+		if useFP {
+			return &sdtypes.UnwindInfoFramePointer
 		}
-		return &sdtypes.UnwindInfoFramePointer
+		return &sdtypes.UnwindInfoStop
 	case "runtime.sigreturn", "runtime.sigreturn__sigaction":
 		// signal frame restorers
 		return &sdtypes.UnwindInfoSignal
@@ -733,7 +735,7 @@ func parseArm64pclntabFunc(deltas *sdtypes.StackDeltaArray, p pcval, s strategy)
 }
 
 func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
-	getSourceFileStrategy func(sourceFile string) strategy) map[int]strategy {
+	getSourceFileStrategy func(sourceFile string) strategy) (map[int]strategy, error) {
 
 	rdr := pfbufio.GetReader()
 	defer pfbufio.PutReader(rdr)
@@ -745,7 +747,7 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 		offset := rdr.Tell()
 		filename, err := rdr.ReadString(0)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		if s := getSourceFileStrategy(filename); s != strategyUnknown {
 			offsetStrategy[int(offset)] = s
@@ -758,6 +760,9 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 	for idx := 0; true; idx++ {
 		offsetBytes, err := rdr.ReadN(4)
 		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
 			break
 		}
 		offset := int(binary.LittleEndian.Uint32(offsetBytes))
@@ -766,12 +771,10 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 		}
 	}
 
-	return cuStrategy
+	return cuStrategy, nil
 }
 
-func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine,
-	framePointerReliable bool) map[int32]*sdtypes.UnwindInfo {
-
+func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine, useFP bool) (map[int32]*sdtypes.UnwindInfo, error) {
 	rdr := pfbufio.GetReader()
 	defer pfbufio.PutReader(rdr)
 
@@ -782,13 +785,16 @@ func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine,
 		offset := rdr.Tell()
 		funcName, err := rdr.ReadString(0)
 		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
 			break
 		}
-		if info := getFunctionUnwindInfo(funcName, arch, framePointerReliable); info != nil {
+		if info := getFunctionUnwindInfo(funcName, arch, useFP); info != nil {
 			functionInfo[int32(offset)] = info
 		}
 	}
-	return functionInfo
+	return functionInfo, nil
 }
 
 // Parse Golang .gopclntab spdelta tables and try to produce minified intervals
@@ -806,7 +812,7 @@ func (ee *elfExtractor) parseGoPclntab() error {
 	// Get target machine architecture for the ELF file
 	arch := ee.file.Machine
 	defaultStrategy := strategyFramePointer
-	isFramePointerReliable := true
+	useFP := true
 	var parsePclntab func(deltas *sdtypes.StackDeltaArray, p pcval, s strategy) error
 	var cuStrategy map[int]strategy
 
@@ -820,7 +826,10 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		// would fill up our precious kernel delta maps fast, the strategy is to
 		// create deltastack maps for non-Go source files only, and otherwise
 		// cover the vast majority with "use frame pointer" stack delta.
-		cuStrategy = resolveCUStrategies(ee.file.Underlying(), g, getSourceFileStrategyX86)
+		cuStrategy, err = resolveCUStrategies(ee.file.Underlying(), g, getSourceFileStrategyX86)
+		if err != nil {
+			return fmt.Errorf("cutab: %v", err)
+		}
 	case elf.EM_AARCH64:
 		parsePclntab = parseArm64pclntabFunc
 		// Go 1.20 and earlier did not maintain frame pointers properly on arm64.
@@ -830,28 +839,31 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		case go1_16, go1_18:
 			// Magic indicates old Go with broken arm64 frame pointers
 			defaultStrategy = strategyDeltasWithFrame
-			isFramePointerReliable = false
+			useFP = false
 		case go1_20:
 			// Ambiguous regarding if frame pointer is kept correctly.
 			// Take the slow path of resolving Go version.
 			goVer, err := ee.file.GoVersion()
 			if err != nil || version.Compare(goVer, "go1.21rc1") < 0 {
 				defaultStrategy = strategyDeltasWithFrame
-				isFramePointerReliable = false
+				useFP = false
 			}
 		}
 	default:
 		return fmt.Errorf("unsupported ELF architecture (%x)", arch)
 	}
 
-	funcUnwindInfo := resolveFunctionUnwindInfo(ee.file.Underlying(), g, arch, isFramePointerReliable)
+	funcUnwindInfo, err := resolveFunctionUnwindInfo(ee.file.Underlying(), g, arch, useFP)
+	if err != nil {
+		return fmt.Errorf("funcnametab: %v", err)
+	}
 
 	// Iterate the golang PC to function lookup table (sorted by PC)
 	for i := 0; i < g.numFuncs; i++ {
 		mapPc, funcOff := g.getFuncMapEntry(i)
 		funcPc, fun := g.getFunc(funcOff)
 		if fun == nil || mapPc != funcPc {
-			return fmt.Errorf(".gopclntab func %v descriptor is invalid (pc %x/%x)",
+			return fmt.Errorf("func %v descriptor is invalid (pc %x/%x)",
 				i, mapPc, funcPc)
 		}
 
@@ -891,7 +903,7 @@ func (ee *elfExtractor) parseGoPclntab() error {
 
 		// Generate stack deltas as the information is available
 		if len(g.pctab) < int(fun.pcspOff) {
-			return fmt.Errorf(".gopclntab func %v pcscOff (%d) is invalid",
+			return fmt.Errorf("func %v pcscOff (%d) is invalid",
 				i, fun.pcspOff)
 		}
 		p := g.getPcval(fun.pcspOff, uint(funcPc))

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -634,8 +634,7 @@ var noFPSourceSuffixes = []string{
 }
 
 // getSourceFileStrategyX86 categorizes sourceFile's unwinding strategy based on its name for amd64
-// If there is no explicit strategy for sourceFile then 
-// strategyUnknown is returned for further strategy resolution. 
+// strategyUnknown is returned if normal strategy resolution should be used.
 func getSourceFileStrategyX86(sourceFile string) strategy {
 	// Most of the assembly code needs explicit SP delta as they do not
 	// create stack frame. Do not recover RBP as it is not modified.

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -760,8 +760,7 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 	rdr.Init(r, g.headerOffset+int64(g.cuOffset), int64(g.filetabOffset-g.cuOffset))
 	var offset uint32
 	for idx := 0; ; idx++ {
-		if _, err := rdr.Read(pfunsafe.FromPointer(&offset)); err != nil {
-		if err != nil {
+		if _, err = rdr.Read(pfunsafe.FromPointer(&offset)); err != nil {
 			if err != io.EOF {
 				return nil, err
 			}

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -332,7 +332,7 @@ func extractGoPclntab(ef *pfelf.File) (data []byte, offset int64, err error) {
 				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: %v", err)
 			}
 			p := ef.ProgByVirtualAddress(uint64(start))
-			if p != nil {
+			if p == nil {
 				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: unmappable virtual address")
 			}
 			offset = int64(start) - int64(p.Vaddr)

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -481,7 +481,7 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 		g.filetabOffset >= g.pctabOffset ||
 		g.pctabOffset >= g.pclnOffset ||
 		g.pclnOffset >= dataLen ||
-		int64(g.numFuncs)*int64(g.funcMapSize) > int64(len(data))-int64(g.pclnOffset) {
+		(int64(g.numFuncs)+1)*int64(g.funcMapSize) > int64(len(data))-int64(g.pclnOffset) {
 		return nil, fmt.Errorf("corrupt header (%x < %x < %x < %x < %x)",
 			g.funcnameOffset, g.cuOffset, g.filetabOffset, g.pctabOffset, g.pclnOffset)
 	}
@@ -634,6 +634,8 @@ var noFPSourceSuffixes = []string{
 }
 
 // getSourceFileStrategyX86 categorizes sourceFile's unwinding strategy based on its name for amd64
+// If there is no explicit strategy for sourceFile then 
+// strategyUnknown is returned for further strategy resolution. 
 func getSourceFileStrategyX86(sourceFile string) strategy {
 	// Most of the assembly code needs explicit SP delta as they do not
 	// create stack frame. Do not recover RBP as it is not modified.
@@ -753,20 +755,20 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 		return nil, err
 	}
 
-	// Walk cutab indexes and map tham to strategy
+	// Walk cutab indexes and map them to strategy
 	cuStrategy := make(map[int]strategy)
 	rdr.Init(r, g.headerOffset+int64(g.cuOffset), int64(g.filetabOffset-g.cuOffset))
-	for idx := 0; true; idx++ {
-		offsetBytes, err := rdr.ReadN(4)
+	var offset uint32
+	for idx := 0; ; idx++ {
+		if _, err := rdr.Read(pfunsafe.FromPointer(&offset)); err != nil {
 		if err != nil {
 			if err != io.EOF {
 				return nil, err
 			}
 			break
 		}
-		offset := int(binary.LittleEndian.Uint32(offsetBytes))
-		if s, ok := offsetStrategy[offset]; ok {
-			cuStrategy[int(idx)] = s
+		if s, ok := offsetStrategy[int(offset)]; ok {
+			cuStrategy[idx] = s
 		}
 	}
 

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfbufio"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
@@ -232,7 +233,7 @@ func getString(data []byte, offset int) string {
 }
 
 // searchGoPclntab uses heuristic to find the gopclntab from RO data.
-func searchGoPclntab(ef *pfelf.File) ([]byte, error) {
+func searchGoPclntab(ef *pfelf.File) ([]byte, int64, error) {
 	// The sections headers are not available for coredump testing, because they are
 	// not inside any PT_LOAD segment. And in the case ofwhere they might be available
 	// because of alignment they are likely not usable, e.g. the musl C-library will
@@ -265,7 +266,7 @@ func searchGoPclntab(ef *pfelf.File) ([]byte, error) {
 		var data []byte
 		var err error
 		if data, err = p.Data(maxBytesGoPclntab); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		for i := 1; i < len(data)-PclntabHeaderSize(); i += 8 {
@@ -282,25 +283,26 @@ func searchGoPclntab(ef *pfelf.File) ([]byte, error) {
 			// for next candidate location.
 			hdr := (*pclntabHeader)(unsafe.Pointer(&data[i]))
 			if goMagicToVersion(hdr.magic) != goInvalid {
-				return data[i:], nil
+				return data[i:], int64(p.Off) + int64(i), nil
 			}
 		}
 	}
 
-	return nil, nil
+	return nil, 0, nil
 }
 
 // extractGoPclntab extracts the .gopclntab data from a given pfelf.File.
-func extractGoPclntab(ef *pfelf.File) (data []byte, err error) {
+func extractGoPclntab(ef *pfelf.File) (data []byte, offset int64, err error) {
 	if ef.InsideCore {
 		// Section tables not available. Use heuristic. Ignore errors as
 		// this might not be a Go binary.
-		data, _ = searchGoPclntab(ef)
+		data, offset, _ = searchGoPclntab(ef)
 	} else if s := ef.Section(".gopclntab"); s != nil {
 		// Load the .gopclntab via section if available.
 		if data, err = s.Data(maxBytesGoPclntab); err != nil {
-			return nil, fmt.Errorf("failed to load .gopclntab section: %v", err)
+			return nil, 0, fmt.Errorf("failed to load .gopclntab section: %v", err)
 		}
+		offset = int64(s.Offset)
 	} else if s := ef.Section(".go.buildinfo"); s != nil {
 		// This looks like Go binary. Lookup the runtime.pclntab symbols,
 		// as the .gopclntab section is not available on PIE binaries.
@@ -318,30 +320,33 @@ func extractGoPclntab(ef *pfelf.File) (data []byte, err error) {
 		if start == 0 || end == 0 {
 			// It seems the Go binary was stripped. So we use the heuristic approach
 			// to get the stack deltas.
-			if data, err = searchGoPclntab(ef); err != nil {
-				return nil, fmt.Errorf("failed to search .gopclntab: %v", err)
+			if data, offset, err = searchGoPclntab(ef); err != nil {
+				return nil, 0, fmt.Errorf("failed to search .gopclntab: %v", err)
 			}
 		} else {
 			if start >= end {
-				return nil, fmt.Errorf("invalid .gopclntab symbols: %v-%v", start, end)
+				return nil, 0, fmt.Errorf("invalid .gopclntab symbols: %v-%v", start, end)
 			}
 			data, err = ef.VirtualMemory(int64(start), int(end-start), maxBytesGoPclntab)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load .gopclntab via symbols: %v", err)
+				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: %v", err)
 			}
+			offset = int64(start)
 		}
 	}
-	return data, nil
+	return data, offset, nil
 }
 
 // Gopclntab is the API for extracting data from .gopclntab
 type Gopclntab struct {
-	dataRef     io.Closer
-	setDontNeed func()
+	dataRef      io.Closer
+	setDontNeed  func()
+	headerOffset int64
 
 	data      []byte
 	textStart uintptr
 	numFuncs  int
+	numFiles  uint
 
 	version     uint8
 	quantum     uint8
@@ -349,12 +354,18 @@ type Gopclntab struct {
 	funSize     uint8
 	funcMapSize uint8
 
+	funcnameOffset uintptr
+	cuOffset       uintptr
+	filetabOffset  uintptr
+	pctabOffset    uintptr
+	pclnOffset     uintptr
+
 	// These are read-only byte slices to various areas within .gopclntab
 	// (subslices of data []byte). Since 'data' a slice returned by pfelf.File
 	// it can be allocated or mmapped read-only data. To keep memory usage
 	// and GC stress minimal the returned strings (symbol and file names) refer
 	// to this data directly (via unsafe.String).
-	functab, funcdata, funcnametab, filetab, pctab, cutab []byte
+	functab, funcnametab, filetab, pctab, cutab []byte
 }
 
 // LookupSymbol searches for a given symbol in .gopclntab.
@@ -384,7 +395,7 @@ func (g *Gopclntab) LookupSymbol(symbol libpf.SymbolName) (*libpf.Symbol, error)
 // NewGopclntab parses and returns the parsed data for further operations.
 // Returns ErrNoPclntab when the file contains no gopclntab data.
 func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
-	data, err := extractGoPclntab(ef)
+	data, headerOffset, err := extractGoPclntab(ef)
 	if err != nil {
 		return nil, err
 	}
@@ -401,73 +412,44 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 
 	hdr := (*pclntabHeader)(unsafe.Pointer(&data[0]))
 	g := &Gopclntab{
-		data:        data,
-		version:     goMagicToVersion(hdr.magic),
-		quantum:     hdr.quantum,
-		ptrSize:     hdr.ptrSize,
-		funSize:     hdr.ptrSize + uint8(unsafe.Sizeof(pclntabFunc{})),
-		funcMapSize: hdr.ptrSize * 2,
-		numFuncs:    int(hdr.numFuncs),
+		headerOffset: headerOffset,
+		data:         data,
+		version:      goMagicToVersion(hdr.magic),
+		quantum:      hdr.quantum,
+		ptrSize:      hdr.ptrSize,
+		funSize:      hdr.ptrSize + uint8(unsafe.Sizeof(pclntabFunc{})),
+		funcMapSize:  hdr.ptrSize * 2,
+		numFuncs:     int(hdr.numFuncs),
 	}
 	if g.version == goInvalid || hdr.pad != 0 || hdr.ptrSize != 8 {
 		return nil, fmt.Errorf(".gopclntab header: %x, %x, %x", hdr.magic, hdr.pad, hdr.ptrSize)
 	}
 
 	switch g.version {
-	case go1_2:
-		functabEnd := int(hdrSize) + g.numFuncs*int(g.funcMapSize) + int(hdr.ptrSize)
-		filetabOffset := getInt32(data, functabEnd)
-		numSourceFiles := getInt32(data, filetabOffset)
-		if filetabOffset == 0 || numSourceFiles == 0 {
-			return nil, fmt.Errorf(".gopclntab corrupt (filetab 0x%x, nfiles %d)",
-				filetabOffset, numSourceFiles)
-		}
-		g.functab = data[hdrSize:filetabOffset]
-		g.cutab = data[filetabOffset:]
-		g.pctab = data
-		g.funcnametab = data
-		g.funcdata = data
-		g.filetab = data
 	case go1_16:
 		hdrSize = unsafe.Sizeof(pclntabHeader116{})
 		if dataLen < hdrSize {
 			return nil, fmt.Errorf(".gopclntab is too short (%v)", len(data))
 		}
 		hdr116 := (*pclntabHeader116)(unsafe.Pointer(&data[0]))
-		if dataLen < hdr116.funcnameOffset || dataLen < hdr116.cuOffset ||
-			dataLen < hdr116.filetabOffset || dataLen < hdr116.pctabOffset ||
-			dataLen < hdr116.pclnOffset {
-			return nil, fmt.Errorf(".gopclntab is corrupt (%x, %x, %x, %x, %x)",
-				hdr116.funcnameOffset, hdr116.cuOffset,
-				hdr116.filetabOffset, hdr116.pctabOffset,
-				hdr116.pclnOffset)
-		}
-		g.funcnametab = data[hdr116.funcnameOffset:]
-		g.cutab = data[hdr116.cuOffset:]
-		g.filetab = data[hdr116.filetabOffset:]
-		g.pctab = data[hdr116.pctabOffset:]
-		g.functab = data[hdr116.pclnOffset:]
-		g.funcdata = g.functab
+		g.numFiles = hdr116.nfiles
+		g.funcnameOffset = hdr116.funcnameOffset
+		g.cuOffset = hdr116.cuOffset
+		g.filetabOffset = hdr116.filetabOffset
+		g.pctabOffset = hdr116.pctabOffset
+		g.pclnOffset = hdr116.pclnOffset
 	case go1_18, go1_20:
 		hdrSize = unsafe.Sizeof(pclntabHeader118{})
 		if dataLen < hdrSize {
 			return nil, fmt.Errorf(".gopclntab is too short (%v)", dataLen)
 		}
 		hdr118 := (*pclntabHeader118)(unsafe.Pointer(&data[0]))
-		if dataLen < hdr118.funcnameOffset || dataLen < hdr118.cuOffset ||
-			dataLen < hdr118.filetabOffset || dataLen < hdr118.pctabOffset ||
-			dataLen < hdr118.pclnOffset {
-			return nil, fmt.Errorf(".gopclntab is corrupt (%x, %x, %x, %x, %x)",
-				hdr118.funcnameOffset, hdr118.cuOffset,
-				hdr118.filetabOffset, hdr118.pctabOffset,
-				hdr118.pclnOffset)
-		}
-		g.funcnametab = data[hdr118.funcnameOffset:]
-		g.cutab = data[hdr118.cuOffset:]
-		g.filetab = data[hdr118.filetabOffset:]
-		g.pctab = data[hdr118.pctabOffset:]
-		g.functab = data[hdr118.pclnOffset:]
-		g.funcdata = g.functab
+		g.numFiles = hdr118.nfiles
+		g.funcnameOffset = hdr118.funcnameOffset
+		g.cuOffset = hdr118.cuOffset
+		g.filetabOffset = hdr118.filetabOffset
+		g.pctabOffset = hdr118.pctabOffset
+		g.pclnOffset = hdr118.pclnOffset
 		g.textStart = hdr118.textStart
 		if g.textStart == 0 {
 			// Starting from Go 1.26, textStart address in pclntab is always set to 0.
@@ -486,7 +468,27 @@ func NewGopclntab(ef *pfelf.File) (*Gopclntab, error) {
 		// See https://github.com/golang/go/blob/6df0957060b1315db4fd6a359eefc3ee92fcc198/src/debug/gosym/pclntab.go#L376-L382
 		g.funcMapSize = 2 * 4
 		g.funSize = 4 + uint8(unsafe.Sizeof(pclntabFunc{}))
+	default:
+		return nil, fmt.Errorf("unsupported goplntab version (%x)", hdr.magic)
 	}
+
+	if g.funcnameOffset >= g.cuOffset ||
+		g.cuOffset >= g.filetabOffset ||
+		g.filetabOffset >= g.pctabOffset ||
+		g.pctabOffset >= g.pclnOffset ||
+		g.pclnOffset >= dataLen {
+		return nil, fmt.Errorf("gopclntab is corrupt (%x, %x, %x, %x, %x)",
+			g.funcnameOffset, g.cuOffset,
+			g.filetabOffset, g.pctabOffset,
+			g.pclnOffset)
+	}
+
+	g.funcnametab = data[g.funcnameOffset:]
+	g.cutab = data[g.cuOffset:]
+	g.filetab = data[g.filetabOffset:]
+	g.pctab = data[g.pctabOffset:]
+	g.functab = data[g.pclnOffset:]
+
 	g.dataRef = ef.Take()
 	g.setDontNeed = ef.SetDontNeed
 
@@ -520,18 +522,18 @@ func (g *Gopclntab) getFuncMapEntry(index int) (pc, funcOff uintptr) {
 // getFunc returns the gopclntab function data and its start address.
 func (g *Gopclntab) getFunc(funcOff uintptr) (uintptr, *pclntabFunc) {
 	// Get the function data
-	if uintptr(len(g.funcdata)) < funcOff+uintptr(g.funSize) {
+	if uintptr(len(g.functab)) < funcOff+uintptr(g.funSize) {
 		return 0, nil
 	}
 	var pc uintptr
 	if g.version >= go1_18 {
-		pc = g.textStart + uintptr(*(*uint32)(unsafe.Pointer(&g.funcdata[funcOff])))
+		pc = g.textStart + uintptr(*(*uint32)(unsafe.Pointer(&g.functab[funcOff])))
 		funcOff += 4
 	} else {
-		pc = *(*uintptr)(unsafe.Pointer(&g.funcdata[funcOff]))
+		pc = *(*uintptr)(unsafe.Pointer(&g.functab[funcOff]))
 		funcOff += uintptr(g.ptrSize)
 	}
-	return pc, (*pclntabFunc)(unsafe.Pointer(&g.funcdata[funcOff]))
+	return pc, (*pclntabFunc)(unsafe.Pointer(&g.functab[funcOff]))
 }
 
 // getPcval returns the pcval table at given offset with 'startPc' as the pc start value.
@@ -575,10 +577,7 @@ func (g *Gopclntab) Symbolize(pc uintptr) (sourceFile string, line uint, funcNam
 	funcName = getString(g.funcnametab, int(fun.nameOff))
 	if fun.pcfileOff != 0 {
 		if fileIndex, ok := g.mapPcval(fun.pcfileOff, uint(funcPc), uint(pc)); ok {
-			if g.version >= go1_16 {
-				fileIndex += fun.npcData
-			}
-			sourceFile = getString(g.filetab, getInt32(g.cutab, 4*int(fileIndex)))
+			sourceFile = getString(g.filetab, getInt32(g.cutab, 4*int(fileIndex+fun.npcData)))
 		}
 	}
 	if fun.pclnOff != 0 {
@@ -607,7 +606,7 @@ func findTextStart(ef *pfelf.File) (uintptr, error) {
 	return uintptr(binary.LittleEndian.Uint64(textBytes[:])), nil
 }
 
-type strategy int
+type strategy uint8
 
 const (
 	strategyUnknown strategy = iota
@@ -632,25 +631,20 @@ var noFPSourceSuffixes = []string{
 	"golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.go",
 }
 
-// getSourceFileStrategy categorizes sourceFile's unwinding strategy based on its name
-func getSourceFileStrategy(arch elf.Machine, sourceFile string, defaultStrategy strategy) strategy {
-	switch arch {
-	case elf.EM_X86_64:
-		// Most of the assembly code needs explicit SP delta as they do not
-		// create stack frame. Do not recover RBP as it is not modified.
-		if strings.HasSuffix(sourceFile, ".s") {
-			return strategyDeltasWithoutFrame
-		}
-		// Check for the Go source files needing SP delta unwinding to recover RBP
-		for _, suffix := range noFPSourceSuffixes {
-			if strings.HasSuffix(sourceFile, suffix) {
-				return strategyDeltasWithFrame
-			}
-		}
-		return defaultStrategy
-	default:
-		return defaultStrategy
+// getSourceFileStrategyX86 categorizes sourceFile's unwinding strategy based on its name for amd64
+func getSourceFileStrategyX86(sourceFile string) strategy {
+	// Most of the assembly code needs explicit SP delta as they do not
+	// create stack frame. Do not recover RBP as it is not modified.
+	if strings.HasSuffix(sourceFile, ".s") {
+		return strategyDeltasWithoutFrame
 	}
+	// Check for the Go source files needing SP delta unwinding to recover RBP
+	for _, suffix := range noFPSourceSuffixes {
+		if strings.HasSuffix(sourceFile, suffix) {
+			return strategyDeltasWithFrame
+		}
+	}
+	return strategyUnknown
 }
 
 // getFunctionDelta determines the special unwind opcode if needed
@@ -738,6 +732,65 @@ func parseArm64pclntabFunc(deltas *sdtypes.StackDeltaArray, p pcval, s strategy)
 	return nil
 }
 
+func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
+	getSourceFileStrategy func(sourceFile string) strategy) map[int]strategy {
+
+	rdr := pfbufio.GetReader()
+	defer pfbufio.PutReader(rdr)
+
+	// Walk all filenames and record the ones needing a strategy
+	rdr.Init(r, g.headerOffset+int64(g.filetabOffset), int64(g.pctabOffset-g.filetabOffset))
+	offsetStrategy := make(map[int]strategy)
+	for range g.numFiles {
+		offset := rdr.Tell()
+		filename, err := rdr.ReadString(0)
+		if err != nil {
+			return nil
+		}
+		if s := getSourceFileStrategy(filename); s != strategyUnknown {
+			offsetStrategy[int(offset)] = s
+		}
+	}
+
+	// Walk cutab indexes and map tham to strategy
+	rdr.Init(r, g.headerOffset+int64(g.cuOffset), int64(g.filetabOffset-g.cuOffset))
+	cuStrategy := make(map[int]strategy)
+	for idx := 0; true; idx++ {
+		offsetBytes, err := rdr.ReadN(4)
+		if err != nil {
+			break
+		}
+		offset := int(binary.LittleEndian.Uint32(offsetBytes))
+		if s, ok := offsetStrategy[offset]; ok {
+			cuStrategy[int(idx)] = s
+		}
+	}
+
+	return cuStrategy
+}
+
+func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine,
+	framePointerReliable bool) map[int32]*sdtypes.UnwindInfo {
+
+	rdr := pfbufio.GetReader()
+	defer pfbufio.PutReader(rdr)
+
+	functionInfo := make(map[int32]*sdtypes.UnwindInfo)
+
+	rdr.Init(r, g.headerOffset+int64(g.funcnameOffset), int64(g.cuOffset-g.funcnameOffset))
+	for {
+		offset := rdr.Tell()
+		funcName, err := rdr.ReadString(0)
+		if err != nil {
+			break
+		}
+		if info := getFunctionUnwindInfo(funcName, arch, framePointerReliable); info != nil {
+			functionInfo[int32(offset)] = info
+		}
+	}
+	return functionInfo
+}
+
 // Parse Golang .gopclntab spdelta tables and try to produce minified intervals
 // by using large frame pointer ranges when possible
 func (ee *elfExtractor) parseGoPclntab() error {
@@ -750,31 +803,31 @@ func (ee *elfExtractor) parseGoPclntab() error {
 	}
 	defer g.Close()
 
-	// Go uses frame-pointers by default since Go 1.7, but unfortunately
-	// it is not necessarily available when in code from non-Golang source
-	// files, such as the assembly, of the Go runtime.
-	// Since Golang binaries are huge statically compiled executables and
-	// would fill up our precious kernel delta maps fast, the strategy is to
-	// create deltastack maps for non-Go source files only, and otherwise
-	// cover the vast majority with "use frame pointer" stack delta.
-	sourceStrategy := make(map[int]strategy)
-
 	// Get target machine architecture for the ELF file
 	arch := ee.file.Machine
 	defaultStrategy := strategyFramePointer
 	isFramePointerReliable := true
 	var parsePclntab func(deltas *sdtypes.StackDeltaArray, p pcval, s strategy) error
+	var cuStrategy map[int]strategy
 
 	switch arch {
 	case elf.EM_X86_64:
 		parsePclntab = parseX86pclntabFunc
+		// Go uses frame-pointers by default since Go 1.7, but unfortunately
+		// it is not necessarily available when in code from non-Golang source
+		// files, such as the assembly, of the Go runtime.
+		// Since Golang binaries are huge statically compiled executables and
+		// would fill up our precious kernel delta maps fast, the strategy is to
+		// create deltastack maps for non-Go source files only, and otherwise
+		// cover the vast majority with "use frame pointer" stack delta.
+		cuStrategy = resolveCUStrategies(ee.file.Underlying(), g, getSourceFileStrategyX86)
 	case elf.EM_AARCH64:
 		parsePclntab = parseArm64pclntabFunc
 		// Go 1.20 and earlier did not maintain frame pointers properly on arm64.
 		// This was fixed for Go 1.21 and later in:
 		// https://github.com/golang/go/commit/a41a29ad19c25c3475a65b7265fcad870d954c2a
 		switch g.version {
-		case go1_2, go1_16, go1_18:
+		case go1_16, go1_18:
 			// Magic indicates old Go with broken arm64 frame pointers
 			defaultStrategy = strategyDeltasWithFrame
 			isFramePointerReliable = false
@@ -791,6 +844,8 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		return fmt.Errorf("unsupported ELF architecture (%x)", arch)
 	}
 
+	funcUnwindInfo := resolveFunctionUnwindInfo(ee.file.Underlying(), g, arch, isFramePointerReliable)
+
 	// Iterate the golang PC to function lookup table (sorted by PC)
 	for i := 0; i < g.numFuncs; i++ {
 		mapPc, funcOff := g.getFuncMapEntry(i)
@@ -801,8 +856,7 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		}
 
 		// First, check for functions with special handling.
-		funcName := getString(g.funcnametab, int(fun.nameOff))
-		if info := getFunctionUnwindInfo(funcName, arch, isFramePointerReliable); info != nil {
+		if info, ok := funcUnwindInfo[int32(fun.nameOff)]; ok {
 			ee.deltas.Add(sdtypes.StackDelta{
 				Address: uint64(funcPc),
 				Info:    *info,
@@ -815,17 +869,9 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		fileStrategy := defaultStrategy
 		if fun.pcfileOff != 0 {
 			p := g.getPcval(fun.pcfileOff, uint(funcPc))
-			fileIndex := int(p.val)
-			if g.version >= go1_16 {
-				fileIndex += int(fun.npcData)
-			}
-
-			// Determine strategy
-			fileStrategy = sourceStrategy[fileIndex]
-			if fileStrategy == strategyUnknown {
-				sourceFile := getString(g.filetab, getInt32(g.cutab, 4*fileIndex))
-				fileStrategy = getSourceFileStrategy(arch, sourceFile, defaultStrategy)
-				sourceStrategy[fileIndex] = fileStrategy
+			cuIndex := int(p.val) + int(fun.npcData)
+			if s, ok := cuStrategy[cuIndex]; ok {
+				fileStrategy = s
 			}
 		}
 

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -335,7 +335,7 @@ func extractGoPclntab(ef *pfelf.File) (data []byte, offset int64, err error) {
 			if p == nil {
 				return nil, 0, fmt.Errorf("failed to load .gopclntab via symbols: unmappable virtual address")
 			}
-			offset = int64(start) - int64(p.Vaddr)
+			offset = int64(p.Off) + int64(start) - int64(p.Vaddr)
 		}
 	}
 	return data, offset, nil
@@ -741,22 +741,18 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 	defer pfbufio.PutReader(rdr)
 
 	// Walk all filenames and record the ones needing a strategy
-	rdr.Init(r, g.headerOffset+int64(g.filetabOffset), int64(g.pctabOffset-g.filetabOffset))
 	offsetStrategy := make(map[int]strategy)
-	for range g.numFiles {
-		offset := rdr.Tell()
-		filename, err := rdr.ReadString(0)
-		if err != nil {
-			return nil, err
-		}
+	rdr.Init(r, g.headerOffset+int64(g.filetabOffset), int64(g.pctabOffset-g.filetabOffset))
+	rdr.WalkStrings(int(g.numFiles), func(offs int64, filename string) error {
 		if s := getSourceFileStrategy(filename); s != strategyUnknown {
-			offsetStrategy[int(offset)] = s
+			offsetStrategy[int(offs)] = s
 		}
-	}
+		return nil
+	})
 
 	// Walk cutab indexes and map tham to strategy
-	rdr.Init(r, g.headerOffset+int64(g.cuOffset), int64(g.filetabOffset-g.cuOffset))
 	cuStrategy := make(map[int]strategy)
+	rdr.Init(r, g.headerOffset+int64(g.cuOffset), int64(g.filetabOffset-g.cuOffset))
 	for idx := 0; true; idx++ {
 		offsetBytes, err := rdr.ReadN(4)
 		if err != nil {
@@ -779,21 +775,13 @@ func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine, us
 	defer pfbufio.PutReader(rdr)
 
 	functionInfo := make(map[int32]*sdtypes.UnwindInfo)
-
 	rdr.Init(r, g.headerOffset+int64(g.funcnameOffset), int64(g.cuOffset-g.funcnameOffset))
-	for {
-		offset := rdr.Tell()
-		funcName, err := rdr.ReadString(0)
-		if err != nil {
-			if err != io.EOF {
-				return nil, err
-			}
-			break
-		}
+	rdr.WalkAllStrings(func(offs int64, funcName string) error {
 		if info := getFunctionUnwindInfo(funcName, arch, useFP); info != nil {
-			functionInfo[int32(offset)] = info
+			functionInfo[int32(offs)] = info
 		}
-	}
+		return nil
+	})
 	return functionInfo, nil
 }
 

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -743,12 +743,15 @@ func resolveCUStrategies(r io.ReaderAt, g *Gopclntab,
 	// Walk all filenames and record the ones needing a strategy
 	offsetStrategy := make(map[int]strategy)
 	rdr.Init(r, g.headerOffset+int64(g.filetabOffset), int64(g.pctabOffset-g.filetabOffset))
-	rdr.WalkStrings(int(g.numFiles), func(offs int64, filename string) error {
+	err := rdr.WalkStrings(int(g.numFiles), func(offs int64, filename string) error {
 		if s := getSourceFileStrategy(filename); s != strategyUnknown {
 			offsetStrategy[int(offs)] = s
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Walk cutab indexes and map tham to strategy
 	cuStrategy := make(map[int]strategy)
@@ -776,13 +779,13 @@ func resolveFunctionUnwindInfo(r io.ReaderAt, g *Gopclntab, arch elf.Machine, us
 
 	functionInfo := make(map[int32]*sdtypes.UnwindInfo)
 	rdr.Init(r, g.headerOffset+int64(g.funcnameOffset), int64(g.cuOffset-g.funcnameOffset))
-	rdr.WalkAllStrings(func(offs int64, funcName string) error {
+	err := rdr.WalkAllStrings(func(offs int64, funcName string) error {
 		if info := getFunctionUnwindInfo(funcName, arch, useFP); info != nil {
 			functionInfo[int32(offs)] = info
 		}
 		return nil
 	})
-	return functionInfo, nil
+	return functionInfo, err
 }
 
 // Parse Golang .gopclntab spdelta tables and try to produce minified intervals

--- a/nativeunwind/elfunwindinfo/elfgopclntab_test.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab_test.go
@@ -4,7 +4,6 @@
 package elfunwindinfo
 
 import (
-	"debug/elf"
 	"testing"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -58,12 +57,12 @@ func TestGoStrategy(t *testing.T) {
 		file   string
 		result strategy
 	}{
-		{"foo.go", strategyFramePointer},
+		{"foo.go", strategyUnknown},
 		{"foo.s", strategyDeltasWithoutFrame},
 		{"go/src/crypto/elliptic/p256_asm.go", strategyDeltasWithFrame},
 	}
 	for _, x := range res {
-		s := getSourceFileStrategy(elf.EM_X86_64, x.file, strategyFramePointer)
+		s := getSourceFileStrategyX86(x.file)
 		assert.Equal(t, x.result, s)
 	}
 }


### PR DESCRIPTION
Instead of chasing function and file name offsets to read the name, pre-parse the filenames and function names to create a map of overrides. This allows parsing the two tables sequentially, and use the `pfbufat` caching for doing it.

Even the old code cached compilation unit data, so there should be no overhead in this change. The function name override is small and should not have impact either. This speeds up things on arm64 the compilation unit table / source filename table walk is completely omitted as it is not needed.

A baby step in #1577.

This also removes support for pre-Go 1.16 versions. Those are EOL since August 2021, and do not have any coredump tests to ensure their functionality. Also the gopclntab for that likely does not contain all the offsets need for the new walking code. So let's simplify and remove that.

Fixes #1602
