### PR TITLE
Make frame cache size configurable

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
+	pm "go.opentelemetry.io/ebpf-profiler/processmanager"
 	"go.opentelemetry.io/ebpf-profiler/tracer"
 )
 
@@ -31,6 +32,7 @@ const (
 	defaultArgSendErrorFrames     = false
 	defaultOffCPUThreshold        = 0
 	defaultEnvVarsValue           = ""
+	defaultArgFrameCacheSize      = pm.DefaultFrameCacheSize
 	defaultBPFFSRoot              = "/sys/fs/bpf/"
 
 	// This is the X in 2^(n + x) where n is the default hardcoded map size value
@@ -80,6 +82,8 @@ var (
 		defaultOffCPUThreshold)
 	envVarsHelp = "Comma separated list of environment variables that will be reported with the" +
 		"captured profiling samples."
+	frameCacheSizeHelp = fmt.Sprintf("Set the maximum number of entries in the frame cache. "+
+		"Default is %d.", defaultArgFrameCacheSize)
 	probeLinkHelper = "Attach a probe to a symbol of an executable. " +
 		"Expected format: probe_type:target[:symbol]. probe_type can be kprobe, kretprobe, uprobe, or uretprobe."
 	loadProbeHelper = "Load generic eBPF program that can be attached externally to " +
@@ -105,6 +109,9 @@ func parseArgs() (*controller.Config, error) {
 	fs.BoolVar(&args.Copyright, "copyright", false, copyrightHelp)
 
 	fs.BoolVar(&args.DisableTLS, "disable-tls", false, disableTLSHelp)
+
+	fs.UintVar(&args.FrameCacheSize, "frame-cache-size",
+		uint(defaultArgFrameCacheSize), frameCacheSizeHelp)
 
 	fs.UintVar(&args.MapScaleFactor, "map-scale-factor",
 		defaultArgMapScaleFactor, mapScaleFactorHelp)

--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -17,6 +17,9 @@ import (
 const (
 	// 1TB of executable address space
 	MaxArgMapScaleFactor = 8
+
+	minFrameCacheSize = 1024
+	maxFrameCacheSize = 1024 * 1024
 )
 
 // ErrorMode controls how the profiler receiver handles startup errors.
@@ -46,6 +49,7 @@ type Config struct {
 	ReporterJitter         float64                  `mapstructure:"reporter_jitter"`
 	MonitorInterval        time.Duration            `mapstructure:"monitor_interval"`
 	SamplesPerSecond       int                      `mapstructure:"samples_per_second"`
+	FrameCacheSize         uint                     `mapstructure:"frame_cache_size"`
 	ProbabilisticInterval  time.Duration            `mapstructure:"probabilistic_interval"`
 	ProbabilisticThreshold uint                     `mapstructure:"probabilistic_threshold"`
 	Interpreters           interpreterconfig.Config `mapstructure:"interpreters"`
@@ -76,6 +80,11 @@ func (cfg *Config) Validate() error {
 
 	if cfg.SamplesPerSecond < 1 {
 		return fmt.Errorf("invalid sampling frequency: %d", cfg.SamplesPerSecond)
+	}
+
+	if cfg.FrameCacheSize < minFrameCacheSize || cfg.FrameCacheSize > maxFrameCacheSize {
+		return fmt.Errorf("invalid frame cache size %d (min: %d, max: %d)",
+			cfg.FrameCacheSize, minFrameCacheSize, maxFrameCacheSize)
 	}
 
 	if cfg.MapScaleFactor > MaxArgMapScaleFactor {

--- a/collector/config/config_test.go
+++ b/collector/config/config_test.go
@@ -15,6 +15,8 @@ import (
 func validConfig() *Config {
 	return &Config{
 		SamplesPerSecond:       20,
+		ErrorMode:              PropagateError,
+		FrameCacheSize:         minFrameCacheSize,
 		ProbabilisticInterval:  1 * time.Minute,
 		ProbabilisticThreshold: 100,
 		NoKernelVersionCheck:   true,
@@ -29,6 +31,49 @@ func TestValidate(t *testing.T) {
 	err := xconfmap.Validate(cfg)
 	require.Error(t, err)
 	require.Equal(t, "invalid sampling frequency: 0", err.Error())
+}
+
+func TestValidateFrameCacheSize(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		frameCacheSize uint
+		wantErr        bool
+	}{
+		{
+			name:           "zero is invalid",
+			frameCacheSize: 0,
+			wantErr:        true,
+		},
+		{
+			name:           "below minimum is invalid",
+			frameCacheSize: minFrameCacheSize - 1,
+			wantErr:        true,
+		},
+		{
+			name:           "minimum is valid",
+			frameCacheSize: minFrameCacheSize,
+		},
+		{
+			name:           "maximum is valid",
+			frameCacheSize: maxFrameCacheSize,
+		},
+		{
+			name:           "above maximum is invalid",
+			frameCacheSize: maxFrameCacheSize + 1,
+			wantErr:        true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.FrameCacheSize = tt.frameCacheSize
+			err := xconfmap.Validate(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestUnmarshalText(t *testing.T) {

--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/internal/controller"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
+	pm "go.opentelemetry.io/ebpf-profiler/processmanager"
 )
 
 var errInvalidConfig = errors.New("invalid config")
@@ -41,6 +42,7 @@ func defaultConfig() component.Config {
 		ReporterJitter:         0.2,
 		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,
+		FrameCacheSize:         uint(pm.DefaultFrameCacheSize),
 		ProbabilisticInterval:  1 * time.Minute,
 		ProbabilisticThreshold: 100,
 		Interpreters:           interpreterconfig.AllInterpreters(),

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -92,6 +92,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		FilterIdleFrames:       !c.config.SendIdleFrames,
 		SamplesPerSecond:       c.config.SamplesPerSecond,
 		MapScaleFactor:         int(c.config.MapScaleFactor),
+		FrameCacheSize:         uint32(c.config.FrameCacheSize),
 		KernelVersionCheck:     !c.config.NoKernelVersionCheck,
 		VerboseMode:            c.config.VerboseMode,
 		BPFVerifierLogLevel:    uint32(c.config.BPFVerifierLogLevel),

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -43,8 +43,8 @@ const (
 	// TTL of entries in the LRU cache holding the executables' ELF information.
 	elfInfoCacheTTL = 6 * time.Hour
 
-	// Maximum size of the LRU cache for frames.
-	frameCacheSize = 16384
+	// DefaultFrameCacheSize is the default maximum size of the LRU cache for frames.
+	DefaultFrameCacheSize uint32 = 16384
 )
 
 // dummyPrefix is the LPM prefix installed to indicate the process is known
@@ -61,9 +61,12 @@ var (
 func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monitorInterval time.Duration,
 	executableUnloadDelay time.Duration, ebpf pmebpf.EbpfHandler, traceReporter reporter.TraceReporter,
 	exeReporter reporter.ExecutableReporter, sdp nativeunwind.StackDeltaProvider,
-	filterErrorFrames bool, includeEnvVars libpf.Set[string]) (*ProcessManager, error) {
+	frameCacheSize uint32, filterErrorFrames bool, includeEnvVars libpf.Set[string]) (*ProcessManager, error) {
 	if exeReporter == nil {
 		exeReporter = executableReporterStub{}
+	}
+	if frameCacheSize == 0 {
+		frameCacheSize = DefaultFrameCacheSize
 	}
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
@@ -75,7 +78,7 @@ func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monit
 
 	frameCache, err := lru.New[frameCacheKey, libpf.Frames](frameCacheSize, hashFrameCacheKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create frameCache: %v", err)
 	}
 
 	em, err := eim.NewExecutableInfoManager(sdp, ebpf, interpretersConfig)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -56,17 +56,28 @@ var (
 	errPIDGone = errors.New("interpreter process gone")
 )
 
+// Config contains the dependencies and options used to create a ProcessManager.
+type Config struct {
+	InterpretersConfig    interpreterconfig.Config
+	MonitorInterval       time.Duration
+	ExecutableUnloadDelay time.Duration
+	EbpfHandler           pmebpf.EbpfHandler
+	TraceReporter         reporter.TraceReporter
+	ExecutableReporter    reporter.ExecutableReporter
+	StackDeltaProvider    nativeunwind.StackDeltaProvider
+	FrameCacheSize        uint32
+	FilterErrorFrames     bool
+	IncludeEnvVars        libpf.Set[string]
+}
+
 // New creates a new ProcessManager which is responsible for keeping track of loading
 // and unloading of symbols for processes.
-func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monitorInterval time.Duration,
-	executableUnloadDelay time.Duration, ebpf pmebpf.EbpfHandler, traceReporter reporter.TraceReporter,
-	exeReporter reporter.ExecutableReporter, sdp nativeunwind.StackDeltaProvider,
-	frameCacheSize uint32, filterErrorFrames bool, includeEnvVars libpf.Set[string]) (*ProcessManager, error) {
-	if exeReporter == nil {
-		exeReporter = executableReporterStub{}
+func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
+	if cfg.ExecutableReporter == nil {
+		cfg.ExecutableReporter = executableReporterStub{}
 	}
-	if frameCacheSize == 0 {
-		frameCacheSize = DefaultFrameCacheSize
+	if cfg.FrameCacheSize == 0 {
+		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
@@ -76,18 +87,18 @@ func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monit
 	}
 	elfInfoCache.SetLifetime(elfInfoCacheTTL)
 
-	frameCache, err := lru.New[frameCacheKey, libpf.Frames](frameCacheSize, hashFrameCacheKey)
+	frameCache, err := lru.New[frameCacheKey, libpf.Frames](cfg.FrameCacheSize, hashFrameCacheKey)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create frameCache: %v", err)
 	}
 
-	em, err := eim.NewExecutableInfoManager(sdp, ebpf, interpretersConfig)
+	em, err := eim.NewExecutableInfoManager(cfg.StackDeltaProvider, cfg.EbpfHandler, cfg.InterpretersConfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ExecutableInfoManager: %v", err)
 	}
 
-	periodiccaller.Start(ctx, executableUnloadDelay, func() {
-		err := em.CleanupUnused(executableUnloadDelay)
+	periodiccaller.Start(ctx, cfg.ExecutableUnloadDelay, func() {
+		err := em.CleanupUnused(cfg.ExecutableUnloadDelay)
 		if err != nil {
 			log.Errorf("Failed to cleanup unused executables: %v", err)
 		}
@@ -106,19 +117,19 @@ func New(ctx context.Context, interpretersConfig interpreterconfig.Config, monit
 		interpreters:             interpreters,
 		exitEvents:               make(map[libpf.PID]times.KTime),
 		pidToProcessInfo:         make(map[libpf.PID]*processInfo),
-		ebpf:                     ebpf,
+		ebpf:                     cfg.EbpfHandler,
 		elfInfoCache:             elfInfoCache,
 		frameCache:               frameCache,
-		traceReporter:            traceReporter,
-		exeReporter:              exeReporter,
+		traceReporter:            cfg.TraceReporter,
+		exeReporter:              cfg.ExecutableReporter,
 		metricsAddSlice:          metrics.AddSlice,
-		filterErrorFrames:        filterErrorFrames,
-		includeEnvVars:           includeEnvVars,
+		filterErrorFrames:        cfg.FilterErrorFrames,
+		includeEnvVars:           cfg.IncludeEnvVars,
 		selfCgroupIno:            selfCgroupIno,
 		selfContainerID:          selfContainerID,
 	}
 
-	collectInterpreterMetrics(ctx, pm, monitorInterval)
+	collectInterpreterMetrics(ctx, pm, cfg.MonitorInterval)
 
 	return pm, nil
 }

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -40,8 +40,14 @@ func (tc *traceCapture) ReportTraceEvent(trace *libpf.Trace, _ *samples.TraceEve
 }
 
 func TestNewConfiguresFrameCacheSize(t *testing.T) {
-	pm, err := New(t.Context(), interpreterconfig.NoInterpreters(), time.Hour, time.Hour,
-		&testEbpfHandler{}, nil, nil, nil, 1, false, libpf.Set[string]{})
+	pm, err := New(t.Context(), Config{
+		InterpretersConfig:    interpreterconfig.NoInterpreters(),
+		MonitorInterval:       time.Hour,
+		ExecutableUnloadDelay: time.Hour,
+		EbpfHandler:           &testEbpfHandler{},
+		FrameCacheSize:        1,
+		IncludeEnvVars:        libpf.Set[string]{},
+	})
 	require.NoError(t, err)
 
 	pm.frameCache.Add(frameCacheKey{data: [3]uint64{1}}, libpf.Frames{})

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"slices"
 	"testing"
+	"time"
 	"unsafe"
 
 	lru "github.com/elastic/go-freelru"
@@ -14,6 +15,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	golang "go.opentelemetry.io/ebpf-profiler/interpreter/go"
+	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/process"
@@ -35,6 +37,16 @@ type traceCapture struct {
 func (tc *traceCapture) ReportTraceEvent(trace *libpf.Trace, _ *samples.TraceEventMeta) error {
 	tc.traces = append(tc.traces, trace)
 	return nil
+}
+
+func TestNewConfiguresFrameCacheSize(t *testing.T) {
+	pm, err := New(t.Context(), interpreterconfig.NoInterpreters(), time.Hour, time.Hour,
+		&testEbpfHandler{}, nil, nil, nil, 1, false, libpf.Set[string]{})
+	require.NoError(t, err)
+
+	pm.frameCache.Add(frameCacheKey{data: [3]uint64{1}}, libpf.Frames{})
+	pm.frameCache.Add(frameCacheKey{data: [3]uint64{2}}, libpf.Frames{})
+	require.Equal(t, 1, pm.frameCache.Len())
 }
 
 func TestFrameCacheCrossProcessPollution(t *testing.T) {

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -181,7 +181,7 @@ func ExtractTracesWithInterpreters(ctx context.Context, pr process.Process, debu
 
 	manager, err := pm.New(todo, interpretersConfig, monitorInterval, executableUnloadDelay,
 		&coredumpEbpfMaps, &traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(),
-		false, libpf.Set[string]{})
+		pm.DefaultFrameCacheSize, false, libpf.Set[string]{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)
 	}

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -179,9 +179,16 @@ func ExtractTracesWithInterpreters(ctx context.Context, pr process.Process, debu
 	coredumpEbpfMaps := ebpfMapsCoredump{ctx: ebpfCtx}
 	traceReporter := traceReporter{}
 
-	manager, err := pm.New(todo, interpretersConfig, monitorInterval, executableUnloadDelay,
-		&coredumpEbpfMaps, &traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(),
-		pm.DefaultFrameCacheSize, false, libpf.Set[string]{})
+	manager, err := pm.New(todo, pm.Config{
+		InterpretersConfig:    interpretersConfig,
+		MonitorInterval:       monitorInterval,
+		ExecutableUnloadDelay: executableUnloadDelay,
+		EbpfHandler:           &coredumpEbpfMaps,
+		TraceReporter:         &traceReporter,
+		StackDeltaProvider:    elfunwindinfo.NewStackDeltaProvider(),
+		FrameCacheSize:        pm.DefaultFrameCacheSize,
+		IncludeEnvVars:        libpf.Set[string]{},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)
 	}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -170,6 +170,8 @@ type Config struct {
 	SamplesPerSecond int
 	// MapScaleFactor is the scaling factor for eBPF map sizes.
 	MapScaleFactor int
+	// FrameCacheSize is the maximum size of the user-mode frame cache.
+	FrameCacheSize uint32
 	// FilterErrorFrames indicates whether error frames should be filtered.
 	FilterErrorFrames bool
 	// FilterIdleFrames indicates whether idle frames should be filtered.
@@ -262,7 +264,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	processManager, err := pm.New(ctx, cfg.InterpretersConfig, cfg.Intervals.MonitorInterval(),
 		cfg.Intervals.ExecutableUnloadDelay(), ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
 		elfunwindinfo.NewStackDeltaProvider(),
-		cfg.FilterErrorFrames, cfg.IncludeEnvVars)
+		cfg.FrameCacheSize, cfg.FilterErrorFrames, cfg.IncludeEnvVars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -261,10 +261,18 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("failed to load eBPF maps: %v", err)
 	}
 
-	processManager, err := pm.New(ctx, cfg.InterpretersConfig, cfg.Intervals.MonitorInterval(),
-		cfg.Intervals.ExecutableUnloadDelay(), ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
-		elfunwindinfo.NewStackDeltaProvider(),
-		cfg.FrameCacheSize, cfg.FilterErrorFrames, cfg.IncludeEnvVars)
+	processManager, err := pm.New(ctx, pm.Config{
+		InterpretersConfig:    cfg.InterpretersConfig,
+		MonitorInterval:       cfg.Intervals.MonitorInterval(),
+		ExecutableUnloadDelay: cfg.Intervals.ExecutableUnloadDelay(),
+		EbpfHandler:           ebpfHandler,
+		TraceReporter:         cfg.TraceReporter,
+		ExecutableReporter:    cfg.ExecutableReporter,
+		StackDeltaProvider:    elfunwindinfo.NewStackDeltaProvider(),
+		FrameCacheSize:        cfg.FrameCacheSize,
+		FilterErrorFrames:     cfg.FilterErrorFrames,
+		IncludeEnvVars:        cfg.IncludeEnvVars,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}


### PR DESCRIPTION
Different users might have different frame cardinality and CPU/memory, overhead targets, so having a configurable size is a useful knob to have.

As requested in https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/802#discussion_r2349156849. Also useful for https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1573 consolidation.