### PR TITLE
downgrade noisy internal logs to debug

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -729,7 +729,7 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 	}
 
 	if err := i.d.walkRangeSectionsMethod(i, ebpf, pr.PID()); err != nil {
-		log.Infof("Failed to walk code ranges: %v", err)
+		log.Debugf("Failed to walk code ranges: %v", err)
 	}
 	if i.precodeStubManagerPtr != 0 {
 		if vms.PrecodeStubManager.StubPrecodeRangeList != 0 {

--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -135,7 +135,7 @@ func loader(cfg Config, info *interpreter.LoaderInfo) (interpreter.Data, error) 
 	case errors.Is(err, libpf.ErrSymbolNotFound):
 		return nil, fmt.Errorf("failed to lookup symbol in %s: %v", info.FileName(), err)
 	case errors.Is(err, errDecodeSymbol), errors.Is(err, errRuntimeIsCgoUnavailable):
-		log.Warnf("In %s: %v", info.FileName(), err)
+		log.Debugf("In %s: %v", info.FileName(), err)
 	case errors.Is(err, nil):
 		// Nothing to do - just continue
 	default:

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -833,7 +833,7 @@ func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 			}
 		}
 		if stubHeapArea == nil {
-			log.Warnf("Unable to find heap for stub: pid = %d, stub.start = 0x%x",
+			log.Debugf("Unable to find heap for stub: pid = %d, stub.start = 0x%x",
 				pid, stub.start)
 			continue
 		}
@@ -841,12 +841,12 @@ func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 		// Create and insert a jitArea for the stub.
 		stubArea, err := jitAreaForStubArm64(&stub, stubHeapArea, d.rm)
 		if err != nil {
-			log.Warnf("Failed to create JIT area for stub (pid = %d, stub.start = 0x%x): %v",
+			log.Debugf("Failed to create JIT area for stub (pid = %d, stub.start = 0x%x): %v",
 				pid, stub.start, err)
 			continue
 		}
 		if err = d.addJitArea(ebpf, pid, stubArea); err != nil {
-			log.Warnf("Failed to insert JIT area for stub (pid = %d, stub.start = 0x%x): %v",
+			log.Debugf("Failed to insert JIT area for stub (pid = %d, stub.start = 0x%x): %v",
 				pid, stub.start, err)
 			continue
 		}

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -2228,7 +2228,7 @@ func lookupRelevantSymbols(ef *pfelf.File) (relevantSymbols, error) {
 	// Match historic behavior: keep going, even if we can't get the snapshot blob.
 	// (TODO: Figure out when/why this can happen)
 	if err != nil {
-		log.Warnf("Couldn't get V8 DefaultSnapshotBlob: %v", err)
+		log.Debugf("Couldn't get V8 DefaultSnapshotBlob: %v", err)
 	} else {
 		rv.DefaultSnapshotBlob = sym
 	}
@@ -2237,7 +2237,7 @@ func lookupRelevantSymbols(ef *pfelf.File) (relevantSymbols, error) {
 	sym, err = ef.LookupSymbol(bytecodeSizesSymbol)
 	if err != nil {
 		// As above, keep going to match historic behavior (why?)
-		log.Warnf("Couldn't get V8 BytecodeSizes: %v", err)
+		log.Debugf("Couldn't get V8 BytecodeSizes: %v", err)
 	} else {
 		rv.BytecodeSizes = sym
 	}

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -837,7 +837,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		var err error
 		staticTLSOffset, err = getTLSOffsetFromAssembly(ef)
 		if err != nil {
-			log.Debugf("Failed to extract TLS offset: %v", err)
+			log.Warnf("Failed to extract TLS offset: %v", err)
 		}
 	}
 

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -837,7 +837,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		var err error
 		staticTLSOffset, err = getTLSOffsetFromAssembly(ef)
 		if err != nil {
-			log.Warnf("Failed to extract TLS offset: %v", err)
+			log.Debugf("Failed to extract TLS offset: %v", err)
 		}
 	}
 
@@ -979,7 +979,7 @@ func findInterpreterRanges(info *interpreter.LoaderInfo, ef *pfelf.File,
 	})
 	coldRange, err := findColdRange(ef, code, interp)
 	if err != nil {
-		log.Errorf("failed to recover python ranges %s: %s", info.FileName(), err.Error())
+		log.Debugf("failed to recover python ranges %s: %s", info.FileName(), err.Error())
 	}
 	if coldRange != (util.Range{}) {
 		interpRanges = append(interpRanges, coldRange)

--- a/interpreter/ruby/ec.go
+++ b/interpreter/ruby/ec.go
@@ -31,7 +31,7 @@ func extractEcTLSOffset(ef *pfelf.File) (int64, error) {
 			if s.Name == symbolName {
 				data, readErr := ef.VirtualMemory(int64(s.Address), int(s.Size), 2048)
 				if readErr != nil {
-					log.Errorf("Failed to read memory for %s: %v", symbolName, readErr)
+					log.Debugf("Failed to read memory for %s: %v", symbolName, readErr)
 				} else {
 					code = data
 					sym.Address = s.Address

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -1009,7 +1009,7 @@ func (r *rubyInstance) readIseqBody(iseqBody, pc libpf.Address, frameAddrType ui
 			libpf.Address(vms.iseq_constant_body.location+vms.iseq_location_struct.base_label))
 		methodName, err = r.getStringCached(methodNamePtr, r.readRubyString)
 		if err != nil {
-			log.Warnf("Unable to find local method name on iseq method (%d) (iseq@0x%08x) %v", iseqType, iseqBody, err)
+			log.Debugf("Unable to find local method name on iseq method (%d) (iseq@0x%08x) %v", iseqType, iseqBody, err)
 		}
 	}
 
@@ -1125,7 +1125,7 @@ func (r *rubyInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ lib
 		if err != nil {
 			// Failing to read the class name is not a fatal error, keep going with just the method name
 			// and provide an incomplete label rather than nothing at all.
-			log.Errorf("Failed to read class name for cme (%d): %v", frameAddrType, err)
+			log.Debugf("Failed to read class name for cme (%d): %v", frameAddrType, err)
 		}
 	}
 
@@ -1141,7 +1141,7 @@ func (r *rubyInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ lib
 		lineNo, err := r.getRubyLineNo(cfpIseq, uint64(pc))
 		if err != nil {
 			lineNo = 0
-			log.Warnf("RubySymbolizer: Failed to get line number (%d) %v", frameAddrType, err)
+			log.Debugf("RubySymbolizer: Failed to get line number (%d) %v", frameAddrType, err)
 		}
 		iseq, err := r.readIseqBody(iseqBody, pc, frameAddrType)
 		if err != nil {
@@ -1412,7 +1412,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		}
 		return true
 	}); err != nil {
-		log.Warnf("failed to visit symbols: %v", err)
+		log.Debugf("failed to visit symbols: %v", err)
 	}
 
 	// NOTE for ruby 3.3.0+, if ruby is stripped, we have no way of locating
@@ -1427,7 +1427,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		}
 		return true
 	}); err != nil {
-		log.Warnf("failed to locate TLS descriptor: %v", err)
+		log.Debugf("failed to locate TLS descriptor: %v", err)
 	}
 
 	// For statically-linked ruby, extract the direct TP-relative offset from
@@ -1437,7 +1437,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	if isBinRuby {
 		offset, ecErr := extractEcTLSOffset(ef)
 		if ecErr != nil {
-			log.Warnf("failed to extract EC TLS offset for static ruby: %v", ecErr)
+			log.Debugf("failed to extract EC TLS offset for static ruby: %v", ecErr)
 		} else {
 			staticTLSOffset = offset
 		}
@@ -1451,7 +1451,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		tlsModuleIdOffset = libpf.Address(r.Off)
 		return false
 	}, pfelf.RelDTPMOD64); err != nil {
-		log.Warnf("failed to find DTPMOD64 relocation: %v", err)
+		log.Debugf("failed to find DTPMOD64 relocation: %v", err)
 	}
 
 	log.Debugf("Discovered EC tls tpbase offset %x, static tls offset %d, dtpmod offset %x, fallback ctx %x, interp ranges: %v, global symbols: %x",

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -309,7 +309,7 @@ func (pm *ProcessManager) processNewMapping(pid libpf.PID, m *Mapping) uint64 {
 	fileID := uint64(host.FileIDFromLibpf(mf.File.Value().FileID))
 	for _, prefix := range prefixes {
 		if err = pm.ebpf.UpdatePidPageMappingInfo(pid, prefix, fileID, bias); err != nil {
-			log.Debugf("Failed to update pid_page_to_mapping_info (pid: %d, page: 0x%x/%d): %v",
+			log.Errorf("Failed to update pid_page_to_mapping_info (pid: %d, page: 0x%x/%d): %v",
 				pid, prefix.Key, prefix.Length, err)
 			break
 		}

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -309,7 +309,7 @@ func (pm *ProcessManager) processNewMapping(pid libpf.PID, m *Mapping) uint64 {
 	fileID := uint64(host.FileIDFromLibpf(mf.File.Value().FileID))
 	for _, prefix := range prefixes {
 		if err = pm.ebpf.UpdatePidPageMappingInfo(pid, prefix, fileID, bias); err != nil {
-			log.Errorf("Failed to update pid_page_to_mapping_info (pid: %d, page: 0x%x/%d): %v",
+			log.Debugf("Failed to update pid_page_to_mapping_info (pid: %d, page: 0x%x/%d): %v",
 				pid, prefix.Key, prefix.Length, err)
 			break
 		}
@@ -396,7 +396,7 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapp
 
 	elfSpaceVA, ok := info.addressMapper.FileOffsetToVirtualAddress(m.FileOffset)
 	if !ok {
-		log.Warnf("Failed to map file offset of PID %d, file %s, offset %d",
+		log.Debugf("Failed to map file offset of PID %d, file %s, offset %d",
 			pr.PID(), m.Path, m.FileOffset)
 		return libpf.FrameMapping{}, anonymousMappingsWanted, errInvalidVirtualAddress
 	}
@@ -744,7 +744,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	collectAnonymousMappings = pm.processRemovedInterpreters(pid, interpretersValid)
 	if collectAnonymousMappings != previousAnonymousMappingsWanted {
 		if err := pm.updatePIDAnonymousMappingInterest(pid, collectAnonymousMappings); err != nil {
-			log.Errorf("Failed to update anonymous mapping interest for PID %d: %v", pid, err)
+			log.Debugf("Failed to update anonymous mapping interest for PID %d: %v", pid, err)
 		}
 	}
 	pm.mu.Unlock()
@@ -782,7 +782,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		err := instance.SynchronizeMappings(pm.ebpf, pm.exeReporter, pr, interpreterMappings.mappings())
 		if err != nil {
 			if alive, _ := isPIDLive(pid); alive {
-				log.Errorf("Failed to handle new anonymous mapping for PID %d: %v", pid, err)
+				log.Debugf("Failed to handle new anonymous mapping for PID %d: %v", pid, err)
 			} else {
 				log.Debugf("Failed to handle new anonymous mapping for PID %d: process exited",
 					pid)

--- a/tracer/systemconfig.go
+++ b/tracer/systemconfig.go
@@ -370,7 +370,7 @@ func determineSysConfig(coll *cebpf.CollectionSpec, maps map[string]*cebpf.Map,
 		}
 	}
 
-	log.Infof("Found offsets: task stack %#x, pt_regs %#x, tpbase %#x, vma vm_file %#x, vma vm_flags %#x",
+	log.Debugf("Found offsets: task stack %#x, pt_regs %#x, tpbase %#x, vma vm_file %#x, vma vm_flags %#x",
 		vars.task_stack_offset,
 		vars.stack_ptregs_offset,
 		vars.tpbase_offset,
@@ -541,7 +541,7 @@ func loadRodataVars(coll *cebpf.CollectionSpec, kmod *kallsyms.Module, cfg *Conf
 
 	pacMask := pacmask.GetPACMask()
 	if pacMask != 0 {
-		log.Infof("Determined PAC mask to be 0x%016X", pacMask)
+		log.Debugf("Determined PAC mask to be 0x%016X", pacMask)
 	} else {
 		log.Debug("PAC is not enabled on the system.")
 	}


### PR DESCRIPTION
After deploying the profiler internally across ~8k hosts, we observed a high volume of log spam. This PR downgrades the log level of the most frequent ones to debug. These logs are not meaningful to customers but remain highly useful for us when debugging the profiler, making debug the appropriate level.

I also took this opportunity to downgrade a few other logs, for consistency. We can follow up later to downgrade more based on our internal observations or any feedback you might have!

#### Log Volumetry (1-day window)

| Log Message | Target Level | Count (1-day) |
| :--- | :---: | :---: |
| `Unable to find heap for stub: pid = [829-4193255], stub.start = *` | **WARN** | 128M |
| `Failed to handle new anonymous mapping for PID [205388-4123229]: fail to read heap array: failed to read PID [205388-4123229] at 0x0: bad address` | **ERROR** | 500k |
| `Failed to create JIT area for stub (pid = 1537922, stub.start = 0xfe93ebbb48c0): failed to analyze stub: failed to read PID 1537922 at 0xfe93ebbb48c0: no such process` | **WARN** | 9k |
| `Found offsets: task stack 0x20, pt_regs 0x3f58, tpbase 0x2428` | **INFO** | 6k |
| `Failed to extract TLS offset: could not extract TLS offset from _PyThreadState_GetCurrent: found MRS TPIDR_EL0 but no matching ADD/LDR with TLS offset` | **INFO** | 2k |
| `RubySymbolizer: Failed to get line number (3) failed to read iseq_constant_body: failed to read PID 2896310 at 0x0: bad address` | **WARN** | 1k |
| `Determined PAC mask to be 0x007F000000000000` | **INFO** | 1k |
| `Failed to update pid_page_to_mapping_info (pid: [965046-3631130], page: * /* update: cannot allocate memory` | **ERROR** | 1k |