### PR TITLE
Update "coredump rebase" to allow passing a list of files

### DIFF
--- a/tools/coredump/rebase.go
+++ b/tools/coredump/rebase.go
@@ -19,7 +19,7 @@ type rebaseCmd struct {
 	store *modulestore.Store
 
 	allowDirty bool
-	flags *flag.FlagSet
+	flags      *flag.FlagSet
 }
 
 func newRebaseCmd(store *modulestore.Store) *ffcli.Command {
@@ -30,8 +30,8 @@ func newRebaseCmd(store *modulestore.Store) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "rebase",
 		Exec:       args.exec,
-		ShortUsage: "rebase",
-		ShortHelp:  "Update all test cases by running them and saving the current unwinding",
+		ShortUsage: "rebase [testCaseJsonFiles]",
+		ShortHelp:  "Update all test cases (or a subset of them) by running them and saving the current unwinding",
 		FlagSet:    set,
 	}
 }

--- a/tools/coredump/rebase.go
+++ b/tools/coredump/rebase.go
@@ -19,12 +19,12 @@ type rebaseCmd struct {
 	store *modulestore.Store
 
 	allowDirty bool
+	flags *flag.FlagSet
 }
 
 func newRebaseCmd(store *modulestore.Store) *ffcli.Command {
-	args := &rebaseCmd{store: store}
-
 	set := flag.NewFlagSet("rebase", flag.ExitOnError)
+	args := &rebaseCmd{store: store, flags: set}
 	set.BoolVar(&args.allowDirty, "allow-dirty", false, "Allow uncommitted changes in git")
 
 	return &ffcli.Command{
@@ -37,9 +37,12 @@ func newRebaseCmd(store *modulestore.Store) *ffcli.Command {
 }
 
 func (cmd *rebaseCmd) exec(context.Context, []string) (err error) {
-	cases, err := findTestCases(true)
-	if err != nil {
-		return fmt.Errorf("failed to find test cases: %w", err)
+	cases := cmd.flags.Args()
+	if len(cases) == 0 {
+		cases, err = findTestCases(true)
+		if err != nil {
+			return fmt.Errorf("failed to find test cases: %w", err)
+		}
 	}
 
 	if !cmd.allowDirty {


### PR DESCRIPTION
This allows rebasing a small number of files rather than the entire testdata directory, and can be significantly faster in the case where the coredump files aren't available locally and need to be downloaded.