### PR TITLE
go: bump supported version to 1.27

### DIFF
--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -123,8 +123,8 @@ func loader(cfg Config, info *interpreter.LoaderInfo) (interpreter.Data, error) 
 		}
 	}
 
-	if version.Compare(goVersion, "go1.27") >= 0 {
-		return nil, fmt.Errorf("unsupported Go version %s (need >= 1.13 and <= 1.26)", goVersion)
+	if version.Compare(goVersion, "go1.28") >= 0 {
+		return nil, fmt.Errorf("unsupported Go version %s (need >= 1.13 and <= 1.27)", goVersion)
 	}
 
 	log.Debugf("file %s detected as go version %s", info.FileName(), goVersion)


### PR DESCRIPTION
Verified with tools/gooffsets and go1.27rc1.

```
go install golang.org/dl/go1.27rc1@latest
go1.27rc1 download
```

More of a quick fix, so users can profile Go 1.27 applications.