### PR TITLE
Use xxh3 for frame cache hashing

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"slices"
 	"time"
 
 	lru "github.com/elastic/go-freelru"
+	"github.com/zeebo/xxh3"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 
 	"go.opentelemetry.io/ebpf-profiler/host"
@@ -306,9 +306,7 @@ func (pm *ProcessManager) maybeNotifyAPMAgent(
 }
 
 func hashFrameCacheKey(fk frameCacheKey) uint32 {
-	h := fnv.New32a()
-	h.Write(pfunsafe.FromSlice(fk.data[:]))
-	return h.Sum32()
+	return uint32(xxh3.Hash(pfunsafe.FromPointer(&fk)))
 }
 
 // HandleTrace processes and reports the given host.Trace. This function

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -225,3 +225,14 @@ func TestFrameCacheSharesNativeFallbackFramesAcrossProcesses(t *testing.T) {
 	assert.Equal(t, uint64(1), pm.frameCacheMiss.Load())
 	assert.Equal(t, uint64(1), pm.frameCacheHit.Load())
 }
+
+func BenchmarkHashFrameCacheKey(b *testing.B) {
+	key := frameCacheKey{
+		pid:  123,
+		data: [3]uint64{0xfeedbabefeedbabe, 0xbeefbeefbeefbeef, 0xdeaddeaddeaddead},
+	}
+
+	for b.Loop() {
+		hashFrameCacheKey(key)
+	}
+}


### PR DESCRIPTION
We see hashing in small amounts in the flamegraph:

<img width="739" height="216" alt="image" src="https://github.com/user-attachments/assets/090c36b8-d35a-45e3-a3bf-aee48b39259d" />

Elastic's benchmarks suggest that xxh3 might be a better choice than fnv:

* https://github.com/elastic/go-freelru#comparison-of-hash-functions

Not only is xxh3 much faster here, it's also PGO friendly (Intel N100 benchmarks):

* fnv32 + no pgo: 40.7ns
* fnv32 + pgo: 40.7ns
* xxh3 + no pgo: 11.4ns
* xxh3 + pgo: 6.4ns

The numbers are less impressive on more powerful hardware (AMD EPYC 7642): 19.1ns for fnv32, 6.2ns -> 4.9ns xxh3.

To produce a PGO profile:

```
$ go test -v -pgo=off ./processmanager -bench=BenchmarkHashFrameCacheKey -benchmem -run XXX -cpuprofile=default.pgo
```

To make use of it:

```
$ go test -v -pgo=default.pgo ./processmanager -bench=BenchmarkHashFrameCacheKey -benchmem -run XXX
```