### PR TITLE
Check SHT_NOTE for build-id

### DIFF
--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -628,10 +628,48 @@ func (f *File) VisitNotes(visitor func(uint64, []byte) bool) error {
 	return ErrNoteNotFound
 }
 
+// visitBuildIDNoteSections iterates the named ELF note sections that can contain build IDs.
+// The visitor must make copies of the 'data' it keeps after return.
+func (f *File) visitBuildIDNoteSections(visitor func(uint64, []byte) bool) error {
+	if f.InsideCore {
+		return ErrNoteNotFound
+	}
+
+	if err := f.LoadSections(); err != nil {
+		return ErrNoteNotFound
+	}
+
+	rdr := pfbufio.GetReader()
+	defer pfbufio.PutReader(rdr)
+
+	visited := false
+	buildIDSections := []string{".note.gnu.build-id", ".note.go.buildid", ".notes"}
+	for i := range f.Sections {
+		section := &f.Sections[i]
+		if section.Type != elf.SHT_NOTE || section.Size == 0 ||
+			!slices.Contains(buildIDSections, section.Name) {
+			continue
+		}
+		visited = true
+
+		rdr.Init(f.elfReader, int64(section.Offset), int64(section.Size))
+		err := visitNotes(rdr, visitor)
+		if errors.Is(err, ErrNoteNotFound) {
+			continue
+		}
+		return err
+	}
+
+	if !visited {
+		return ErrNoteNotFound
+	}
+	return nil
+}
+
 // parseNotes parses and caches the ELF notes for the File.
 func (f *File) parseNotes() error {
 	if f.notesError == errNotProcessed {
-		f.notesError = f.VisitNotes(func(note uint64, desc []byte) bool {
+		cacheNote := func(note uint64, desc []byte) bool {
 			switch note {
 			case NoteGnuBuildId:
 				f.gnuBuildId = hex.EncodeToString(desc)
@@ -639,11 +677,19 @@ func (f *File) parseNotes() error {
 				f.goBuildId = string(desc)
 			}
 			return true
-		})
-		if errors.Is(f.notesError, ErrNoteNotFound) {
-			// Visiting every note is expected here because parseNotes caches all
-			// build ID notes, which results in terminating with ErrNoteNotFound.
-			f.notesError = nil
+		}
+
+		f.notesError = f.visitBuildIDNoteSections(cacheNote)
+		if f.notesError != nil && !errors.Is(f.notesError, ErrNoteNotFound) {
+			return f.notesError
+		}
+		if f.notesError != nil || f.gnuBuildId == "" || f.goBuildId == "" {
+			f.notesError = f.VisitNotes(cacheNote)
+			if errors.Is(f.notesError, ErrNoteNotFound) {
+				// Visiting every note is expected here because parseNotes caches all
+				// build ID notes, which results in terminating with ErrNoteNotFound.
+				f.notesError = nil
+			}
 		}
 	}
 	return f.notesError

--- a/libpf/pfelf/notes_test.go
+++ b/libpf/pfelf/notes_test.go
@@ -90,6 +90,117 @@ func TestGetBuildIDVisitsAllProgramNoteSegments(t *testing.T) {
 	assert.Equal(t, expected, buildID)
 }
 
+func TestGetBuildIDReadsNamedNoteSection(t *testing.T) {
+	expected := "e4b38c63b6127d09ccaf62932cfb72bbf2240fbe"
+	desc, err := hex.DecodeString(expected)
+	require.NoError(t, err)
+
+	goNote := testELFNote("Go", 4, []byte("go-build-id"))
+	gnuNote := testELFNote("GNU", 3, desc)
+	shstrtab := []byte("\x00.note.gnu.build-id\x00.shstrtab\x00")
+	sectionHeaderOffset := len(goNote) + len(gnuNote) + len(shstrtab)
+
+	var sectionHeaders bytes.Buffer
+	require.NoError(t, binary.Write(&sectionHeaders, binary.LittleEndian, []elf.Section64{
+		{},
+		{
+			Name:      1,
+			Type:      uint32(elf.SHT_NOTE),
+			Off:       uint64(len(goNote)),
+			Size:      uint64(len(gnuNote)),
+			Addralign: 4,
+		},
+		{
+			Name:      uint32(len("\x00.note.gnu.build-id\x00")),
+			Type:      uint32(elf.SHT_STRTAB),
+			Off:       uint64(len(goNote) + len(gnuNote)),
+			Size:      uint64(len(shstrtab)),
+			Addralign: 1,
+		},
+	}))
+
+	data := make([]byte, 0, sectionHeaderOffset+sectionHeaders.Len())
+	data = append(data, goNote...)
+	data = append(data, gnuNote...)
+	data = append(data, shstrtab...)
+	data = append(data, sectionHeaders.Bytes()...)
+
+	f := &File{
+		elfReader: bytes.NewReader(data),
+		Progs: []Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: 0, Filesz: uint64(len(goNote))}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_LOAD, Off: 0, Filesz: uint64(len(goNote) + len(gnuNote))}},
+		},
+		elfHeader: elf.Header64{
+			Shoff:    uint64(sectionHeaderOffset),
+			Shnum:    3,
+			Shstrndx: 2,
+		},
+		notesError: errNotProcessed,
+	}
+
+	buildID, err := f.GetBuildID()
+	require.NoError(t, err)
+	assert.Equal(t, expected, buildID)
+}
+
+func TestGetBuildIDInsideCoreUsesProgramNotes(t *testing.T) {
+	expected := "5883092a3cf39b3f4a8b5289b409829651c3ada3"
+	programDesc, err := hex.DecodeString(expected)
+	require.NoError(t, err)
+
+	sectionDesc, err := hex.DecodeString("e4b38c63b6127d09ccaf62932cfb72bbf2240fbe")
+	require.NoError(t, err)
+
+	programNote := testELFNote("GNU", 3, programDesc)
+	sectionNote := testELFNote("GNU", 3, sectionDesc)
+	shstrtab := []byte("\x00.note.gnu.build-id\x00.shstrtab\x00")
+	sectionHeaderOffset := len(programNote) + len(sectionNote) + len(shstrtab)
+
+	var sectionHeaders bytes.Buffer
+	require.NoError(t, binary.Write(&sectionHeaders, binary.LittleEndian, []elf.Section64{
+		{},
+		{
+			Name:      1,
+			Type:      uint32(elf.SHT_NOTE),
+			Off:       uint64(len(programNote)),
+			Size:      uint64(len(sectionNote)),
+			Addralign: 4,
+		},
+		{
+			Name:      uint32(len("\x00.note.gnu.build-id\x00")),
+			Type:      uint32(elf.SHT_STRTAB),
+			Off:       uint64(len(programNote) + len(sectionNote)),
+			Size:      uint64(len(shstrtab)),
+			Addralign: 1,
+		},
+	}))
+
+	data := make([]byte, 0, sectionHeaderOffset+sectionHeaders.Len())
+	data = append(data, programNote...)
+	data = append(data, sectionNote...)
+	data = append(data, shstrtab...)
+	data = append(data, sectionHeaders.Bytes()...)
+
+	f := &File{
+		elfReader:  bytes.NewReader(data),
+		InsideCore: true,
+		Progs: []Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_NOTE, Off: 0, Filesz: uint64(len(programNote))}},
+		},
+		elfHeader: elf.Header64{
+			Shoff:    uint64(sectionHeaderOffset),
+			Shnum:    3,
+			Shstrndx: 2,
+		},
+		notesError: errNotProcessed,
+	}
+
+	buildID, err := f.GetBuildID()
+	require.NoError(t, err)
+	assert.Equal(t, expected, buildID)
+}
+
 func testELFNote(name string, noteType uint32, desc []byte) []byte {
 	nameBytes := append([]byte(name), 0)
 	note := make([]byte, 12)


### PR DESCRIPTION
We have some binaries that do not have build-id in `PT_NOTE`.

Here `readelf -nW` shows both GNU and Go build ids:

```
Displaying notes found in: .note.gnu.build-id
  Owner                Data size        Description
  GNU                  0x00000014       NT_GNU_BUILD_ID (unique build ID bitstring)         Build ID: e4b38c63b6127d09ccaf62932cfb72bbf2240fbe

Displaying notes found in: .note.go.buildid
  Owner                Data size        Description
  Go                   0x00000053       GO BUILDID         description data: 42 67 78 32 55 46 4b 61 4f 4a 64 5f 59 5a 62 35 7a 73 79 68 2f 6d 6e 4a 73 39 32 63 47 6b 48 4f 63 5a 6b 4a 77 53 5f 49 6c 2f 73 31 6c 44 51 6a 42 73 2d 6f 4f 78 6a 52 6c 39 48 76 45 5a 2f 62 4c 61 46 6c 47 6f 31 4a 33 77 4a 56 62 59 77 74 6e 58 34
```

Here `readelf -lW` shows one `PT_NOTE` program header:

```
Program Headers:
  Type           Offset   VirtAddr           FileSiz  MemSiz   Flg Align
  NOTE           0x000f5c 0x0000000000400f5c 0x000064 0x000064 R   0x4

Section to Segment mapping:
  Segment Sections...
   02     .note.go.buildid
   03     .text .plt .interp .note.gnu.build-id .note.go.buildid
```

The GNU build-id note exists, but it is not covered by the `PT_NOTE` program header:

```
[34] .note.gnu.build-id NOTE 0000000000400fc0 000fc0 000024 00 A 0 0 4
[35] .note.go.buildid  NOTE 0000000000400f5c 000f5c 000064 00 A 0 0 4
```

This doesn't bother `file`, so we it should work for us too:

```
$ file /usr/bin/consul
/usr/bin/consul: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=e4b38c63b6127d09ccaf62932cfb72bbf2240fbe, with debug_info, not stripped
```