### PR TITLE
Report main executable build id in TraceMeta

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -130,24 +130,25 @@ type Trace struct {
 
 // EbpfTrace represents a stack trace from Ebpf code.
 type EbpfTrace struct {
-	EnvVars          map[String]String
-	ProcessName      String
-	ExecutablePath   String
-	ContainerID      String
-	CustomLabels     map[String]String
-	Comm             Comm
-	FrameData        []uint64
-	KernelFrames     Frames
-	FrameDataBuf     [3072]uint64
-	Value            int64
-	KTime            int64
-	CpuID            uint32
-	TID              PID
-	PID              PID
-	NumFrames        uint16
-	Origin           Origin
-	APMTraceID       APMTraceID
-	APMTransactionID APMTransactionID
+	EnvVars               map[String]String
+	ProcessName           String
+	ExecutableMappingFile FrameMappingFileData
+	ExecutablePath        String
+	ContainerID           String
+	CustomLabels          map[String]String
+	Comm                  Comm
+	FrameData             []uint64
+	KernelFrames          Frames
+	FrameDataBuf          [3072]uint64
+	Value                 int64
+	KTime                 int64
+	CpuID                 uint32
+	TID                   PID
+	PID                   PID
+	NumFrames             uint16
+	Origin                Origin
+	APMTraceID            APMTraceID
+	APMTransactionID      APMTransactionID
 }
 
 type EbpfFrame []uint64

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // CoredumpProcess implements Process interface to ELF coredumps.
@@ -209,6 +210,21 @@ func (cd *CoredumpProcess) GetProcessMeta(_ MetaConfig) ProcessMeta {
 
 func (cd *CoredumpProcess) GetExe() (libpf.String, error) {
 	return cd.fname, nil
+}
+
+func (cd *CoredumpProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	executable := cd.MainExecutable()
+	if executable == "" {
+		return util.OnDiskFileIdentifier{}, errors.New("main executable is unknown")
+	}
+	cf, ok := cd.files[executable]
+	if !ok {
+		return util.OnDiskFileIdentifier{}, fmt.Errorf("executable file %q not found", executable)
+	}
+	return util.OnDiskFileIdentifier{
+		DeviceID: 1,
+		InodeNum: cf.inode,
+	}, nil
 }
 
 // IterateMappings implements the Process interface.

--- a/process/process.go
+++ b/process/process.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/stringutil"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // ErrNoMappings is returned when no mappings can be extracted.
@@ -108,6 +109,17 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 		return libpf.NullString, err
 	}
 	return libpf.Intern(str), nil
+}
+
+func (sp *systemProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	var stat unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf("/proc/%d/exe", sp.pid), &stat); err != nil {
+		return util.OnDiskFileIdentifier{}, err
+	}
+	return util.OnDiskFileIdentifier{
+		DeviceID: uint64(stat.Dev),
+		InodeNum: stat.Ino,
+	}, nil
 }
 
 func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {

--- a/process/types.go
+++ b/process/types.go
@@ -112,6 +112,8 @@ type ProcessMeta struct {
 	Name libpf.String
 	// executable path retrieved from /proc/PID/exe
 	Executable libpf.String
+	// mapping file data for the executable mapping matching /proc/PID/exe
+	ExecutableMappingFile libpf.FrameMappingFileData
 	// process env vars from /proc/PID/environ
 	EnvVariables map[libpf.String]libpf.String
 	// container ID retrieved from /proc/PID/cgroup
@@ -136,6 +138,9 @@ type Process interface {
 
 	// GetExe returns the executable path of the process.
 	GetExe() (libpf.String, error)
+
+	// GetExecutableFileIdentifier returns the device and inode of /proc/PID/exe.
+	GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error)
 
 	// IterateMappings parses process memory mappings and calls the
 	// callback for each mapping. The RawMapping's Path field may reference

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -329,20 +329,21 @@ func hashFrameCacheKey(fk frameCacheKey) uint32 {
 // strategy needs to be updated accordingly.
 func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *samples.TypeMetadata) {
 	meta := &samples.TraceEventMeta{
-		Timestamp:      libpf.UnixTime64(times.KTime(bpfTrace.KTime).UnixNano()),
-		Comm:           bpfTrace.Comm,
-		PID:            bpfTrace.PID,
-		TID:            bpfTrace.TID,
-		APMServiceName: "", // filled in below
-		CPU:            bpfTrace.CpuID,
-		ProcessName:    bpfTrace.ProcessName,
-		ExecutablePath: bpfTrace.ExecutablePath,
-		ContainerID:    bpfTrace.ContainerID,
-		ProfileType:    profileType,
-		Value:          bpfTrace.Value,
-		EnvVars:        bpfTrace.EnvVars,
-		TraceID:        bpfTrace.APMTraceID,
-		SpanID:         bpfTrace.APMTransactionID,
+		Timestamp:             libpf.UnixTime64(times.KTime(bpfTrace.KTime).UnixNano()),
+		Comm:                  bpfTrace.Comm,
+		PID:                   bpfTrace.PID,
+		TID:                   bpfTrace.TID,
+		APMServiceName:        "", // filled in below
+		CPU:                   bpfTrace.CpuID,
+		ProcessName:           bpfTrace.ProcessName,
+		ExecutableMappingFile: bpfTrace.ExecutableMappingFile,
+		ExecutablePath:        bpfTrace.ExecutablePath,
+		ContainerID:           bpfTrace.ContainerID,
+		ProfileType:           profileType,
+		Value:                 bpfTrace.Value,
+		EnvVars:               bpfTrace.EnvVars,
+		TraceID:               bpfTrace.APMTraceID,
+		SpanID:                bpfTrace.APMTransactionID,
 	}
 
 	pid := bpfTrace.PID

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -573,6 +573,14 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		// The /proc/PID/exe returns "not exists" error also in
 		// the case of main thread exit. Ignore it.
 	}
+	var exeFileID util.OnDiskFileIdentifier
+	exeFileIDValid := false
+	if exe != libpf.NullString {
+		if fileID, err := pr.GetExecutableFileIdentifier(); err == nil {
+			exeFileID = fileID
+			exeFileIDValid = true
+		}
+	}
 
 	pm.mu.Lock()
 	info := pm.getPidInformation(pid, pr)
@@ -580,9 +588,10 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		pm.mu.Unlock()
 		return
 	}
+	meta := info.meta
 	// Check if process meta needs an update
 	updateProcessMeta := exe != libpf.NullString && exe != info.meta.Executable
-	oldProcessContextInfo := info.meta.ProcessContextInfo
+	oldProcessContextInfo := meta.ProcessContextInfo
 
 	// Get existing info
 	oldMappings := info.mappings
@@ -618,6 +627,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	mappings := make([]Mapping, 0, capHint)
 	mpAdd := make([]*Mapping, 0, capHint)
 	var processContextInfo processcontext.Info
+	var executableMappingFile libpf.FrameMappingFileData
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
@@ -671,6 +681,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			if fm.Valid() {
 				key := m.GetOnDiskFileIdentifier()
 				interpretersValid[key] = libpf.Void{}
+				if exeFileIDValid && key == exeFileID {
+					executableMappingFile = fm.Value().File.Value()
+				}
 
 				mappings = append(mappings, Mapping{
 					Vaddr:        libpf.Address(m.Vaddr),
@@ -757,7 +770,6 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	pm.pidPageToMappingInfoSize += numChanges
 
 	// Update metadata of the process.
-	var meta process.ProcessMeta
 	if updateProcessMeta {
 		meta = pr.GetProcessMeta(process.MetaConfig{IncludeEnvVars: pm.includeEnvVars})
 		pm.fillSelfContainerID(pid, &meta)
@@ -769,10 +781,12 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	info = pm.getPidInformation(pid, pr)
 	if info != nil {
 		info.mappings = mappings
-		if updateProcessMeta {
-			info.meta = meta
+		if !updateProcessMeta {
+			meta = info.meta
 		}
-		info.meta.ProcessContextInfo = processContextInfo
+		meta.ExecutableMappingFile = executableMappingFile
+		meta.ProcessContextInfo = processContextInfo
+		info.meta = meta
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -146,6 +146,10 @@ func (h *testEbpfHandler) SupportsLPMTrieBatchOperations() bool {
 type testProcess struct {
 	pid      libpf.PID
 	mappings []process.RawMapping
+	meta     process.ProcessMeta
+	exe      libpf.String
+	exeID    util.OnDiskFileIdentifier
+	exeIDErr error
 }
 
 func (tp *testProcess) PID() libpf.PID {
@@ -157,11 +161,18 @@ func (tp *testProcess) GetMachineData() process.MachineData {
 }
 
 func (tp *testProcess) GetProcessMeta(process.MetaConfig) process.ProcessMeta {
-	return process.ProcessMeta{}
+	return tp.meta
 }
 
 func (tp *testProcess) GetExe() (libpf.String, error) {
-	return libpf.NullString, nil
+	return tp.exe, nil
+}
+
+func (tp *testProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	if tp.exeIDErr != nil {
+		return util.OnDiskFileIdentifier{}, tp.exeIDErr
+	}
+	return tp.exeID, nil
 }
 
 func (tp *testProcess) IterateMappings(callback func(process.RawMapping) bool) (uint32, error) {
@@ -482,6 +493,65 @@ func TestSynchronizeProcessSkipsDllMappingsWithoutAnonymousMappingInterest(t *te
 	})
 
 	require.Empty(instance.syncMappings)
+}
+
+func TestSynchronizeProcessAddsExecutableMappingFileFromMatchingMapping(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exePath := libpf.Intern("/usr/bin/app")
+	exeID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 2}
+	fileID := libpf.NewFileID(3, 4)
+	frameMapping := libpf.NewFrameMapping(libpf.FrameMappingData{
+		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+			FileID:     fileID,
+			FileName:   libpf.Intern("app"),
+			GnuBuildID: "gnu-build-id",
+			GoBuildID:  "go-build-id",
+		}),
+		Start: 0,
+		End:   0x1000,
+	})
+	rawMapping := process.RawMapping{
+		Vaddr:  0x1000,
+		Length: 0x1000,
+		Flags:  elf.PF_R | elf.PF_X,
+		Device: exeID.DeviceID,
+		Inode:  exeID.InodeNum,
+		Path:   exePath.String(),
+	}
+	pm := &ProcessManager{
+		ebpf: &testEbpfHandler{},
+		pidToProcessInfo: map[libpf.PID]*processInfo{
+			pid: {
+				meta: process.ProcessMeta{Executable: exePath},
+				mappings: []Mapping{
+					{
+						Vaddr:        libpf.Address(rawMapping.Vaddr),
+						Length:       rawMapping.Length,
+						Device:       rawMapping.Device,
+						Inode:        rawMapping.Inode,
+						FrameMapping: frameMapping,
+					},
+				},
+			},
+		},
+		exitEvents: make(map[libpf.PID]times.KTime),
+	}
+
+	pm.SynchronizeProcess(&testProcess{
+		pid:      pid,
+		exe:      exePath,
+		exeID:    exeID,
+		meta:     process.ProcessMeta{Executable: exePath},
+		mappings: []process.RawMapping{rawMapping},
+	})
+
+	require.Equal(libpf.FrameMappingFileData{
+		FileID:     fileID,
+		FileName:   libpf.Intern("app"),
+		GnuBuildID: "gnu-build-id",
+		GoBuildID:  "go-build-id",
+	}, pm.MetaForPID(pid).ExecutableMappingFile)
 }
 
 func TestIsInterpreterMapping(t *testing.T) {

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -57,10 +57,11 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	key := samples.ResourceKey{
-		APMServiceName: meta.APMServiceName,
-		ContainerID:    meta.ContainerID,
-		PID:            int64(meta.PID),
-		ExecutablePath: meta.ExecutablePath,
+		APMServiceName:        meta.APMServiceName,
+		ContainerID:           meta.ContainerID,
+		PID:                   int64(meta.PID),
+		ExecutableMappingFile: meta.ExecutableMappingFile,
+		ExecutablePath:        meta.ExecutablePath,
 	}
 	traceHash := traceutil.HashTrace(trace)
 

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -220,14 +220,11 @@ func (p *Pdata) setProfile(
 				mapping.SetFilenameStrindex(stringSet.Add(mf.FileName.String()))
 
 				attrMgr.AppendOptionalString(mapping.AttributeIndices(),
-					semconv.ProcessExecutableBuildIDGNUKey,
-					mf.GnuBuildID)
+					semconv.ProcessExecutableBuildIDGNUKey, mf.GnuBuildID)
 				attrMgr.AppendOptionalString(mapping.AttributeIndices(),
-					semconv.ProcessExecutableBuildIDGoKey,
-					mf.GoBuildID)
+					semconv.ProcessExecutableBuildIDGoKey, mf.GoBuildID)
 				attrMgr.AppendOptionalString(mapping.AttributeIndices(),
-					semconv.ProcessExecutableBuildIDHtlhashKey,
-					mf.FileID.StringNoQuotes())
+					semconv.ProcessExecutableBuildIDHtlhashKey, mf.FileID.StringNoQuotes())
 			}
 			locInfo.mappingIndex = index
 
@@ -317,6 +314,19 @@ func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envV
 		attrs.PutStr(string(semconv.ProcessExecutablePathKey), resource.ExecutablePath.String())
 		_, exeName := filepath.Split(resource.ExecutablePath.String())
 		attrs.PutStr(string(semconv.ProcessExecutableNameKey), exeName)
+	}
+	mf := resource.ExecutableMappingFile
+	if mf.GnuBuildID != "" {
+		attrs.PutStr(string(semconv.ProcessExecutableBuildIDGNUKey),
+			mf.GnuBuildID)
+	}
+	if mf.GoBuildID != "" {
+		attrs.PutStr(string(semconv.ProcessExecutableBuildIDGoKey),
+			mf.GoBuildID)
+	}
+	if !mf.FileID.IsZero() {
+		attrs.PutStr(string(semconv.ProcessExecutableBuildIDHtlhashKey),
+			mf.FileID.StringNoQuotes())
 	}
 
 	for key, value := range envVars {

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -386,6 +386,12 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 	})
 
 	resourceKey := samples.ResourceKey{
+		ExecutableMappingFile: libpf.FrameMappingFileData{
+			FileID:     libpf.NewFileID(0x0011223344556677, 0x8899aabbccddeeff),
+			FileName:   libpf.Intern("test"),
+			GnuBuildID: "gnu-build-id",
+			GoBuildID:  "go-build-id",
+		},
 		ExecutablePath: filePath,
 		PID:            123,
 		APMServiceName: "svc",
@@ -415,6 +421,12 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 	rp := profiles.ResourceProfiles().At(0)
 	val, _ := rp.Resource().Attributes().Get(string(semconv.ContainerIDKey))
 	assert.Equal(t, "container1", val.Str())
+	val, _ = rp.Resource().Attributes().Get(string(semconv.ProcessExecutableBuildIDGNUKey))
+	assert.Equal(t, "gnu-build-id", val.Str())
+	val, _ = rp.Resource().Attributes().Get(string(semconv.ProcessExecutableBuildIDGoKey))
+	assert.Equal(t, "go-build-id", val.Str())
+	val, _ = rp.Resource().Attributes().Get(string(semconv.ProcessExecutableBuildIDHtlhashKey))
+	assert.Equal(t, "00112233445566778899aabbccddeeff", val.Str())
 	assert.Equal(t, semconv.SchemaURL, rp.SchemaUrl())
 	require.Equal(t, 1, rp.ScopeProfiles().Len())
 	sp := rp.ScopeProfiles().At(0)

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -8,19 +8,20 @@ import (
 )
 
 type TraceEventMeta struct {
-	Comm           libpf.Comm
-	ProcessName    libpf.String
-	ExecutablePath libpf.String
-	ContainerID    libpf.String
-	EnvVars        map[libpf.String]libpf.String
-	APMServiceName string
-	Timestamp      libpf.UnixTime64
-	CPU            uint32
-	ProfileType    *TypeMetadata
-	Value          int64
-	PID, TID       libpf.PID
-	SpanID         libpf.APMSpanID
-	TraceID        libpf.APMTraceID
+	Comm                  libpf.Comm
+	ProcessName           libpf.String
+	ExecutableMappingFile libpf.FrameMappingFileData
+	ExecutablePath        libpf.String
+	ContainerID           libpf.String
+	EnvVars               map[libpf.String]libpf.String
+	APMServiceName        string
+	Timestamp             libpf.UnixTime64
+	CPU                   uint32
+	ProfileType           *TypeMetadata
+	Value                 int64
+	PID, TID              libpf.PID
+	SpanID                libpf.APMSpanID
+	TraceID               libpf.APMTraceID
 }
 
 // TraceEvents holds known information about a trace.
@@ -57,6 +58,9 @@ type SampleToEvents map[SampleKey]*TraceEvents
 type ResourceKey struct {
 	// ContainerID represents an extracted key from /proc/<PID>/cgroup.
 	ContainerID libpf.String
+
+	// ExecutableMappingFile contains mapping file data for the executable path.
+	ExecutableMappingFile libpf.FrameMappingFileData
 
 	// Executable path is retrieved from /proc/PID/exe
 	ExecutablePath libpf.String

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1138,19 +1138,20 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 	procMeta := t.processManager.MetaForPID(pid)
 	trace := t.tracePool.Get().(*libpf.EbpfTrace)
 	*trace = libpf.EbpfTrace{
-		Comm:             libpf.NewComm(ptr.Comm),
-		ExecutablePath:   procMeta.Executable,
-		ContainerID:      procMeta.ContainerID,
-		ProcessName:      procMeta.Name,
-		APMTraceID:       *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.Apm_trace_id)),
-		APMTransactionID: *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.Apm_transaction_id)),
-		PID:              pid,
-		TID:              libpf.PID(ptr.Tid),
-		Origin:           libpf.Origin(ptr.Origin),
-		Value:            int64(ptr.Value),
-		KTime:            int64(ptr.Ktime),
-		CpuID:            ptr.Cpu_id,
-		EnvVars:          procMeta.EnvVariables,
+		Comm:                  libpf.NewComm(ptr.Comm),
+		ExecutableMappingFile: procMeta.ExecutableMappingFile,
+		ExecutablePath:        procMeta.Executable,
+		ContainerID:           procMeta.ContainerID,
+		ProcessName:           procMeta.Name,
+		APMTraceID:            *(*libpf.APMTraceID)(unsafe.Pointer(&ptr.Apm_trace_id)),
+		APMTransactionID:      *(*libpf.APMTransactionID)(unsafe.Pointer(&ptr.Apm_transaction_id)),
+		PID:                   pid,
+		TID:                   libpf.PID(ptr.Tid),
+		Origin:                libpf.Origin(ptr.Origin),
+		Value:                 int64(ptr.Value),
+		KTime:                 int64(ptr.Ktime),
+		CpuID:                 ptr.Cpu_id,
+		EnvVars:               procMeta.EnvVariables,
 	}
 
 	switch trace.Origin {


### PR DESCRIPTION
This is a good proxy for running version for the cases where multiple versions of the same software are running simultaneously, for example during graceful upgrades. See: #1613.