### PR TITLE
asm/amd: sign-extend 32-bit memory displacements

### DIFF
--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -120,7 +120,7 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 				if src.Base == x86asm.RIP {
 					// For RIP-relative, the address is RIP + displacement.
 					// RIP points to the already updated next instruction.
-					v = expression.Add(i.Regs.GetX86(x86asm.RIP), expression.Imm(uint64(src.Disp)))
+					v = expression.Add(i.Regs.GetX86(x86asm.RIP), immFromDisp(src.Disp))
 				} else {
 					v = i.MemArg(src)
 				}
@@ -163,10 +163,21 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 	return inst, nil
 }
 
+// immFromDisp builds an immediate from an x86asm displacement. x86asm doesn't
+// sign-extend 32-bit displacements: they arrive zero-extended in
+// [0, math.MaxUint32], so recover the sign. A full 64-bit displacement (the
+// moffs64 absolute MOV form) is already the intended value and passes through.
+func immFromDisp(disp int64) expression.Expression {
+	if uint64(disp) <= math.MaxUint32 {
+		return expression.Imm(uint64(int32(disp)))
+	}
+	return expression.Imm(uint64(disp))
+}
+
 func (i *Interpreter) MemArg(src x86asm.Mem) expression.Expression {
 	vs := make([]expression.Expression, 0, 3)
 	if src.Disp != 0 {
-		vs = append(vs, expression.Imm(uint64(src.Disp)))
+		vs = append(vs, immFromDisp(src.Disp))
 	}
 	if src.Base != 0 {
 		vs = append(vs, i.Regs.GetX86(src.Base))

--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -218,3 +218,55 @@ func TestRIPRelativeAddressing(t *testing.T) {
 
 	assertEval(t, rcxVal, expectedExpr)
 }
+
+func TestDisplacementSignExtension(t *testing.T) {
+	// x86asm zero-extends 32-bit displacements, so immFromDisp must recover the
+	// sign for backward references while leaving a full 64-bit moffs address
+	// intact. Cover both immFromDisp call sites (MemArg and the RIP-relative
+	// MOV special case) plus the moffs64 form.
+	mem8 := func(addr uint64) expression.Expression {
+		return expression.ZeroExtend(expression.Mem(expression.Imm(addr), 8), 64)
+	}
+	for _, tc := range []struct {
+		name string
+		code []byte
+		base uint64
+		reg  x86asm.Reg
+		want expression.Expression
+	}{
+		{
+			// lea -0x1d13(%rip),%rdx at 0x6d96c -> 0x6bc60 (MemArg path).
+			name: "lea-negative-rip",
+			code: []byte{0x48, 0x8d, 0x15, 0xed, 0xe2, 0xff, 0xff},
+			base: 0x6d96c,
+			reg:  x86asm.RDX,
+			want: expression.Imm(0x6bc60),
+		},
+		{
+			// mov -0x1234(%rip),%rax at 0x10000: RIP=0x10007 -> [0xedd3]
+			// (RIP-relative MOV path, not MemArg).
+			name: "mov-negative-rip",
+			code: []byte{0x48, 0x8b, 0x05, 0xcc, 0xed, 0xff, 0xff},
+			base: 0x10000,
+			reg:  x86asm.RAX,
+			want: mem8(0xedd3),
+		},
+		{
+			// movabs rax, [0x1122334455667788]: the moffs64 form carries a full
+			// 64-bit address that must not be truncated to 32 bits.
+			name: "moffs64-full-width",
+			code: []byte{0x48, 0xa1, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11},
+			base: 0,
+			reg:  x86asm.RAX,
+			want: mem8(0x1122334455667788),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := NewInterpreterWithCode(tc.code)
+			it.CodeAddress = expression.Imm(tc.base)
+			_, err := it.Step()
+			require.NoError(t, err)
+			assertEval(t, it.Regs.GetX86(tc.reg), tc.want)
+		})
+	}
+}


### PR DESCRIPTION
`x86asm` stores 32-bit memory displacements in an `int64` `Disp` field without sign-extending them, so a negative displacement like `-0x1d13` comes back as `0xffffe2ed`. `MemArg` and the MOV RIP-relative path fold that in via `uint64(src.Disp)`, which puts every backward RIP-relative reference (and any `base+disp32` with the high bit set) 2^32 too high. 8-bit displacements aren't affected — x86asm sign-extends those.

Recover the sign with `int32` before widening, in both spots.

`TestRIPRelativeNegativeDisplacement` covers a backward `lea -0x1d13(%rip),%rdx`; it returns `0x6bc60 + 2^32` without the fix and the correct `0x6bc60` with it. The existing RIP-relative test only used a positive displacement, so the sign path was never exercised.

Discovered moving some crufty luajit code to the `asm/amd` interpreter. 
