### PR TITLE
fix(ruby): adjust 4.0.6 offsets

### DIFF
--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -1560,6 +1560,13 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		} else {
 			vms.vm_struct.gc_objspace = 1272
 		}
+		if version >= rubyVersion(4, 0, 6) {
+			// Ruby 4.0.6 inserted rb_vm_t.master_box before root_box,
+			// shifting the gc.objspace field by one pointer.
+			// https://github.com/ruby/ruby/blob/v4.0.6/vm_core.h
+			// https://github.com/ruby/ruby/commit/99aac00fa13c03f71d3a4d89686e447f2950df68
+			vms.vm_struct.gc_objspace += 8
+		}
 		vms.objspace.flags = 28
 	default:
 		rid.hasObjspace = true
@@ -1715,6 +1722,14 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 				vms.rb_ractor_struct.running_ec = 0x138
 			} else {
 				vms.rb_ractor_struct.running_ec = 0x148
+			}
+			if version >= rubyVersion(4, 0, 6) {
+				// Ruby 4.0.6 added runnable_hot_th and runnable_hot_th_waiting
+				// to struct rb_thread_sched, which is embedded in
+				// rb_ractor_struct.threads before running_ec.
+				// https://github.com/ruby/ruby/blob/v4.0.6/thread_pthread.h
+				// https://github.com/ruby/ruby/commit/21a2595676d2d3df0eccd3af74065e2ba2a876b5
+				vms.rb_ractor_struct.running_ec += 8
 			}
 		} else if version >= rubyVersion(3, 3, 0) {
 			if runtime.GOARCH == "amd64" {

--- a/tools/coredump/testdata/amd64/ruby-4.0.6-loop-no-tls.json
+++ b/tools/coredump/testdata/amd64/ruby-4.0.6-loop-no-tls.json
@@ -1,0 +1,77 @@
+{
+  "coredump-ref": "1df3f85c49df333abbb61dce1d28786b2e6e26bcba5a32b1fb5a0f0c168cbd62",
+  "threads": [
+    {
+      "lwp": 1486,
+      "frames": [
+        "libc.so.6+0x9eb2c",
+        "libc.so.6+0x4527d",
+        "ruby+0x35846",
+        "ruby+0x137e95",
+        "libc.so.6+0x4532f",
+        "ruby+0x1c5048",
+        "ruby+0x1ca058",
+        "ruby+0xf2573",
+        "ruby+0x1afe21",
+        "ruby+0x1bf994",
+        "ruby+0x1cf4f9",
+        "ruby+0x1c00e2",
+        "ruby+0x1c4a5f",
+        "ruby+0xf23ed",
+        "ruby+0x1afe21",
+        "ruby+0x1bf994",
+        "ruby+0x1cf4f9",
+        "Range#each+0 in <cfunc>:0",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
+        "?+0x0",
+        "ruby+0x1c0013",
+        "ruby+0x387b4",
+        "ruby+0x3b3d8",
+        "ruby+0x35ea5",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "ruby+0x35ef4"
+      ]
+    },
+    {
+      "lwp": 1488,
+      "frames": [
+        "libc.so.6+0x12a072",
+        "ruby+0x1795d0",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "1502636e3be8232c9cf801dfb533694aea985d449904f3e1295db26d7b348946",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "3168707c3fe4e3638bac4c56991c6f8a21502d283dc3f93786642a0c53b39f45",
+      "local-path": "/tmp/ruby-notls/ruby"
+    },
+    {
+      "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/ruby-4.0.6-loop-no-tls.json
+++ b/tools/coredump/testdata/amd64/ruby-4.0.6-loop-no-tls.json
@@ -1,17 +1,19 @@
 {
-  "coredump-ref": "1df3f85c49df333abbb61dce1d28786b2e6e26bcba5a32b1fb5a0f0c168cbd62",
+  "coredump-ref": "5c68e2f404d48aac9888ff3ff0fe3e1942bdc1b759693944fbaa6fc6f6e89a61",
   "threads": [
     {
-      "lwp": 1486,
+      "lwp": 2965,
       "frames": [
         "libc.so.6+0x9eb2c",
         "libc.so.6+0x4527d",
         "ruby+0x35846",
         "ruby+0x137e95",
         "libc.so.6+0x4532f",
-        "ruby+0x1c5048",
-        "ruby+0x1ca058",
-        "ruby+0xf2573",
+        "ruby+0x1aeffa",
+        "ruby+0x1bc69b",
+        "ruby+0x1c3541",
+        "ruby+0x1c4a5f",
+        "ruby+0xf253d",
         "ruby+0x1afe21",
         "ruby+0x1bf994",
         "ruby+0x1cf4f9",
@@ -24,7 +26,7 @@
         "Range#each+0 in <cfunc>:0",
         "Object#is_prime+0 in /tmp/loop.rb:14",
         "Object#sum_of_primes+0 in /tmp/loop.rb:24",
-        "?+0x0",
+        "block (2 levels) in <main>+0 in /tmp/loop.rb:34",
         "ruby+0x1c0013",
         "ruby+0x387b4",
         "ruby+0x3b3d8",
@@ -35,7 +37,7 @@
       ]
     },
     {
-      "lwp": 1488,
+      "lwp": 2967,
       "frames": [
         "libc.so.6+0x12a072",
         "ruby+0x1795d0",
@@ -45,6 +47,10 @@
     }
   ],
   "modules": [
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
     {
       "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
       "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
@@ -68,10 +74,6 @@
     {
       "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
       "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
-    },
-    {
-      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
-      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
     }
   ]
 }

--- a/tools/coredump/testdata/amd64/ruby-4.0.6-loop.json
+++ b/tools/coredump/testdata/amd64/ruby-4.0.6-loop.json
@@ -1,20 +1,32 @@
 {
-  "coredump-ref": "a51e5601191d314b83d86ce209da4b06c564f6e42c0542df9c736d356cba66f8",
+  "coredump-ref": "3d23f2b363ed1fa404fba59ff4a7e3376c8eb4de2c39006886d61478a6fe6024",
   "threads": [
     {
-      "lwp": 1485,
+      "lwp": 3153,
       "frames": [
         "libc.so.6+0x9eb2c",
         "libc.so.6+0x4527d",
         "libruby.so.4.0.6+0x43da4",
         "libruby.so.4.0.6+0x224835",
         "libc.so.6+0x4532f",
-        "libruby.so.4.0.6+0x2b9f42",
+        "libc.so.6+0x125d7b",
+        "libruby.so.4.0.6+0x11ab57",
+        "libruby.so.4.0.6+0x11e114",
+        "libruby.so.4.0.6+0x11edfb",
+        "libruby.so.4.0.6+0x11fb27",
+        "libruby.so.4.0.6+0x2ac8c6",
+        "libruby.so.4.0.6+0x2b1993",
+        "Object#is_prime+0 in /tmp/loop.rb:15",
+        "libruby.so.4.0.6+0x2b6993",
         "libruby.so.4.0.6+0x2bb51f",
         "libruby.so.4.0.6+0x1dfa3d",
         "libruby.so.4.0.6+0x29dae1",
         "libruby.so.4.0.6+0x2acb94",
         "libruby.so.4.0.6+0x2b2755",
+        "Range#each+0 in <cfunc>:0",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
+        "block (2 levels) in <main>+0 in /tmp/loop.rb:34",
         "libruby.so.4.0.6+0x2b6a62",
         "libruby.so.4.0.6+0x2bb51f",
         "libruby.so.4.0.6+0x1df8ed",
@@ -22,9 +34,9 @@
         "libruby.so.4.0.6+0x2acb94",
         "libruby.so.4.0.6+0x2b2755",
         "Range#each+0 in <cfunc>:0",
-        "Object#is_prime+0 in /tmp/loop.rb:14",
-        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
-        "?+0x0",
+        "block in <main>+0 in /tmp/loop.rb:33",
+        "Kernel#loop+0 in <internal:kernel>:169",
+        "<main>+0 in /tmp/loop.rb:32",
         "libruby.so.4.0.6+0x2b6993",
         "libruby.so.4.0.6+0xfbb04",
         "libruby.so.4.0.6+0x10000a",
@@ -35,7 +47,7 @@
       ]
     },
     {
-      "lwp": 1489,
+      "lwp": 3155,
       "frames": [
         "libc.so.6+0x12a072",
         "libruby.so.4.0.6+0x2646dc",
@@ -46,12 +58,20 @@
   ],
   "modules": [
     {
+      "ref": "f4b4dfbd9783ceb973d3a0a2f7ed86a588f065760e2dc520a74dd3c995a4781c",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "1502636e3be8232c9cf801dfb533694aea985d449904f3e1295db26d7b348946",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
       "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
       "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
     },
     {
-      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
-      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+      "ref": "32d4f7da410e83a981ea4f5b8b3f00b30c17fc3a6d349c88f6eec48899a50358",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/encdb.so"
     },
     {
       "ref": "1f11812a3e5d0daf20bc6387823e1c2cc02991c2b3a7581232160e15f7262846",
@@ -62,32 +82,24 @@
       "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
     },
     {
-      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
-      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
-    },
-    {
-      "ref": "f4b4dfbd9783ceb973d3a0a2f7ed86a588f065760e2dc520a74dd3c995a4781c",
-      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/trans/transdb.so"
-    },
-    {
-      "ref": "32d4f7da410e83a981ea4f5b8b3f00b30c17fc3a6d349c88f6eec48899a50358",
-      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/encdb.so"
-    },
-    {
       "ref": "d065a621708fa9f506c1dafcc572bd8359bb9221746d799f3a9814e53babbfff",
       "local-path": "/root/ruby-check/install-shared/lib/libruby.so.4.0.6"
-    },
-    {
-      "ref": "4bded688253066068b3da252c8d8927f2e9cb1099746d0ed4e6b2d1203bdd164",
-      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/monitor.so"
     },
     {
       "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
       "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
     },
     {
-      "ref": "1502636e3be8232c9cf801dfb533694aea985d449904f3e1295db26d7b348946",
-      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0"
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "4bded688253066068b3da252c8d8927f2e9cb1099746d0ed4e6b2d1203bdd164",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/monitor.so"
     }
   ]
 }

--- a/tools/coredump/testdata/amd64/ruby-4.0.6-loop.json
+++ b/tools/coredump/testdata/amd64/ruby-4.0.6-loop.json
@@ -1,0 +1,93 @@
+{
+  "coredump-ref": "a51e5601191d314b83d86ce209da4b06c564f6e42c0542df9c736d356cba66f8",
+  "threads": [
+    {
+      "lwp": 1485,
+      "frames": [
+        "libc.so.6+0x9eb2c",
+        "libc.so.6+0x4527d",
+        "libruby.so.4.0.6+0x43da4",
+        "libruby.so.4.0.6+0x224835",
+        "libc.so.6+0x4532f",
+        "libruby.so.4.0.6+0x2b9f42",
+        "libruby.so.4.0.6+0x2bb51f",
+        "libruby.so.4.0.6+0x1dfa3d",
+        "libruby.so.4.0.6+0x29dae1",
+        "libruby.so.4.0.6+0x2acb94",
+        "libruby.so.4.0.6+0x2b2755",
+        "libruby.so.4.0.6+0x2b6a62",
+        "libruby.so.4.0.6+0x2bb51f",
+        "libruby.so.4.0.6+0x1df8ed",
+        "libruby.so.4.0.6+0x29dae1",
+        "libruby.so.4.0.6+0x2acb94",
+        "libruby.so.4.0.6+0x2b2755",
+        "Range#each+0 in <cfunc>:0",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
+        "?+0x0",
+        "libruby.so.4.0.6+0x2b6993",
+        "libruby.so.4.0.6+0xfbb04",
+        "libruby.so.4.0.6+0x10000a",
+        "ruby+0x1185",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "ruby+0x11d4"
+      ]
+    },
+    {
+      "lwp": 1489,
+      "frames": [
+        "libc.so.6+0x12a072",
+        "libruby.so.4.0.6+0x2646dc",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "1f11812a3e5d0daf20bc6387823e1c2cc02991c2b3a7581232160e15f7262846",
+      "local-path": "/root/ruby-check/install-shared/bin/ruby"
+    },
+    {
+      "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "f4b4dfbd9783ceb973d3a0a2f7ed86a588f065760e2dc520a74dd3c995a4781c",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "32d4f7da410e83a981ea4f5b8b3f00b30c17fc3a6d349c88f6eec48899a50358",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "d065a621708fa9f506c1dafcc572bd8359bb9221746d799f3a9814e53babbfff",
+      "local-path": "/root/ruby-check/install-shared/lib/libruby.so.4.0.6"
+    },
+    {
+      "ref": "4bded688253066068b3da252c8d8927f2e9cb1099746d0ed4e6b2d1203bdd164",
+      "local-path": "/root/ruby-check/install-shared/lib/ruby/4.0.0/x86_64-linux/monitor.so"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "1502636e3be8232c9cf801dfb533694aea985d449904f3e1295db26d7b348946",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/ruby-4.0.6-loop-no-tls.json
+++ b/tools/coredump/testdata/arm64/ruby-4.0.6-loop-no-tls.json
@@ -1,0 +1,92 @@
+{
+  "coredump-ref": "d77c654c4baa33e21e08960f7d29348e632d2f0036f0c5bce01dafebdfed4d7e",
+  "threads": [
+    {
+      "lwp": 116134,
+      "frames": [
+        "ruby+0x1ec430",
+        "ruby+0x203f0f",
+        "ruby+0x12d423",
+        "ruby+0x1eefbf",
+        "ruby+0x1f9ebf",
+        "ruby+0x2082a7",
+        "ruby+0x1fa8cb",
+        "ruby+0x1feea3",
+        "ruby+0x12d2d3",
+        "ruby+0x1eefbf",
+        "ruby+0x1f9ebf",
+        "ruby+0x2082a7",
+        "Range#each+0 in <cfunc>:0",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
+        "block (2 levels) in <main>+0 in /tmp/loop.rb:34",
+        "ruby+0x1fa5bf",
+        "ruby+0x6a033",
+        "ruby+0x6c9ab",
+        "ruby+0x675af",
+        "libc.so.6+0x284c3",
+        "libc.so.6+0x28597",
+        "ruby+0x6766f"
+      ]
+    },
+    {
+      "lwp": 116136,
+      "frames": [
+        "libc.so.6+0xebe74",
+        "ruby+0x1b461f",
+        "libc.so.6+0x8595b",
+        "libc.so.6+0xebb4b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "82accf1f18cb9964e5c86f6198ae51524db1c3cdbdca4d7598ab593c8a6bc1ae",
+      "local-path": "/home/korniltsev/ruby-check/install-4.0.6/lib/ruby/4.0.0/aarch64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "fe5966a43e068ad7cb389c3affa069f4ee6f296e07d7ccc0398a23cfde4f0b7e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "f2d3ad2bf0b61f6bc944cc37d7b6ab7f88d2582b41ff989ca164803f56cc5f20",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "d5b262e559d38769e4959f036a1cc2c4009fa60b4ec836a7a19ca8554aebf5a5",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "b41cebf0be70f869bf60228cb5761f875ced865b0f4016f544d82f7a9ded28b0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "170380b4e7ab28ec86eb090b48df90f84089392cb72fecd5067e5b7a4dc5239f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "075c5d22f93ca55b1ce22bcf2f11218f24a67e0989e067e9fabd4bf6c66bbb18",
+      "local-path": "/home/korniltsev/ruby-check/install-4.0.6/lib/ruby/4.0.0/aarch64-linux/monitor.so"
+    },
+    {
+      "ref": "210b2068922587c05bdb3779cecd681986f390c61abe53bc8108663cf4bb1493",
+      "local-path": "/home/korniltsev/ruby-check/install-4.0.6/lib/ruby/4.0.0/aarch64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "39b6701812ed7135f28df49352b3f6664c7a9f56880a3fe50c1b87cd7681db9b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "393384096ffa869e1be20d2f91fdf08dfadb9f3e531dfe724085d8501d3f85d9",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "f26d61a395e4800cfc165f120af1de6341512b2a3e31c616001b19bc3902bb29",
+      "local-path": "/usr/lib/locale/locale-archive"
+    },
+    {
+      "ref": "a1969d5211836524f32ccd02928572bd74dfc2e109708611f475fd2d2b7888f4",
+      "local-path": "/tmp/ruby-notls/ruby"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/ruby-4.0.6-loop.json
+++ b/tools/coredump/testdata/arm64/ruby-4.0.6-loop.json
@@ -1,0 +1,102 @@
+{
+  "coredump-ref": "ba8ce44ac9e7abad29d35ef8f76491e041a5ebba2b0f1521177852c847f319f9",
+  "threads": [
+    {
+      "lwp": 105781,
+      "frames": [
+        "libruby.so.4.0.6+0x2dd5ec",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "libruby.so.4.0.6+0x2e2b9f",
+        "libruby.so.4.0.6+0x2e7493",
+        "libruby.so.4.0.6+0x20b96b",
+        "libruby.so.4.0.6+0x2ce833",
+        "libruby.so.4.0.6+0x2d89ef",
+        "libruby.so.4.0.6+0x2dd0d7",
+        "Range#each+0 in <cfunc>:0",
+        "Object#is_prime+0 in /tmp/loop.rb:14",
+        "Object#sum_of_primes+0 in /tmp/loop.rb:24",
+        "block (2 levels) in <main>+0 in /tmp/loop.rb:34",
+        "libruby.so.4.0.6+0x2e2eab",
+        "libruby.so.4.0.6+0x2e7493",
+        "libruby.so.4.0.6+0x20b833",
+        "libruby.so.4.0.6+0x2ce833",
+        "libruby.so.4.0.6+0x2d89ef",
+        "libruby.so.4.0.6+0x2dd0d7",
+        "Range#each+0 in <cfunc>:0",
+        "block in <main>+0 in /tmp/loop.rb:33",
+        "Kernel#loop+0 in <internal:kernel>:169",
+        "<main>+0 in /tmp/loop.rb:32",
+        "libruby.so.4.0.6+0x2e2b9f",
+        "libruby.so.4.0.6+0x1263cf",
+        "libruby.so.4.0.6+0x12a3bf",
+        "ruby+0xb2f",
+        "libc.so.6+0x284c3",
+        "libc.so.6+0x28597",
+        "ruby+0xbaf"
+      ]
+    },
+    {
+      "lwp": 105783,
+      "frames": [
+        "libc.so.6+0xebe74",
+        "libruby.so.4.0.6+0x291397",
+        "libc.so.6+0x8595b",
+        "libc.so.6+0xebb4b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "441431b6e284854b7fa75431566dceb40169f53ba6769b0cce7f703b048f3e44",
+      "local-path": "/home/korniltsev/ruby-check/install-shared-4.0.6/lib/ruby/4.0.0/aarch64-linux/monitor.so"
+    },
+    {
+      "ref": "f2d3ad2bf0b61f6bc944cc37d7b6ab7f88d2582b41ff989ca164803f56cc5f20",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "39b6701812ed7135f28df49352b3f6664c7a9f56880a3fe50c1b87cd7681db9b",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "82bf72f5f374de3639f5581f1e5c268fbdd7548d9afeb7a314106b264b662c4a",
+      "local-path": "/home/korniltsev/ruby-check/install-shared-4.0.6/lib/libruby.so.4.0.6"
+    },
+    {
+      "ref": "393384096ffa869e1be20d2f91fdf08dfadb9f3e531dfe724085d8501d3f85d9",
+      "local-path": "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+    },
+    {
+      "ref": "f26d61a395e4800cfc165f120af1de6341512b2a3e31c616001b19bc3902bb29",
+      "local-path": "/usr/lib/locale/locale-archive"
+    },
+    {
+      "ref": "e7f11338a9ea4e6b77e2cf0b504a32443435f682d879bf96c9020c8bd1f608ab",
+      "local-path": "/home/korniltsev/ruby-check/install-shared-4.0.6/lib/ruby/4.0.0/aarch64-linux/enc/trans/transdb.so"
+    },
+    {
+      "ref": "7d06455702e7083605afcb8686e069ef72afb7589a7f7600d7724629d26f6c6f",
+      "local-path": "/home/korniltsev/ruby-check/install-shared-4.0.6/lib/ruby/4.0.0/aarch64-linux/enc/encdb.so"
+    },
+    {
+      "ref": "fe5966a43e068ad7cb389c3affa069f4ee6f296e07d7ccc0398a23cfde4f0b7e",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "d5b262e559d38769e4959f036a1cc2c4009fa60b4ec836a7a19ca8554aebf5a5",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "b41cebf0be70f869bf60228cb5761f875ced865b0f4016f544d82f7a9ded28b0",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0"
+    },
+    {
+      "ref": "170380b4e7ab28ec86eb090b48df90f84089392cb72fecd5067e5b7a4dc5239f",
+      "local-path": "/usr/lib/aarch64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "5d5a98aceacf77230a0ba519c39d9f9a6e7850fbc8b95bd4669458ae7a8f0c0c",
+      "local-path": "/home/korniltsev/ruby-check/install-shared-4.0.6/bin/ruby"
+    }
+  ]
+}


### PR DESCRIPTION
Some offsets changed in cruby
1. inserted rb_vm_t.master_box before root_box,
shifting the gc.objspace field by one pointer.
https://github.com/ruby/ruby/blob/v4.0.6/vm_core.h
https://github.com/ruby/ruby/commit/99aac00fa13c03f71d3a4d89686e447f2950df68

2. added runnable_hot_th and runnable_hot_th_waiting
to struct rb_thread_sched, which is embedded in
rb_ractor_struct.threads before running_ec.
https://github.com/ruby/ruby/blob/v4.0.6/thread_pthread.h
https://github.com/ruby/ruby/commit/21a2595676d2d3df0eccd3af74065e2ba2a876b5

This PR adjusts the affected offsets and adds coredump tests