### PR TITLE
fix(make): pass GO_FLAGS to test and test-junit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ export OBJCOPY = $(ARCH_PREFIX)-linux-gnu-objcopy
 BRANCH = $(shell git branch --show-current)
 
 GO_TAGS := osusergo,netgo
+GO_FLAGS ?=
 EBPF_FLAGS :=
 
 GO_TOOLS := -modfile=internal/tools/go.mod
@@ -122,11 +123,11 @@ vanity-import-fix:
 
 test: generate ebpf test-deps
 	# tools/coredump tests build ebpf C-code using CGO to test it against coredumps
-	CGO_ENABLED=1 go test -tags $(GO_TAGS) ./...
+	CGO_ENABLED=1 go test $(GO_FLAGS) -tags $(GO_TAGS) ./...
 
 test-junit: generate ebpf test-deps
 	mkdir -p $(JUNIT_OUT_DIR)
-	CGO_ENABLED=1 go tool $(GO_TOOLS) gotestsum --junitfile $(JUNIT_OUT_DIR)/junit.xml -- -tags $(GO_TAGS) ./...
+	CGO_ENABLED=1 go tool $(GO_TOOLS) gotestsum --junitfile $(JUNIT_OUT_DIR)/junit.xml -- $(GO_FLAGS) -tags $(GO_TAGS) ./...
 
 TESTDATA_DIRS:= \
 	nativeunwind/elfunwindinfo/testdata \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ export OBJCOPY = $(ARCH_PREFIX)-linux-gnu-objcopy
 BRANCH = $(shell git branch --show-current)
 
 GO_TAGS := osusergo,netgo
+# Some github action test job matrix entries pass GO_FLAGS=-race
 GO_FLAGS ?=
 EBPF_FLAGS :=
 


### PR DESCRIPTION
Some of github action test job matrix entries pass  `GO_FLAGS=-race` which is no longer passed to the `go test` command.