### PR TITLE
asm/amd: handle SUB in the interpreter

### DIFF
--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -82,26 +82,7 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 	i.code = i.code[inst.Len:]
 	i.Regs.setX86asm(x86asm.RIP, expression.Add(i.CodeAddress, expression.Imm(uint64(i.pc))))
 	switch inst.Op {
-	case x86asm.ADD:
-		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
-			left := i.Regs.GetX86(dst)
-			switch src := inst.Args[1].(type) {
-			case x86asm.Imm:
-				right := expression.Imm(uint64(src))
-				i.Regs.setX86asm(dst, expression.Add(left, right))
-			case x86asm.Reg:
-				right := i.Regs.GetX86(src)
-				i.Regs.setX86asm(dst, expression.Add(left, right))
-			case x86asm.Mem:
-				right := i.MemArg(src)
-				right = expression.MemWithSegment(src.Segment, right, inst.MemBytes)
-				i.Regs.setX86asm(dst, expression.Add(left, right))
-			}
-		}
-	case x86asm.SUB:
-		// SUB is ADD with the right operand negated (-1 * x). Multiply/Add fold
-		// the immediate case, so `sub reg, imm` cancels a later `+imm`. Note that
-		// symbolic cancellation doesn't happen, so X + (-1 * X) doesn't become 0.
+	case x86asm.ADD, x86asm.SUB:
 		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
 			left := i.Regs.GetX86(dst)
 			var right expression.Expression
@@ -114,8 +95,13 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 				right = expression.MemWithSegment(src.Segment, i.MemArg(src), inst.MemBytes)
 			}
 			if right != nil {
-				neg := expression.Multiply(expression.Imm(^uint64(0)), right)
-				i.Regs.setX86asm(dst, expression.Add(left, neg))
+				// SUB is ADD with the right operand negated (-1 * x). Multiply/Add fold
+				// the immediate case, so `sub reg, imm` cancels a later `+imm`. Note that
+				// symbolic cancellation doesn't happen, so X + (-1 * X) doesn't become 0.
+				if inst.Op == x86asm.SUB {
+					right = expression.Multiply(expression.Imm(^uint64(0)), right)
+				}
+				i.Regs.setX86asm(dst, expression.Add(left, right))
 			}
 		}
 	case x86asm.SHL:

--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -98,6 +98,26 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 				i.Regs.setX86asm(dst, expression.Add(left, right))
 			}
 		}
+	case x86asm.SUB:
+		// SUB is ADD with the right operand negated (-1 * x). Multiply/Add fold
+		// the immediate case, so `sub reg, imm` cancels a later `+imm`. Note that
+		// symbolic cancellation doesn't happen, so X + (-1 * X) doesn't become 0.
+		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
+			left := i.Regs.GetX86(dst)
+			var right expression.Expression
+			switch src := inst.Args[1].(type) {
+			case x86asm.Imm:
+				right = expression.Imm(uint64(src))
+			case x86asm.Reg:
+				right = i.Regs.GetX86(src)
+			case x86asm.Mem:
+				right = expression.MemWithSegment(src.Segment, i.MemArg(src), inst.MemBytes)
+			}
+			if right != nil {
+				neg := expression.Multiply(expression.Imm(^uint64(0)), right)
+				i.Regs.setX86asm(dst, expression.Add(left, neg))
+			}
+		}
 	case x86asm.SHL:
 		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
 			if src, imm := inst.Args[1].(x86asm.Imm); imm {

--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -174,9 +174,6 @@ func TestMoveSignExtend(t *testing.T) {
 }
 
 func TestSub(t *testing.T) {
-	// SUB negates its right operand (-1 * x) and adds it. When x folds to an
-	// immediate the offset collapses just like ADD; a symbolic x stays a -1*x
-	// term - in particular X + (-1*X) does NOT fold to 0 (the mem case).
 	for _, tc := range []struct {
 		name string
 		code []byte

--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -173,6 +173,75 @@ func TestMoveSignExtend(t *testing.T) {
 	require.True(t, i.Regs.Get(RAX).Match(pattern))
 }
 
+func TestSub(t *testing.T) {
+	// SUB negates its right operand (-1 * x) and adds it. When x folds to an
+	// immediate the offset collapses just like ADD; a symbolic x stays a -1*x
+	// term - in particular X + (-1*X) does NOT fold to 0 (the mem case).
+	for _, tc := range []struct {
+		name string
+		code []byte
+		reg  x86asm.Reg
+		// want is a func so the mem case can build its expectation from the
+		// interpreter's own (pointer-identity) register expressions.
+		want     func(it *Interpreter) expression.Expression
+		symbolic bool // assert the result did not fold to a constant
+	}{
+		{
+			name: "imm",
+			// mov rdx,0x1000 ; sub rdx,0xc ; mov rdx,[rdx+0x43c]
+			// -> [0x1000 - 0xc + 0x43c] = [0x1430]
+			code: []byte{
+				0x48, 0xba, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x48, 0x83, 0xea, 0x0c,
+				0x48, 0x8b, 0x92, 0x3c, 0x04, 0x00, 0x00,
+			},
+			reg: x86asm.RDX,
+			want: func(*Interpreter) expression.Expression {
+				return expression.Mem8(expression.Imm(0x1430))
+			},
+		},
+		{
+			name: "reg",
+			// mov rax,0x1000 ; mov rcx,0xc ; sub rax,rcx ; mov rax,[rax+0x43c]
+			// %rcx holds a known immediate, so -1*rcx folds to the same [0x1430].
+			code: []byte{
+				0x48, 0xb8, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x48, 0xb9, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x48, 0x29, 0xc8,
+				0x48, 0x8b, 0x80, 0x3c, 0x04, 0x00, 0x00,
+			},
+			reg: x86asm.RAX,
+			want: func(*Interpreter) expression.Expression {
+				return expression.Mem8(expression.Imm(0x1430))
+			},
+		},
+		{
+			name: "mem",
+			// mov rax,[rbx] ; sub rax,[rbx]. A memory operand is symbolic, so
+			// rax becomes X + (-1*X) with X = Mem8(rbx) and does not cancel.
+			code: []byte{0x48, 0x8b, 0x03, 0x48, 0x2b, 0x03},
+			reg:  x86asm.RAX,
+			want: func(it *Interpreter) expression.Expression {
+				x := expression.Mem8(it.Regs.GetX86(x86asm.RBX))
+				return expression.Add(x, expression.Multiply(expression.Imm(^uint64(0)), x))
+			},
+			symbolic: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := NewInterpreterWithCode(tc.code)
+			_, err := it.Loop()
+			require.ErrorIs(t, err, io.EOF)
+			got := it.Regs.GetX86(tc.reg)
+			assertEval(t, got, tc.want(it))
+			if tc.symbolic {
+				require.False(t, got.Match(expression.Imm(0)),
+					"X + (-1*X) with symbolic X must not fold to 0")
+			}
+		})
+	}
+}
+
 func TestRIPRelativeAddressing(t *testing.T) {
 	// Test case: mov 0x10512121(%rip),%rcx
 	code := []byte{


### PR DESCRIPTION
The `asm/amd` interpreter models `ADD` (and `SHL`, `MOV`, `XOR`, `AND`, `LEA`) but not `SUB`. This adds `SUB`'s mirror.

`SUB` is `ADD` with the right operand negated (`-1 * x`). No `Subtract` primitive is needed: `Multiply` folds `-1 * imm` to a concrete value, so `sub reg, imm` cancels against a later `+imm` exactly the way `ADD` immediates already fold. The same negation applies to `Reg`/`Mem` operands and folds whenever they resolve to an immediate; a genuinely symbolic operand stays as a `-1*x` term.

One sharp edge worth calling out: `X + (-1*X)` does **not** fold to `0` — `Add` has no additive-inverse rule — so symbolic subtraction doesn't cancel. That's fine for offset-tracking (the constant case is what matters) but is a real limitation if a future consumer expects cancellation.

### Consumer

Full disclosure: there's no in-tree consumer of `SUB` upstream today. We use it downstream (parca's LuaJIT offset extraction, where a build applies `sub $const, %greg` to the global-state pointer before a struct load, and the interpreter needs to fold that back out). 

