### PR TITLE
Have "format" match "lint" in support/ebpf/Makefile

### DIFF
--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -85,7 +85,7 @@ lint:
 	$(CLANG_FORMAT) -Werror --dry-run -style=file *.[ch] ../../tools/coredump/*.[ch]
 
 format:
-	$(CLANG_FORMAT) -i -style=file *.[ch]
+	$(CLANG_FORMAT) -i -style=file *.[ch] ../../tools/coredump/*.[ch]
 
 clean:
 	rm -f *.o *.d


### PR DESCRIPTION
We should have `format` and `lint` look at the same set of files, so that lint errors can easily be fixed via `make format`.