### PR TITLE
interpreter/dotnet: bound enclosing-class walk to prevent DoS via cyclic NestedClass metadata

### DIFF
--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -53,6 +53,14 @@ const (
 
 	// TTL of entries in the LRU cache holding the .NET strings.
 	peInfoStringsCacheTTL = 1 * time.Hour
+
+	// maxTypeNestingDepth bounds the enclosing-class walk in resolveMethodName.
+	// The ECMA-335 II.22.32 NestedClass metadata that populates enclosingClass is
+	// untrusted (it comes from the profiled process' PE file) and may contain
+	// cycles or pathologically deep chains, either of which would otherwise spin
+	// the walk forever while growing the type name without bound. 64 is far
+	// beyond any legitimate source-level nesting depth.
+	maxTypeNestingDepth = 64
 )
 
 // peHash is a content-derived cache key for a dotnet PE file: SHA256 of the
@@ -886,6 +894,13 @@ func (pp *peParser) parseNestedClass() {
 				i, nestedClass, enclosingClass, numTypeDefs)
 			return
 		}
+		if nestedClass == enclosingClass {
+			// A type enclosing itself is a guaranteed cycle that would make the
+			// enclosing-class walk in resolveMethodName loop forever.
+			pp.err = fmt.Errorf("invalid NestedClass row %d: self-reference (index %d)",
+				i, nestedClass)
+			return
+		}
 		pp.info.typeSpecs[nestedClass-1].enclosingClass = enclosingClass
 	}
 }
@@ -1250,7 +1265,16 @@ func (pi *peInfo) resolveMethodName(methodIdx uint32,
 
 	typeSpec := &pi.typeSpecs[idx]
 	typeName := lookup(typeSpec.typeNameIdx).String()
-	for typeSpec.enclosingClass != 0 {
+	for depth := 0; typeSpec.enclosingClass != 0; depth++ {
+		if depth >= maxTypeNestingDepth {
+			// The enclosing-class chain is cyclic or deeper than any
+			// legitimate type nesting. parseNestedClass rejects direct
+			// self-references, but longer cycles are only detectable here, so
+			// bail out with a sentinel instead of looping forever.
+			return libpf.Intern(fmt.Sprintf(
+				"<cyclic or too deep NestedClass metadata for method index %d>",
+				methodIdx))
+		}
 		enclosingSpec := &pi.typeSpecs[typeSpec.enclosingClass-1]
 		typeName = fmt.Sprintf("%s/%s", lookup(enclosingSpec.typeNameIdx), typeName)
 		typeSpec = enclosingSpec

--- a/interpreter/dotnet/pe.go
+++ b/interpreter/dotnet/pe.go
@@ -53,14 +53,6 @@ const (
 
 	// TTL of entries in the LRU cache holding the .NET strings.
 	peInfoStringsCacheTTL = 1 * time.Hour
-
-	// maxTypeNestingDepth bounds the enclosing-class walk in resolveMethodName.
-	// The ECMA-335 II.22.32 NestedClass metadata that populates enclosingClass is
-	// untrusted (it comes from the profiled process' PE file) and may contain
-	// cycles or pathologically deep chains, either of which would otherwise spin
-	// the walk forever while growing the type name without bound. 64 is far
-	// beyond any legitimate source-level nesting depth.
-	maxTypeNestingDepth = 64
 )
 
 // peHash is a content-derived cache key for a dotnet PE file: SHA256 of the
@@ -894,11 +886,18 @@ func (pp *peParser) parseNestedClass() {
 				i, nestedClass, enclosingClass, numTypeDefs)
 			return
 		}
-		if nestedClass == enclosingClass {
-			// A type enclosing itself is a guaranteed cycle that would make the
-			// enclosing-class walk in resolveMethodName loop forever.
-			pp.err = fmt.Errorf("invalid NestedClass row %d: self-reference (index %d)",
-				i, nestedClass)
+		if enclosingClass >= nestedClass {
+			// ECMA-335 II.22 requires that "the definition of an enclosing class
+			// shall precede the definition of all classes it encloses". This data
+			// comes from the profiled process' PE file and is untrusted, so the
+			// constraint is enforced rather than assumed: it keeps every
+			// enclosing-class edge pointing at a strictly lower TypeDef index,
+			// which makes the chains walked by resolveMethodName acyclic by
+			// construction. A crafted PE could otherwise form a cycle and spin
+			// that walk forever, growing the type name without bound.
+			pp.err = fmt.Errorf("invalid NestedClass row %d: "+
+				"enclosing class %d does not precede nested class %d",
+				i, enclosingClass, nestedClass)
 			return
 		}
 		pp.info.typeSpecs[nestedClass-1].enclosingClass = enclosingClass
@@ -1265,16 +1264,10 @@ func (pi *peInfo) resolveMethodName(methodIdx uint32,
 
 	typeSpec := &pi.typeSpecs[idx]
 	typeName := lookup(typeSpec.typeNameIdx).String()
-	for depth := 0; typeSpec.enclosingClass != 0; depth++ {
-		if depth >= maxTypeNestingDepth {
-			// The enclosing-class chain is cyclic or deeper than any
-			// legitimate type nesting. parseNestedClass rejects direct
-			// self-references, but longer cycles are only detectable here, so
-			// bail out with a sentinel instead of looping forever.
-			return libpf.Intern(fmt.Sprintf(
-				"<cyclic or too deep NestedClass metadata for method index %d>",
-				methodIdx))
-		}
+	// parseNestedClass enforces the ECMA-335 II.22 rule that an enclosing class
+	// precedes the classes it encloses, so each step here strictly decreases the
+	// TypeDef index and the walk always terminates.
+	for typeSpec.enclosingClass != 0 {
 		enclosingSpec := &pi.typeSpecs[typeSpec.enclosingClass-1]
 		typeName = fmt.Sprintf("%s/%s", lookup(enclosingSpec.typeNameIdx), typeName)
 		typeSpec = enclosingSpec

--- a/interpreter/dotnet/pe_test.go
+++ b/interpreter/dotnet/pe_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dotnet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+// TestResolveMethodNameCyclicNestedClass ensures that cyclic enclosing-class
+// chains (from untrusted ECMA-335 II.22.32 NestedClass metadata) are bounded by
+// resolveMethodName instead of spinning forever with unbounded string growth.
+// The call is run in a goroutine with a timeout so a regression fails fast
+// rather than hanging the whole test binary.
+func TestResolveMethodNameCyclicNestedClass(t *testing.T) {
+	testCases := map[string]struct {
+		typeSpecs []peTypeSpec
+	}{
+		"self-cycle": {
+			// A type whose enclosing class is itself.
+			typeSpecs: []peTypeSpec{
+				{enclosingClass: 1},
+			},
+		},
+		"mutual-cycle": {
+			// Two types that enclose each other.
+			typeSpecs: []peTypeSpec{
+				{enclosingClass: 2},
+				{enclosingClass: 1},
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			pi := &peInfo{
+				typeSpecs:   test.typeSpecs,
+				methodSpecs: []peMethodSpec{{}},
+			}
+
+			done := make(chan string, 1)
+			go func() {
+				// String offsets are all zero here, so lookupString returns
+				// libpf.NullString without touching the strings cache or remote
+				// memory, making the zero-value RemoteMemory{} safe.
+				done <- pi.resolveMethodName(1, remotememory.RemoteMemory{}, 0).String()
+			}()
+
+			select {
+			case res := <-done:
+				assert.Contains(t, res, "cyclic or too deep NestedClass metadata")
+			case <-time.After(5 * time.Second):
+				t.Fatal("resolveMethodName did not return within 5s; " +
+					"cyclic NestedClass metadata likely caused an infinite loop")
+			}
+		})
+	}
+}
+
+// TestResolveMethodNameDeepNesting ensures a legitimate, acyclic nesting chain
+// (deeper than typical source but well within maxTypeNestingDepth) resolves
+// normally without triggering the cycle sentinel.
+func TestResolveMethodNameDeepNesting(t *testing.T) {
+	const depth = 16
+	typeSpecs := make([]peTypeSpec, depth)
+	for i := range typeSpecs {
+		// methodIdx must be sorted ascending for the binary search in
+		// resolveMethodName. Give the innermost type methodIdx 1 and the rest
+		// methodIdx 2 so that resolving method index 1 starts the walk at
+		// typeSpecs[0].
+		if i == 0 {
+			typeSpecs[i].methodIdx = 1
+		} else {
+			typeSpecs[i].methodIdx = 2
+		}
+		// Link each type to the next as its enclosing class, leaving the last
+		// one at the top of the chain (enclosingClass 0).
+		if i < depth-1 {
+			typeSpecs[i].enclosingClass = uint32(i + 2)
+		}
+	}
+
+	pi := &peInfo{
+		typeSpecs:   typeSpecs,
+		methodSpecs: []peMethodSpec{{}},
+	}
+
+	res := pi.resolveMethodName(1, remotememory.RemoteMemory{}, 0).String()
+	assert.NotContains(t, res, "cyclic or too deep NestedClass metadata")
+}

--- a/interpreter/dotnet/pe_test.go
+++ b/interpreter/dotnet/pe_test.go
@@ -4,84 +4,120 @@
 package dotnet
 
 import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
-// TestResolveMethodNameCyclicNestedClass ensures that cyclic enclosing-class
-// chains (from untrusted ECMA-335 II.22.32 NestedClass metadata) are bounded by
-// resolveMethodName instead of spinning forever with unbounded string growth.
-// The call is run in a goroutine with a timeout so a regression fails fast
-// rather than hanging the whole test binary.
-func TestResolveMethodNameCyclicNestedClass(t *testing.T) {
+// nestedClassTable encodes rows as an ECMA-335 II.22.32 NestedClass table using
+// 2-byte TypeDef indexes. Each pair is (NestedClass, EnclosingClass).
+func nestedClassTable(rows ...[2]uint16) io.ReadSeeker {
+	var buf bytes.Buffer
+	for _, row := range rows {
+		_ = binary.Write(&buf, binary.LittleEndian, row[0])
+		_ = binary.Write(&buf, binary.LittleEndian, row[1])
+	}
+	return bytes.NewReader(buf.Bytes())
+}
+
+// TestParseNestedClass covers the validation of the ECMA-335 II.22.32
+// NestedClass table, which is parsed from the profiled process' PE file and is
+// therefore untrusted. Rows that violate the II.22 ordering rule ("the
+// definition of an enclosing class shall precede the definition of all classes
+// it encloses") are rejected, which keeps the enclosing-class chains walked by
+// resolveMethodName acyclic by construction.
+func TestParseNestedClass(t *testing.T) {
+	const numTypeDefs = 4
+
 	testCases := map[string]struct {
-		typeSpecs []peTypeSpec
+		rows [][2]uint16
+		// enclosing is the expected enclosingClass of each typeSpec on success.
+		enclosing []uint32
+		err       string
 	}{
-		"self-cycle": {
-			// A type whose enclosing class is itself.
-			typeSpecs: []peTypeSpec{
-				{enclosingClass: 1},
-			},
+		"valid nesting chain": {
+			// TypeDef 1 encloses 2, which encloses 3.
+			rows:      [][2]uint16{{2, 1}, {3, 2}},
+			enclosing: []uint32{0, 1, 2, 0},
 		},
-		"mutual-cycle": {
-			// Two types that enclose each other.
-			typeSpecs: []peTypeSpec{
-				{enclosingClass: 2},
-				{enclosingClass: 1},
-			},
+		"self reference": {
+			rows: [][2]uint16{{2, 2}},
+			err:  "enclosing class 2 does not precede nested class 2",
+		},
+		"enclosing class defined after nested class": {
+			// A single row that would make resolveMethodName walk forward, and
+			// in combination with {2, 3} would form a cycle.
+			rows: [][2]uint16{{2, 3}},
+			err:  "enclosing class 3 does not precede nested class 2",
+		},
+		"mutual cycle": {
+			// The first row is already invalid; the walk never sees the pair.
+			rows: [][2]uint16{{2, 3}, {3, 2}},
+			err:  "enclosing class 3 does not precede nested class 2",
+		},
+		"index out of range": {
+			rows: [][2]uint16{{numTypeDefs + 1, 1}},
+			err:  "indexes (5/1) vs. 4 typedefs",
+		},
+		"zero index": {
+			rows: [][2]uint16{{2, 0}},
+			err:  "indexes (2/0) vs. 4 typedefs",
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			pi := &peInfo{
-				typeSpecs:   test.typeSpecs,
-				methodSpecs: []peMethodSpec{{}},
+			pp := &peParser{
+				info:         &peInfo{typeSpecs: make([]peTypeSpec, numTypeDefs)},
+				dotnetTables: nestedClassTable(test.rows...),
 			}
+			pp.indexSizes[indexTypeDef] = 2
+			pp.tableRows[tableNestedClass] = uint32(len(test.rows))
 
-			done := make(chan string, 1)
-			go func() {
-				// String offsets are all zero here, so lookupString returns
-				// libpf.NullString without touching the strings cache or remote
-				// memory, making the zero-value RemoteMemory{} safe.
-				done <- pi.resolveMethodName(1, remotememory.RemoteMemory{}, 0).String()
-			}()
+			pp.parseNestedClass()
 
-			select {
-			case res := <-done:
-				assert.Contains(t, res, "cyclic or too deep NestedClass metadata")
-			case <-time.After(5 * time.Second):
-				t.Fatal("resolveMethodName did not return within 5s; " +
-					"cyclic NestedClass metadata likely caused an infinite loop")
+			if test.err != "" {
+				require.Error(t, pp.err)
+				assert.Contains(t, pp.err.Error(), test.err)
+				return
 			}
+			require.NoError(t, pp.err)
+
+			enclosing := make([]uint32, len(pp.info.typeSpecs))
+			for i, spec := range pp.info.typeSpecs {
+				enclosing[i] = spec.enclosingClass
+			}
+			assert.Equal(t, test.enclosing, enclosing)
 		})
 	}
 }
 
-// TestResolveMethodNameDeepNesting ensures a legitimate, acyclic nesting chain
-// (deeper than typical source but well within maxTypeNestingDepth) resolves
-// normally without triggering the cycle sentinel.
-func TestResolveMethodNameDeepNesting(t *testing.T) {
-	const depth = 16
+// TestResolveMethodNameNesting checks that resolveMethodName walks a nesting
+// chain that satisfies the invariant enforced by parseNestedClass. The chain is
+// deeper than any realistic source-level nesting to show that the walk is
+// bounded by the number of TypeDefs rather than by the data.
+func TestResolveMethodNameNesting(t *testing.T) {
+	const depth = 64
+
+	// typeSpecs[depth-1] is the innermost type and owns method index 1; each
+	// type is enclosed by the one before it, so every enclosingClass is
+	// strictly lower than its own index, as parseNestedClass requires.
 	typeSpecs := make([]peTypeSpec, depth)
 	for i := range typeSpecs {
-		// methodIdx must be sorted ascending for the binary search in
-		// resolveMethodName. Give the innermost type methodIdx 1 and the rest
-		// methodIdx 2 so that resolving method index 1 starts the walk at
-		// typeSpecs[0].
-		if i == 0 {
-			typeSpecs[i].methodIdx = 1
-		} else {
-			typeSpecs[i].methodIdx = 2
+		if i > 0 {
+			typeSpecs[i].enclosingClass = uint32(i)
 		}
-		// Link each type to the next as its enclosing class, leaving the last
-		// one at the top of the chain (enclosingClass 0).
-		if i < depth-1 {
-			typeSpecs[i].enclosingClass = uint32(i + 2)
+		// methodIdx must be ascending for the binary search in
+		// resolveMethodName. Only the innermost type owns method index 1.
+		if i == depth-1 {
+			typeSpecs[i].methodIdx = 1
 		}
 	}
 
@@ -90,6 +126,11 @@ func TestResolveMethodNameDeepNesting(t *testing.T) {
 		methodSpecs: []peMethodSpec{{}},
 	}
 
-	res := pi.resolveMethodName(1, remotememory.RemoteMemory{}, 0).String()
-	assert.NotContains(t, res, "cyclic or too deep NestedClass metadata")
+	// All string offsets are zero, so lookupString returns libpf.NullString
+	// without touching the strings cache or remote memory, which makes the
+	// zero-value RemoteMemory{} safe here.
+	res := pi.resolveMethodName(1, remotememory.RemoteMemory{}, 0)
+
+	// depth type names joined by "/", then ".<method name>".
+	assert.Equal(t, depth-1, strings.Count(res.String(), "/"))
 }


### PR DESCRIPTION
## Description

`resolveMethodName()` in `interpreter/dotnet/pe.go` walks a type's enclosing-class chain via the `enclosingClass` field, which is populated from ECMA-335 II.22.32 `NestedClass` metadata in the profiled process' PE file — i.e. untrusted input. `parseNestedClass()` range-checks the indices but permits self-references and longer cycles, so a crafted PE can form a cycle. The `for typeSpec.enclosingClass != 0` loop then spins forever, concatenating type names each iteration and growing the string without bound — an unprivileged DoS against the profiler.

## Fix

ECMA-335 II.22, in the notes on table ordering, states:

> the definition of an enclosing class shall precede the definition of all classes it encloses

So a `NestedClass` row whose `EnclosingClass` index is not strictly lower than its `NestedClass` index is invalid. `parseNestedClass()` now rejects those rows alongside its existing range checks, which makes every enclosing-class edge point at a strictly lower `TypeDef` index — and therefore makes the chains walked by `resolveMethodName()` acyclic by construction.

`resolveMethodName()` itself is unchanged apart from a comment recording that invariant. There is no depth cap, so no legitimate nesting depth is truncated and no sentinel type name is ever produced.

The check follows the failure mode already established for malformed `NestedClass` rows: `pp.err` is set, which aborts the metadata parse for that PE.

## Tests

- `TestParseNestedClass`: valid nesting chain, self-reference, forward reference, mutual cycle, out-of-range index, zero index.
- `TestResolveMethodNameNesting`: a 64-deep acyclic chain satisfying the invariant resolves to the full nested type name.

`gofmt`, `go vet` and `go test ./interpreter/dotnet/...` all pass.

Fixes #1603
