### PR TITLE
fix(test): enable KVM only when host supports virtualization

### DIFF
--- a/support/run-tests.sh
+++ b/support/run-tests.sh
@@ -42,7 +42,7 @@ done < <(find . -name '*.test' -print0)
 additionalQemuArgs=""
 
 supportKVM=$(grep -E 'vmx|svm' /proc/cpuinfo || true)
-if [ ! "$supportKVM" ] && [ "$qemu_arch" = "$(uname -m)" ]; then
+if [ -n "$supportKVM" ] && [ "$qemu_arch" = "$(uname -m)" ]; then
   additionalQemuArgs="-enable-kvm"
 fi
 


### PR DESCRIPTION
The condition guarding the -enable-kvm QEMU argument was inverted: it enabled KVM when /proc/cpuinfo lacked vmx/svm flags and disabled it when they were present. Use -n so KVM is enabled only when virtualization support is actually available.