### PR TITLE
process: cache proc base path

### DIFF
--- a/process/debug_linux.go
+++ b/process/debug_linux.go
@@ -52,7 +52,7 @@ func NewPtrace(pid libpf.PID) (Process, error) {
 
 	sp := &ptraceProcess{}
 	sp.pid = pid
-	sp.procBase = "/proc/" + strconv.Itoa(int(pid))
+	sp.procBase = "/proc/" + strconv.Itoa(int(pid)) + "/"
 	sp.remoteMemory = remotememory.RemoteMemory{ReaderAt: sp}
 	if err := sp.attach(); err != nil {
 		runtime.UnlockOSThread()
@@ -62,7 +62,7 @@ func NewPtrace(pid libpf.PID) (Process, error) {
 }
 
 func (sp *ptraceProcess) GetThreads() ([]ThreadInfo, error) {
-	tidFiles, err := os.ReadDir(sp.procBase + "/task")
+	tidFiles, err := os.ReadDir(sp.procBase + "task")
 	if err != nil {
 		return nil, err
 	}

--- a/process/debug_linux.go
+++ b/process/debug_linux.go
@@ -52,6 +52,7 @@ func NewPtrace(pid libpf.PID) (Process, error) {
 
 	sp := &ptraceProcess{}
 	sp.pid = pid
+	sp.procBase = "/proc/" + strconv.Itoa(int(pid))
 	sp.remoteMemory = remotememory.RemoteMemory{ReaderAt: sp}
 	if err := sp.attach(); err != nil {
 		runtime.UnlockOSThread()
@@ -61,7 +62,7 @@ func NewPtrace(pid libpf.PID) (Process, error) {
 }
 
 func (sp *ptraceProcess) GetThreads() ([]ThreadInfo, error) {
-	tidFiles, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", sp.pid))
+	tidFiles, err := os.ReadDir(sp.procBase + "/task")
 	if err != nil {
 		return nil, err
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -62,7 +62,7 @@ var (
 type systemProcess struct {
 	pid      libpf.PID
 	tid      libpf.PID
-	procBase string // "/proc/<pid>"
+	procBase string // "/proc/<pid>/"
 
 	mainThreadExit bool
 	remoteMemory   remotememory.RemoteMemory
@@ -91,7 +91,7 @@ func New(pid, tid libpf.PID) Process {
 	return &systemProcess{
 		pid:          pid,
 		tid:          tid,
-		procBase:     "/proc/" + strconv.Itoa(int(pid)),
+		procBase:     "/proc/" + strconv.Itoa(int(pid)) + "/",
 		remoteMemory: remotememory.NewProcessVirtualMemory(pid),
 	}
 }
@@ -105,7 +105,7 @@ func (sp *systemProcess) GetMachineData() MachineData {
 }
 
 func (sp *systemProcess) GetExe() (libpf.String, error) {
-	str, err := os.Readlink(sp.procBase + "/exe")
+	str, err := os.Readlink(sp.procBase + "exe")
 	if err != nil {
 		return libpf.NullString, err
 	}
@@ -115,13 +115,13 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {
 	var processName libpf.String
 	exePath, _ := sp.GetExe()
-	if name, err := os.ReadFile(sp.procBase + "/comm"); err == nil {
+	if name, err := os.ReadFile(sp.procBase + "comm"); err == nil {
 		processName = libpf.Intern(pfunsafe.ToString(name))
 	}
 
 	var envVarMap map[libpf.String]libpf.String
 	if len(cfg.IncludeEnvVars) > 0 {
-		if envVars, err := os.ReadFile(sp.procBase + "/environ"); err == nil {
+		if envVars, err := os.ReadFile(sp.procBase + "environ"); err == nil {
 			envVarMap = make(map[libpf.String]libpf.String, len(cfg.IncludeEnvVars))
 			// environ has environment variables separated by a null byte (hex: 00)
 			for envVar := range strings.SplitSeq(pfunsafe.ToString(envVars), "\000") {
@@ -393,7 +393,7 @@ func iterateMappings(mapsFile io.Reader, callback func(m RawMapping) bool) (uint
 }
 
 func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint32, error) {
-	mapsFile, err := os.Open(sp.procBase + "/maps")
+	mapsFile, err := os.Open(sp.procBase + "maps")
 	if err != nil {
 		return 0, err
 	}
@@ -424,7 +424,7 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 		}
 
 		log.Debugf("TID: %v extracting mappings", sp.tid)
-		mapsFileAlt, err := os.Open(fmt.Sprintf("%s/task/%d/maps", sp.procBase, sp.tid))
+		mapsFileAlt, err := os.Open(fmt.Sprintf("%stask/%d/maps", sp.procBase, sp.tid))
 		// On all errors resulting from trying to get mappings from a different thread,
 		// return ErrNoMappings which will keep the PID tracked in processmanager and
 		// allow for a future iteration to try extracting mappings from a different thread.
@@ -482,7 +482,7 @@ func (sp *systemProcess) getMappingFile(m *RawMapping) (*os.File, error) {
 		// Neither /proc/sp.pid/map_files nor /proc/sp.pid/task/sp.tid/map_files
 		// nor /proc/sp.pid/root exist if main thread has exited, so we use the
 		// mapping path directly under the sp.tid root.
-		rootPath := fmt.Sprintf("%s/task/%d/root", sp.procBase, sp.tid)
+		rootPath := fmt.Sprintf("%stask/%d/root", sp.procBase, sp.tid)
 		f, err := openInRoot(rootPath, m.Path)
 		if err != nil {
 			return nil, err
@@ -494,7 +494,7 @@ func (sp *systemProcess) getMappingFile(m *RawMapping) (*os.File, error) {
 		}
 		return f, nil
 	}
-	filename := fmt.Sprintf("%s/map_files/%x-%x", sp.procBase, m.Vaddr, m.Vaddr+m.Length)
+	filename := fmt.Sprintf("%smap_files/%x-%x", sp.procBase, m.Vaddr, m.Vaddr+m.Length)
 	return os.Open(filename)
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -60,8 +60,9 @@ var (
 // systemProcess provides an implementation of the Process interface for a
 // process that is currently running on this machine.
 type systemProcess struct {
-	pid libpf.PID
-	tid libpf.PID
+	pid      libpf.PID
+	tid      libpf.PID
+	procBase string // "/proc/<pid>"
 
 	mainThreadExit bool
 	remoteMemory   remotememory.RemoteMemory
@@ -90,6 +91,7 @@ func New(pid, tid libpf.PID) Process {
 	return &systemProcess{
 		pid:          pid,
 		tid:          tid,
+		procBase:     "/proc/" + strconv.Itoa(int(pid)),
 		remoteMemory: remotememory.NewProcessVirtualMemory(pid),
 	}
 }
@@ -103,7 +105,7 @@ func (sp *systemProcess) GetMachineData() MachineData {
 }
 
 func (sp *systemProcess) GetExe() (libpf.String, error) {
-	str, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", sp.pid))
+	str, err := os.Readlink(sp.procBase + "/exe")
 	if err != nil {
 		return libpf.NullString, err
 	}
@@ -113,13 +115,13 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 func (sp *systemProcess) GetProcessMeta(cfg MetaConfig) ProcessMeta {
 	var processName libpf.String
 	exePath, _ := sp.GetExe()
-	if name, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", sp.pid)); err == nil {
+	if name, err := os.ReadFile(sp.procBase + "/comm"); err == nil {
 		processName = libpf.Intern(pfunsafe.ToString(name))
 	}
 
 	var envVarMap map[libpf.String]libpf.String
 	if len(cfg.IncludeEnvVars) > 0 {
-		if envVars, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", sp.pid)); err == nil {
+		if envVars, err := os.ReadFile(sp.procBase + "/environ"); err == nil {
 			envVarMap = make(map[libpf.String]libpf.String, len(cfg.IncludeEnvVars))
 			// environ has environment variables separated by a null byte (hex: 00)
 			for envVar := range strings.SplitSeq(pfunsafe.ToString(envVars), "\000") {
@@ -391,7 +393,7 @@ func iterateMappings(mapsFile io.Reader, callback func(m RawMapping) bool) (uint
 }
 
 func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint32, error) {
-	mapsFile, err := os.Open(fmt.Sprintf("/proc/%d/maps", sp.pid))
+	mapsFile, err := os.Open(sp.procBase + "/maps")
 	if err != nil {
 		return 0, err
 	}
@@ -422,7 +424,7 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 		}
 
 		log.Debugf("TID: %v extracting mappings", sp.tid)
-		mapsFileAlt, err := os.Open(fmt.Sprintf("/proc/%d/task/%d/maps", sp.pid, sp.tid))
+		mapsFileAlt, err := os.Open(fmt.Sprintf("%s/task/%d/maps", sp.procBase, sp.tid))
 		// On all errors resulting from trying to get mappings from a different thread,
 		// return ErrNoMappings which will keep the PID tracked in processmanager and
 		// allow for a future iteration to try extracting mappings from a different thread.
@@ -480,7 +482,7 @@ func (sp *systemProcess) getMappingFile(m *RawMapping) (*os.File, error) {
 		// Neither /proc/sp.pid/map_files nor /proc/sp.pid/task/sp.tid/map_files
 		// nor /proc/sp.pid/root exist if main thread has exited, so we use the
 		// mapping path directly under the sp.tid root.
-		rootPath := fmt.Sprintf("/proc/%v/task/%v/root", sp.pid, sp.tid)
+		rootPath := fmt.Sprintf("%s/task/%d/root", sp.procBase, sp.tid)
 		f, err := openInRoot(rootPath, m.Path)
 		if err != nil {
 			return nil, err
@@ -492,7 +494,7 @@ func (sp *systemProcess) getMappingFile(m *RawMapping) (*os.File, error) {
 		}
 		return f, nil
 	}
-	filename := fmt.Sprintf("/proc/%v/map_files/%x-%x", sp.pid, m.Vaddr, m.Vaddr+m.Length)
+	filename := fmt.Sprintf("%s/map_files/%x-%x", sp.procBase, m.Vaddr, m.Vaddr+m.Length)
 	return os.Open(filename)
 }
 


### PR DESCRIPTION
Using `fmt.Sprintf()` is expensive, especially for repeated information. Looking at flamegraphs, I noticed we call `GetExe()` and `GetProcessMeta()` on a regular base, where we construct certain paths using `fmt.Sprintf()`.

Caching the proc base path reduced allocations and speed up these functions.