### PR TITLE
Arm interpreter

### DIFF
--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -21,7 +21,7 @@ type Interpreter struct {
 	Regs        Registers
 	code        []byte
 	CodeAddress expression.Expression
-	pc          int
+	pc          uint64
 }
 
 func NewInterpreter() *Interpreter {
@@ -36,7 +36,7 @@ func NewInterpreterWithCode(code []byte) *Interpreter {
 	return it
 }
 
-func (i *Interpreter) PC() int {
+func (i *Interpreter) PC() uint64 {
 	return i.pc
 }
 
@@ -78,7 +78,7 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 			return inst, fmt.Errorf("at 0x%x : %v", i.pc, err)
 		}
 	}
-	i.pc += inst.Len
+	i.pc += uint64(inst.Len)
 	i.code = i.code[inst.Len:]
 	i.Regs.setX86asm(x86asm.RIP, expression.Add(i.CodeAddress, expression.Imm(uint64(i.pc))))
 	switch inst.Op {

--- a/asm/arm/interpreter.go
+++ b/asm/arm/interpreter.go
@@ -1,0 +1,234 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package arm // import "go.opentelemetry.io/ebpf-profiler/asm/arm"
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"go.opentelemetry.io/ebpf-profiler/asm/expression"
+	"golang.org/x/arch/arm64/arm64asm"
+)
+
+type Interpreter struct {
+	Regs        Registers
+	code        []byte
+	CodeAddress expression.Expression
+	pc          uint64
+}
+
+func NewInterpreter() *Interpreter {
+	it := &Interpreter{}
+	it.initRegs()
+	return it
+}
+
+func NewInterpreterWithCode(code []byte) *Interpreter {
+	it := &Interpreter{code: code, CodeAddress: expression.Named("code address")}
+	it.initRegs()
+	return it
+}
+
+func (i *Interpreter) PC() uint64 {
+	return i.pc
+}
+
+func (i *Interpreter) ResetCode(code []byte, address expression.Expression) {
+	i.code = code
+	i.CodeAddress = address
+	i.pc = 0
+}
+
+func (i *Interpreter) Loop() (arm64asm.Inst, error) {
+	return i.LoopWithBreak(func(arm64asm.Inst) bool { return false })
+}
+
+func (i *Interpreter) LoopWithBreak(breakLoop func(op arm64asm.Inst) bool) (arm64asm.Inst, error) {
+	prev := arm64asm.Inst{}
+	for {
+		op, err := i.Step()
+		if err != nil {
+			return prev, err
+		}
+		if breakLoop(op) {
+			return op, nil
+		}
+		prev = op
+	}
+}
+
+const (
+	// InstSz is the size (in bytes) of an aarch64 instruction;
+	// in our universe, it is always 4.
+	InstSz int = 4
+)
+
+// maybeHandleLoadStore checks if an instruction is a load or store, processing it if so.
+// The first return value is true if we attempted to process the instruction.
+func (i *Interpreter) maybeHandleLoadStore(inst arm64asm.Inst, pc expression.Expression) (bool, error) {
+	// TODO: There are tons of load/store instructions. Fill in new ones if/when we need them.
+	var isLoad bool
+	switch inst.Op {
+	case arm64asm.LDR, arm64asm.STR:
+		isLoad = inst.Op == arm64asm.LDR
+		dst, ok := inst.Args[0].(arm64asm.Reg)
+		if !ok {
+			return false, nil
+		}
+		var memAddr expression.Expression
+
+		// for writeback instructions.
+		var newValue expression.Expression
+		// if newValue is set, this must also be set (it's where we will write the new value).
+		var baseReg arm64asm.RegSP
+
+		switch src := inst.Args[1].(type) {
+		case arm64asm.MemImmediate:
+			imm, _ := DecodeImmediate(src)
+			baseReg = src.Base
+			// TODO - Bogus if `imm` is negative.
+			immExpr := expression.Imm(uint64(imm))
+			base := i.Regs.GetArmSP(baseReg)
+			switch src.Mode {
+			case arm64asm.AddrPostIndex:
+				memAddr = base
+				newValue = expression.Add(base, immExpr)
+			case arm64asm.AddrPreIndex:
+				memAddr = expression.Add(base, immExpr)
+				newValue = memAddr
+			case arm64asm.AddrOffset:
+				memAddr = expression.Add(base, immExpr)
+			default:
+				return true, errors.New("apparently malformed ldr")
+			}
+
+		case arm64asm.MemExtend:
+			base := i.Regs.GetArmSP(src.Base)
+			idx := i.Regs.GetArm(src.Index)
+			var ext expression.Expression
+			switch src.Extend.String() {
+			case "UXTW":
+				ext = expression.ZeroExtend32(idx)
+			case "SXTW":
+				ext = expression.SignExtend32(idx)
+			default:
+				ext = idx
+			}
+
+			memAddr = expression.Add(base, expression.Multiply(ext, expression.Imm(uint64(1)<<uint64(src.Amount))))
+		case arm64asm.PCRel:
+			memAddr = expression.Add(pc, expression.Imm(uint64(src)))
+		}
+		if memAddr != nil {
+			if isLoad {
+				// NB: encoding the read as all 8 bytes is fine even if the register is W*; setArm64asm
+				// properly encodes that the higher order bytes should be zeroed in that case.
+				i.Regs.setArm64asm(dst, expression.Mem8(memAddr))
+			} else {
+				// TODO: Our interpreter doesn't model memory contents yet,
+				// so stores are currently a no-op (except that we will properly update
+				// the register for writebacks below)
+			}
+			if newValue != nil {
+				i.Regs.setArm64asmSP(baseReg, newValue)
+			}
+			return true, nil
+		}
+	}
+	// either an instruction or an addressing mode that we didn't know how to handle; this isn't an error.
+	return false, nil
+}
+
+func (i *Interpreter) Step() (arm64asm.Inst, error) {
+	if len(i.code) < InstSz {
+		return arm64asm.Inst{}, io.EOF
+	}
+	inst, err := arm64asm.Decode(i.code)
+	if err != nil {
+		return inst, fmt.Errorf("at 0x%x : %v", i.pc, err)
+	}
+	oldPC := i.Regs.Get(PC)
+	i.pc += uint64(InstSz)
+	i.code = i.code[InstSz:]
+	i.Regs.setPC(expression.Add(i.CodeAddress, expression.Imm(uint64(i.pc))))
+	if ok, err := i.maybeHandleLoadStore(inst, oldPC); ok {
+		return inst, err
+	}
+	switch inst.Op {
+	case arm64asm.ADD, arm64asm.SUB:
+		isSub := inst.Op == arm64asm.SUB
+		var left, right expression.Expression
+		switch leftArg := inst.Args[1].(type) {
+		case arm64asm.RegSP:
+			left = i.Regs.GetArmSP(leftArg)
+		case arm64asm.Reg:
+			left = i.Regs.GetArm(leftArg)
+		}
+		switch rightArg := inst.Args[2].(type) {
+		case arm64asm.RegSP:
+			right = i.Regs.GetArmSP(rightArg)
+		case arm64asm.Reg:
+			right = i.Regs.GetArm(rightArg)
+		case arm64asm.Imm:
+			right = expression.Imm(uint64(rightArg.Imm))
+		case arm64asm.ImmShift:
+			if imm, ok := DecodeImmediate(rightArg); ok {
+				right = expression.Imm(uint64(imm))
+			}
+		case arm64asm.RegExtshiftAmount:
+			// TODO: Handle this. Similar to ImmShift, it doesn't
+			// have public fields, so we'll need to either parse it from the string representation
+			// or use reflection.
+		}
+		if left != nil && right != nil {
+			if isSub {
+				right = expression.Multiply(expression.Imm(^uint64(0)), right)
+			}
+			sum := expression.Add(left, right)
+			switch dst := inst.Args[0].(type) {
+			case arm64asm.Reg:
+				i.Regs.setArm64asm(dst, sum)
+			case arm64asm.RegSP:
+				i.Regs.setArm64asmSP(dst, sum)
+			}
+		}
+	case arm64asm.MOV:
+		var v expression.Expression
+		switch src := inst.Args[1].(type) {
+		case arm64asm.Imm:
+			imm, _ := DecodeImmediate(src)
+			// TODO - Bogus if imm is negative
+			v = expression.Imm(uint64(imm))
+		case arm64asm.Reg:
+			v = i.Regs.GetArm(src)
+		case arm64asm.RegSP:
+			v = i.Regs.GetArmSP(src)
+		}
+		if v != nil {
+			switch dst := inst.Args[0].(type) {
+			case arm64asm.RegSP:
+				i.Regs.setArm64asmSP(dst, v)
+			case arm64asm.Reg:
+				i.Regs.setArm64asm(dst, v)
+			}
+		}
+	case arm64asm.ADRP:
+		if src, ok := inst.Args[1].(arm64asm.PCRel); ok {
+			if dst, ok := inst.Args[0].(arm64asm.Reg); ok {
+				pcPage := expression.Clear(oldPC, 12)
+				i.Regs.setArm64asm(dst, expression.Add(pcPage, expression.Imm(uint64(src))))
+			}
+
+		}
+	default:
+	}
+	return inst, nil
+}
+
+func (i *Interpreter) initRegs() {
+	for j := range len(i.Regs.regs) {
+		i.Regs.regs[j] = expression.Named(Reg(j).String())
+	}
+}

--- a/asm/arm/interpreter_test.go
+++ b/asm/arm/interpreter_test.go
@@ -60,8 +60,8 @@ func TestLuaOffsets(t *testing.T) {
 	// where `x2` is ultimately derived from L->g (usually an
 	// offset will have already been applied, e.g. `add x2, x2,
 	// #0x2e0`, which the interpreter handles transparently.)
-	cap := expression.NewImmediateCapture("g2traces")
-	jFieldLoad := expression.Mem8(expression.Add(gLoad, cap))
+	g2traces := expression.NewImmediateCapture("g2traces")
+	jFieldLoad := expression.Mem8(expression.Add(gLoad, g2traces))
 	jShortFieldLoad := expression.ZeroExtend32(jFieldLoad)
 	var result int
 	_, err := it.LoopWithBreak(func(i arm64asm.Inst) bool {
@@ -73,14 +73,14 @@ func TestLuaOffsets(t *testing.T) {
 			case arm64asm.RegSP:
 				e = it.Regs.GetArmSP(typed)
 			}
-			if e != nil && e.Match(jFieldLoad) ||
-				e.Match(jShortFieldLoad) {
-				result = int(cap.CapturedValue())
+			if e != nil && (e.Match(jFieldLoad) ||
+				e.Match(jShortFieldLoad)) {
+				result = int(g2traces.CapturedValue())
 				return true
 			}
 		}
 		return false
 	})
 	require.NoError(t, err)
-	require.Equal(t, result, 0x41C)
+	require.Equal(t, 0x41C, result)
 }

--- a/asm/arm/interpreter_test.go
+++ b/asm/arm/interpreter_test.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package arm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/asm/expression"
+	"golang.org/x/arch/arm64/arm64asm"
+)
+
+// TestLuaOffsets is based on armExtractor.findG2TracesOffsetFromChecktrace, which
+// is currently only available in Parca's fork, but is in the process of being upstreamed;
+// until then, it's good to have it as a test of the arm interpreter. This exercises loads,
+// adds, and movs.
+//
+// This function accesses `L->g->J.sztraces`, where `g` is at offset 0x10
+// in the object pointer to by `L`, which is the first argument to the
+// function; we are interested in finding the offset of `sztraces` in the
+// object pointed to by `g`. Thus we must find the offset of the first
+// load from a pointer that was itself loaded from offset 0x10 from the first argument.
+//
+// To make thing slightly more complicated, the first argument has been moved out of x0 by
+// the time we read it, and the offset is computed in two steps (the `add x2, x2, #0x2a8` at 0x5dcb8 below,
+// and the `ldr x0, [x2, #0x174]` at 0x5dcbc. Thus the answer should be 0x2a8 + 0x174 = 0x41c.
+func TestLuaOffsets(t *testing.T) {
+	// 0x5dc98: stp x19, x30, [sp, #-0x10]!
+	// 0x5dc9c: mov w1, #1
+	// 0x5dca0: mov x19, x0
+	// 0x5dca4: bl #0x52e70 ; lj_lib_checkint+0
+	// 0x5dca8: cbz w0, #0x5dcd8 ; jit_checktrace+0x40
+	// 0x5dcac: ldr x2, [x19, #0x10]
+	// 0x5dcb0: mov w1, w0
+	// 0x5dcb4: mov x0, #0
+	// 0x5dcb8: add x2, x2, #0x2a8
+	// 0x5dcbc: ldr w3, [x2, #0x174]
+	// 0x5dcc0: cmp w3, w1
+	// 0x5dcc4: b.ls #0x5dcd0 ; jit_checktrace+0x38
+	// 0x5dcc8: ldr x0, [x2, #0x168]
+	// 0x5dccc: ldr x0, [x0, w1, uxtw #3]
+	// 0x5dcd0: ldp x19, x30, [sp], #0x10
+	// 0x5dcd4: ret
+	// 0x5dcd8: mov x0, #0
+	// 0x5dcdc: ldp x19, x30, [sp], #0x10
+	// 0x5dce0: ret
+	code := []byte{
+		0xf3, 0x7b, 0xbf, 0xa9, 0x21, 0x00, 0x80, 0x52, 0xf3, 0x03, 0x00, 0xaa,
+		0x73, 0xd4, 0xff, 0x97, 0x80, 0x01, 0x00, 0x34, 0x62, 0x0a, 0x40, 0xf9,
+		0xe1, 0x03, 0x00, 0x2a, 0x00, 0x00, 0x80, 0xd2, 0x42, 0xa0, 0x0a, 0x91,
+		0x43, 0x74, 0x41, 0xb9, 0x7f, 0x00, 0x01, 0x6b, 0x69, 0x00, 0x00, 0x54,
+		0x40, 0xb4, 0x40, 0xf9, 0x00, 0x58, 0x61, 0xf8, 0xf3, 0x7b, 0xc1, 0xa8,
+		0xc0, 0x03, 0x5f, 0xd6, 0x00, 0x00, 0x80, 0xd2, 0xf3, 0x7b, 0xc1, 0xa8,
+		0xc0, 0x03, 0x5f, 0xd6}
+	it := NewInterpreterWithCode(code)
+	// e.g.: `ldr x2, [x19, #0x10]`, where `x19` came from `mov x19, x0`
+	gLoad := expression.Mem8(expression.Add(expression.Named("X0"), expression.Imm(0x10)))
+	// e.g.: `ldr w3, [x2, #0x174]` or `ldr x2, [x2, #0x168]`,
+	// where `x2` is ultimately derived from L->g (usually an
+	// offset will have already been applied, e.g. `add x2, x2,
+	// #0x2e0`, which the interpreter handles transparently.)
+	cap := expression.NewImmediateCapture("g2traces")
+	jFieldLoad := expression.Mem8(expression.Add(gLoad, cap))
+	jShortFieldLoad := expression.ZeroExtend32(jFieldLoad)
+	var result int
+	_, err := it.LoopWithBreak(func(i arm64asm.Inst) bool {
+		if i.Op == arm64asm.LDR {
+			var e expression.Expression
+			switch typed := i.Args[0].(type) {
+			case arm64asm.Reg:
+				e = it.Regs.GetArm(typed)
+			case arm64asm.RegSP:
+				e = it.Regs.GetArmSP(typed)
+			}
+			if e != nil && e.Match(jFieldLoad) ||
+				e.Match(jShortFieldLoad) {
+				result = int(cap.CapturedValue())
+				return true
+			}
+		}
+		return false
+	})
+	require.NoError(t, err)
+	require.Equal(t, result, 0x41C)
+}

--- a/asm/arm/regs_state.go
+++ b/asm/arm/regs_state.go
@@ -1,0 +1,328 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package arm // import "go.opentelemetry.io/ebpf-profiler/asm/arm"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/ebpf-profiler/asm/expression"
+	"golang.org/x/arch/arm64/arm64asm"
+)
+
+type Registers struct {
+	regs [int(registersCount)]expression.Expression
+}
+
+type regEntry struct {
+	idx  Reg
+	bits int
+}
+type Reg uint8
+
+const (
+	_ Reg = iota
+	X0
+	X1
+	X2
+	X3
+	X4
+	X5
+	X6
+	X7
+	X8
+	X9
+	X10
+	X11
+	X12
+	X13
+	X14
+	X15
+	X16
+	X17
+	X18
+	X19
+	X20
+	X21
+	X22
+	X23
+	X24
+	X25
+	X26
+	X27
+	X28
+	X29
+	X30
+	SP
+	XZR
+	PC
+	registersCount
+)
+
+var regNames = [...]string{
+	X0:  "X0",
+	X1:  "X1",
+	X2:  "X2",
+	X3:  "X3",
+	X4:  "X4",
+	X5:  "X5",
+	X6:  "X6",
+	X7:  "X7",
+	X8:  "X8",
+	X9:  "X9",
+	X10: "X10",
+	X11: "X11",
+	X12: "X12",
+	X13: "X13",
+	X14: "X14",
+	X15: "X15",
+	X16: "X16",
+	X17: "X17",
+	X18: "X18",
+	X19: "X19",
+	X20: "X20",
+	X21: "X21",
+	X22: "X22",
+	X23: "X23",
+	X24: "X24",
+	X25: "X25",
+	X26: "X26",
+	X27: "X27",
+	X28: "X28",
+	X29: "X29",
+	X30: "X30",
+	SP:  "SP",
+	XZR: "XZR",
+	PC:  "PC",
+}
+
+func (r Reg) String() string {
+	i := int(r)
+	if r == 0 || i >= len(regNames) || regNames[i] == "" {
+		return fmt.Sprintf("Reg(%d)", i)
+	}
+	return regNames[i]
+}
+
+func regMappingFor(reg arm64asm.Reg) regEntry {
+	switch reg {
+	case arm64asm.W0:
+		return regEntry{idx: X0, bits: 32}
+	case arm64asm.X0:
+		return regEntry{idx: X0, bits: 64}
+	case arm64asm.W1:
+		return regEntry{idx: X1, bits: 32}
+	case arm64asm.X1:
+		return regEntry{idx: X1, bits: 64}
+	case arm64asm.W2:
+		return regEntry{idx: X2, bits: 32}
+	case arm64asm.X2:
+		return regEntry{idx: X2, bits: 64}
+	case arm64asm.W3:
+		return regEntry{idx: X3, bits: 32}
+	case arm64asm.X3:
+		return regEntry{idx: X3, bits: 64}
+	case arm64asm.W4:
+		return regEntry{idx: X4, bits: 32}
+	case arm64asm.X4:
+		return regEntry{idx: X4, bits: 64}
+	case arm64asm.W5:
+		return regEntry{idx: X5, bits: 32}
+	case arm64asm.X5:
+		return regEntry{idx: X5, bits: 64}
+	case arm64asm.W6:
+		return regEntry{idx: X6, bits: 32}
+	case arm64asm.X6:
+		return regEntry{idx: X6, bits: 64}
+	case arm64asm.W7:
+		return regEntry{idx: X7, bits: 32}
+	case arm64asm.X7:
+		return regEntry{idx: X7, bits: 64}
+	case arm64asm.W8:
+		return regEntry{idx: X8, bits: 32}
+	case arm64asm.X8:
+		return regEntry{idx: X8, bits: 64}
+	case arm64asm.W9:
+		return regEntry{idx: X9, bits: 32}
+	case arm64asm.X9:
+		return regEntry{idx: X9, bits: 64}
+	case arm64asm.W10:
+		return regEntry{idx: X10, bits: 32}
+	case arm64asm.X10:
+		return regEntry{idx: X10, bits: 64}
+	case arm64asm.W11:
+		return regEntry{idx: X11, bits: 32}
+	case arm64asm.X11:
+		return regEntry{idx: X11, bits: 64}
+	case arm64asm.W12:
+		return regEntry{idx: X12, bits: 32}
+	case arm64asm.X12:
+		return regEntry{idx: X12, bits: 64}
+	case arm64asm.W13:
+		return regEntry{idx: X13, bits: 32}
+	case arm64asm.X13:
+		return regEntry{idx: X13, bits: 64}
+	case arm64asm.W14:
+		return regEntry{idx: X14, bits: 32}
+	case arm64asm.X14:
+		return regEntry{idx: X14, bits: 64}
+	case arm64asm.W15:
+		return regEntry{idx: X15, bits: 32}
+	case arm64asm.X15:
+		return regEntry{idx: X15, bits: 64}
+	case arm64asm.W16:
+		return regEntry{idx: X16, bits: 32}
+	case arm64asm.X16:
+		return regEntry{idx: X16, bits: 64}
+	case arm64asm.W17:
+		return regEntry{idx: X17, bits: 32}
+	case arm64asm.X17:
+		return regEntry{idx: X17, bits: 64}
+	case arm64asm.W18:
+		return regEntry{idx: X18, bits: 32}
+	case arm64asm.X18:
+		return regEntry{idx: X18, bits: 64}
+	case arm64asm.W19:
+		return regEntry{idx: X19, bits: 32}
+	case arm64asm.X19:
+		return regEntry{idx: X19, bits: 64}
+	case arm64asm.W20:
+		return regEntry{idx: X20, bits: 32}
+	case arm64asm.X20:
+		return regEntry{idx: X20, bits: 64}
+	case arm64asm.W21:
+		return regEntry{idx: X21, bits: 32}
+	case arm64asm.X21:
+		return regEntry{idx: X21, bits: 64}
+	case arm64asm.W22:
+		return regEntry{idx: X22, bits: 32}
+	case arm64asm.X22:
+		return regEntry{idx: X22, bits: 64}
+	case arm64asm.W23:
+		return regEntry{idx: X23, bits: 32}
+	case arm64asm.X23:
+		return regEntry{idx: X23, bits: 64}
+	case arm64asm.W24:
+		return regEntry{idx: X24, bits: 32}
+	case arm64asm.X24:
+		return regEntry{idx: X24, bits: 64}
+	case arm64asm.W25:
+		return regEntry{idx: X25, bits: 32}
+	case arm64asm.X25:
+		return regEntry{idx: X25, bits: 64}
+	case arm64asm.W26:
+		return regEntry{idx: X26, bits: 32}
+	case arm64asm.X26:
+		return regEntry{idx: X26, bits: 64}
+	case arm64asm.W27:
+		return regEntry{idx: X27, bits: 32}
+	case arm64asm.X27:
+		return regEntry{idx: X27, bits: 64}
+	case arm64asm.W28:
+		return regEntry{idx: X28, bits: 32}
+	case arm64asm.X28:
+		return regEntry{idx: X28, bits: 64}
+	case arm64asm.W29:
+		return regEntry{idx: X29, bits: 32}
+	case arm64asm.X29:
+		return regEntry{idx: X29, bits: 64}
+	case arm64asm.W30:
+		return regEntry{idx: X30, bits: 32}
+	case arm64asm.X30:
+		return regEntry{idx: X30, bits: 64}
+	// Note: WSP/SP are aliases for WZR/XZR in arm64asm.
+	// If you need these to be interpreted as *SP, use regMappingForSp.
+	case arm64asm.WZR:
+		return regEntry{idx: XZR, bits: 32}
+	case arm64asm.XZR:
+		return regEntry{idx: XZR, bits: 64}
+	default:
+		return regEntry{idx: 0, bits: 64}
+	}
+}
+
+func regMappingForSP(reg arm64asm.RegSP) regEntry {
+	r := arm64asm.Reg(reg)
+	switch r {
+	case arm64asm.SP:
+		return regEntry{idx: SP, bits: 64}
+	case arm64asm.WSP:
+		return regEntry{idx: SP, bits: 32}
+	default:
+		return regMappingFor(r)
+	}
+}
+
+func (r *Registers) setArm64asm(reg arm64asm.Reg, v expression.Expression) {
+	e := regMappingFor(reg)
+	if e.idx == XZR {
+		// stores to *ZR are ignored.
+		return
+	}
+	if e.bits != 64 {
+		v = expression.ZeroExtend(v, e.bits)
+	}
+	r.regs[e.idx] = v
+}
+
+func (r *Registers) setArm64asmSP(reg arm64asm.RegSP, v expression.Expression) {
+	e := regMappingForSP(reg)
+	if e.bits != 64 {
+		v = expression.ZeroExtend(v, e.bits)
+	}
+	r.regs[e.idx] = v
+}
+
+// setPC sets the value of the PC register. PC is not a possible value of
+// arm64asm.Reg, so this needs to be a separate function.
+func (r *Registers) setPC(v expression.Expression) {
+	r.regs[PC] = v
+}
+
+// GetArm returns the expression.Expression value associated with the given arm64asm.Reg, zero-extended
+// to 64 bits if necessary.
+func (r *Registers) GetArm(reg arm64asm.Reg) expression.Expression {
+	e := regMappingFor(reg)
+	if e.idx == XZR {
+		// *ZR always reads zero.
+		return expression.Imm(0)
+	}
+	res := r.regs[e.idx]
+	if e.bits != 64 {
+		res = expression.ZeroExtend(res, e.bits)
+	}
+	return res
+}
+
+// GetArmSP is like GetArm, except that X31/W31 is interpreted as SP/WSP, not XZR/WZR.
+func (r *Registers) GetArmSP(reg arm64asm.RegSP) expression.Expression {
+	e := regMappingForSP(reg)
+	res := r.regs[e.idx]
+	if e.bits != 64 {
+		res = expression.ZeroExtend(res, e.bits)
+	}
+	return res
+}
+
+// Get returns the expression.Expression value associated with the given Reg register
+func (r *Registers) Get(reg Reg) expression.Expression {
+	if reg == XZR {
+		// *ZR always reads zero.
+		return expression.Imm(0)
+	}
+	if int(reg) >= len(r.regs) {
+		return r.regs[0]
+	}
+	return r.regs[int(reg)]
+}
+
+// NameRegisterArm discards information about the expression currently stored in `reg`,
+// replacing it with a name. This is useful if we want to track stores to the address
+// contained in the register (e.g. if we know that at some point a register contains
+// a pointer to an interesting variable, and later we want to find the offset at which something is stored
+// in that variable.
+//
+// It may not be called on SP/WSP; calling it on XZR/WZR has no effect.
+func (r *Registers) NameRegisterArm(reg arm64asm.Reg, name string) {
+	r.setArm64asm(reg, expression.Named(name))
+}

--- a/asm/expression/clear.go
+++ b/asm/expression/clear.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package expression // import "go.opentelemetry.io/ebpf-profiler/asm/expression"
+
+import (
+	"fmt"
+)
+
+type clear struct {
+	v    Expression
+	bits int
+}
+
+func mask(bits int) uint64 {
+	return (uint64(1) << bits) - 1
+}
+
+// Clear returns an expression with the least-significant
+// bits cleared; for example, Clear(expr, 16) would model
+// expr & ^0xFFFF
+func Clear(v Expression, bits int) Expression {
+	if bits >= 64 {
+		bits = 64
+	}
+	if bits == 0 {
+		return v
+	}
+	switch typed := v.(type) {
+	case *immediate:
+		return Imm(typed.Value & ^mask(bits))
+	case *clear:
+		return Clear(typed.v, max(typed.bits, bits))
+	default:
+		return &clear{v, bits}
+	}
+}
+
+func (c *clear) Match(pattern Expression) bool {
+	if typed, ok := pattern.(*clear); ok && typed.bits == c.bits && c.v.Match(typed.v) {
+		return true
+	}
+	return false
+}
+
+func (c *clear) DebugString() string {
+	if c.bits == 0 {
+		// shouldn't happen; we should have simplified Clear(expr, 0) to expr.
+		// But do something sensible here just in case.
+		return fmt.Sprintf("(%s) & ^0x0 [no-op!]", c.v.DebugString())
+	}
+	return fmt.Sprintf("(%s) & ^%#x", c.v.DebugString(), mask(c.bits))
+}

--- a/asm/expression/clear.go
+++ b/asm/expression/clear.go
@@ -9,17 +9,18 @@ import (
 
 type clear struct {
 	v    Expression
-	bits int
+	bits uint
 }
 
-func mask(bits int) uint64 {
+// int must be nonnegative
+func mask(bits uint) uint64 {
 	return (uint64(1) << bits) - 1
 }
 
 // Clear returns an expression with the least-significant
 // bits cleared; for example, Clear(expr, 16) would model
 // expr & ^0xFFFF
-func Clear(v Expression, bits int) Expression {
+func Clear(v Expression, bits uint) Expression {
 	if bits >= 64 {
 		bits = 64
 	}

--- a/asm/expression/expression.go
+++ b/asm/expression/expression.go
@@ -80,3 +80,37 @@ func cmpOrder(u Expression) int {
 		return 0
 	}
 }
+
+// AsConstant checks whether the value of the expression is statically known,
+// and if so, returns it.
+//
+// Currently, we don't attempt to do any simplification that hasn't
+// already been done while constructing expressions, so this is just
+// shorthand for the common pattern of checking for an immediate at
+// the top level:
+//
+//	cap := expression.NewImmediateCapture("cap")
+//
+//	if v.Match(cap) {
+//	  return cap.CapturedValue(), true
+//	}
+//
+//	 return 0, false;
+func AsConstant(v Expression) (uint64, bool) {
+	switch typed := v.(type) {
+	case *immediate:
+		return typed.Value, true
+	default:
+		return 0, false
+	}
+}
+
+// AsNamed checks whether `v` is a named value, returning its name if so.
+func AsNamed(v Expression) (string, bool) {
+	switch typed := v.(type) {
+	case *named:
+		return typed.name, true
+	default:
+		return "", false
+	}
+}

--- a/asm/expression/expression.go
+++ b/asm/expression/expression.go
@@ -74,6 +74,8 @@ func cmpOrder(u Expression) int {
 		return 4
 	case *immediate:
 		return 5
+	case *clear:
+		return 6
 	default:
 		return 0
 	}

--- a/asm/expression/expression_test.go
+++ b/asm/expression/expression_test.go
@@ -132,4 +132,13 @@ func TestExpression(t *testing.T) {
 		require.Equal(t, wantExpr, expr.DebugString(),
 			"Match must not sort the expression's operand slice in-place")
 	})
+
+	t.Run("named must use equality of names", func(t *testing.T) {
+		n1 := Named("good")
+		n2 := Named("good")
+		require.True(t, n1.Match(n2))
+
+		n3 := Named("bad")
+		require.False(t, n1.Match(n3))
+	})
 }

--- a/asm/expression/extend.go
+++ b/asm/expression/extend.go
@@ -9,6 +9,14 @@ import (
 
 var _ Expression = &extend{}
 
+func SignExtend32(v Expression) Expression {
+	return SignExtend(v, 32)
+}
+
+func SignExtend8(v Expression) Expression {
+	return SignExtend(v, 8)
+}
+
 func SignExtend(v Expression, bits int) Expression {
 	return &extend{v, bits, true}
 }

--- a/asm/expression/named.go
+++ b/asm/expression/named.go
@@ -20,5 +20,10 @@ func (v *named) DebugString() string {
 }
 
 func (v *named) Match(pattern Expression) bool {
-	return pattern == v
+	switch typed := pattern.(type) {
+	case *named:
+		return typed.name == v.name
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
There are 5 commits here; four are simple changes to `expression.go`; the fifth is the beginnings of an aarch64 interpreter. Currently it handles mov, add, sub, adrp, ldr, and str. This is what is required to support the LuaJIT interpreter which is in preparation: https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1648