### PR TITLE
collector/config: replace xconfmap with confmap

### DIFF
--- a/collector/config/config_linux.go
+++ b/collector/config/config_linux.go
@@ -82,7 +82,7 @@ type Config struct {
 }
 
 // Validate validates the config.
-// This is automatically called by the config parser as it implements the xconfmap.Validator interface.
+// This is automatically called by the config parser as it implements the confmap.Validator interface.
 func (cfg *Config) Validate() error {
 	if cfg.ErrorMode != IgnoreError && cfg.ErrorMode != PropagateError {
 		return fmt.Errorf("unknown error mode %q", cfg.ErrorMode)

--- a/collector/config/config_test.go
+++ b/collector/config/config_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 // validConfig returns a config with valid defaults for testing.
@@ -30,7 +30,7 @@ func TestValidate(t *testing.T) {
 		SamplesPerSecond: 0,
 		ErrorMode:        PropagateError,
 	}
-	err := xconfmap.Validate(cfg)
+	err := confmap.Validate(cfg)
 	require.Error(t, err)
 	require.Equal(t, "invalid sampling frequency: 0", err.Error())
 }
@@ -68,7 +68,7 @@ func TestValidateFrameCacheSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.FrameCacheSize = tt.frameCacheSize
-			err := xconfmap.Validate(cfg)
+			err := confmap.Validate(cfg)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -145,7 +145,7 @@ func TestValidateTargetCPUIDs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.TargetCPUIDs = tt.targetCPUIDs
-			err := xconfmap.Validate(cfg)
+			err := confmap.Validate(cfg)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -187,7 +187,7 @@ func TestValidateErrorMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.ErrorMode = tt.errorMode
-			err := xconfmap.Validate(cfg)
+			err := confmap.Validate(cfg)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -202,6 +202,6 @@ func TestValidateFilterMinProcessAge(t *testing.T) {
 	cfg := validConfig()
 	cfg.FilterMinProcessAge = -1 * time.Second
 
-	err := xconfmap.Validate(cfg)
+	err := confmap.Validate(cfg)
 	require.Error(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/zeebo/xxh3 v1.1.0
 	go.opentelemetry.io/collector/component v1.63.0
 	go.opentelemetry.io/collector/component/componenttest v0.157.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.157.0
+	go.opentelemetry.io/collector/confmap v1.63.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.157.0
 	go.opentelemetry.io/collector/consumer/xconsumer v0.157.0
 	go.opentelemetry.io/collector/pdata v1.63.0
@@ -89,7 +89,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/confmap v1.63.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.63.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.157.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.63.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ go.opentelemetry.io/collector/component/componenttest v0.157.0 h1:kTMapOVJ3YMKf5
 go.opentelemetry.io/collector/component/componenttest v0.157.0/go.mod h1:AUzvlwDat8AHaNRDm+dzQ59uaEXQO1qTWccjkRjqq00=
 go.opentelemetry.io/collector/confmap v1.63.0 h1:1THBabHoQc8t/9r6ztMsghiO1OxDPZpYtn0cuwwsxYI=
 go.opentelemetry.io/collector/confmap v1.63.0/go.mod h1:ksJNAmLTiMkBjMYwXFW1MRRfXYnRsHXA0fW+ZGwb/1U=
-go.opentelemetry.io/collector/confmap/xconfmap v0.157.0 h1:jZV8p2wMQhq0ktl1/LAFGOXMCzzfMq56r80r41kKoEs=
-go.opentelemetry.io/collector/confmap/xconfmap v0.157.0/go.mod h1:W1wZk6YJ3+IyvIZEmkXH/ejwkUtBV2zCThY6ewZYd6E=
 go.opentelemetry.io/collector/consumer v1.63.0 h1:0eOZh0qmDg6HCJaiUqI9FAb4BD4fKJNNO+ygMV/WW0w=
 go.opentelemetry.io/collector/consumer v1.63.0/go.mod h1:IVhjv4d+PmSf4Ttz/guJFbWJtRM3Ld3nRcZ12gxy6PA=
 go.opentelemetry.io/collector/consumer/consumererror v0.157.0 h1:ljztZISi+MgMz5DVPq0BT7tH0OX9MRCKPFXXLcm7zWc=


### PR DESCRIPTION
xconfmap.Validator and xconfmap.Validate were removed upstream with https://github.com/open-telemetry/opentelemetry-collector/pull/15613.

Fixes #1706.