### PR TITLE
feat: emit process.runtime.name and process.runtime.version resource attributes

### DIFF
--- a/interpreter/beam/beam.go
+++ b/interpreter/beam/beam.go
@@ -281,6 +281,12 @@ func (d *beamData) String() string {
 	return fmt.Sprintf("BEAM OTP %d, ERTS %s", d.otpRelease, d.ertsVersion)
 }
 
+func (i *beamInstance) RuntimeInfo() (string, string, bool) {
+	// The OTP release (e.g. 26) keys the erlang/otp source and not the finer ERTS
+	// version (i.data.ertsVersion)
+	return "erlang", fmt.Sprintf("%d", i.data.otpRelease), true
+}
+
 func hashMFA(key beamMfa) uint32 {
 	mfhash := uint32(hash.Uint64(uint64(key.module)<<32 | uint64(key.function)))
 	return uint32(hash.Uint64(uint64(mfhash)<<32 | uint64(key.arity)))

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -874,6 +874,11 @@ func (i *dotnetInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
 	}, nil
 }
 
+func (i *dotnetInstance) RuntimeInfo() (string, string, bool) {
+	ver := i.d.version
+	return "dotnet", fmt.Sprintf("%d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff), true
+}
+
 func (i *dotnetInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	if !ef.Type().IsInterpType(libpf.Dotnet) {
 		return interpreter.ErrMismatchInterpreterType

--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go/version"
+	"strings"
 	"sync/atomic"
 	"unsafe"
 
@@ -59,6 +60,13 @@ func (d *goData) unref() {
 
 func (d *goData) String() string {
 	return "Go " + d.goVersion
+}
+
+func (g *goInstance) RuntimeInfo() (string, string, bool) {
+	if g.d.goVersion == "" {
+		return "", "", false
+	}
+	return "go", strings.TrimPrefix(g.d.goVersion, "go"), true
 }
 
 func (d *goData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID,

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -853,6 +853,15 @@ func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 	}
 }
 
+func (d *hotspotInstance) RuntimeInfo() (string, string, bool) {
+	vmd := d.d.Get()
+	if vmd == nil {
+		return "", "", false
+	}
+	return "openjdk", fmt.Sprintf("%d.%d.%d",
+		(vmd.version>>24)&0xff, (vmd.version>>16)&0xff, (vmd.version>>8)&0xff), true
+}
+
 func (d *hotspotInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 	_ reporter.ExecutableReporter, pr process.Process, _ []process.RawMapping,
 ) error {

--- a/interpreter/instancestubs.go
+++ b/interpreter/instancestubs.go
@@ -40,3 +40,7 @@ func (is *InstanceStubs) GetAndResetMetrics() ([]metrics.Metric, error) {
 func (is *InstanceStubs) ReleaseResources() error {
 	return nil
 }
+
+func (is *InstanceStubs) RuntimeInfo() (string, string, bool) {
+	return "", "", false
+}

--- a/interpreter/multi.go
+++ b/interpreter/multi.go
@@ -162,3 +162,14 @@ func (m *MultiInstance) ReleaseResources() error {
 	}
 	return errors.Join(errs...)
 }
+
+// RuntimeInfo returns the runtime info of the first wrapped instance that
+// reports one (ok=true), or ok=false if none do.
+func (m *MultiInstance) RuntimeInfo() (string, string, bool) {
+	for _, instance := range m.instances {
+		if name, version, ok := instance.RuntimeInfo(); ok {
+			return name, version, ok
+		}
+	}
+	return "", "", false
+}

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -398,6 +398,11 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName libpf.String) (
 	return c, nil
 }
 
+func (i *perlInstance) RuntimeInfo() (string, string, bool) {
+	ver := i.d.version
+	return "perl", fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff), true
+}
+
 func (i *perlInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	if !ef.Type().IsInterpType(libpf.Perl) {
 		return interpreter.ErrMismatchInterpreterType

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -185,6 +185,11 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 	return pf, nil
 }
 
+func (i *phpInstance) RuntimeInfo() (string, string, bool) {
+	ver := i.d.version
+	return "php", fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff), true
+}
+
 func (i *phpInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	// With Symbolize() in opcacheInstance there is a dedicated function to symbolize JITTed
 	// PHP frames. But as we also attach phpInstance to PHP processes with JITTed frames, we

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -54,26 +54,40 @@ const (
 	maxPyMemberDefs = 256
 )
 
-func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, err error) {
+// decodePyVersionHex extracts major.minor.micro from the CPython PY_VERSION_HEX
+// layout: (major<<24) | (minor<<16) | (micro<<8) | (releaselevel<<4) | serial.
+// The micro/patch byte is used only for RuntimeInfo() source resolution, not for
+// offset selection
+// https://docs.python.org/3/c-api/apiabiversion.html
+func decodePyVersionHex(versionHex uint32) (major uint8, minor uint8, patch uint8) {
+	return uint8((versionHex >> 24) & 0xff),
+		uint8((versionHex >> 16) & 0xff),
+		uint8((versionHex >> 8) & 0xff)
+}
+
+func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, patch uint8, err error) {
 	// Py_Version is referenced in CPython internals for versioned Python binaries.
 	// https://github.com/python/cpython/blob/v3.11.0/Doc/c-api/apiabiversion.rst
 	addr, err := ef.LookupSymbolAddress("Py_Version")
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	rm := ef.GetRemoteMemory()
 	versionHex := rm.Uint32(libpf.Address(addr))
-	major = uint8((versionHex >> 24) & 0xff)
-	minor = uint8((versionHex >> 16) & 0xff)
+	major, minor, patch = decodePyVersionHex(versionHex)
 	if major == 0 {
-		return 0, 0, fmt.Errorf("invalid Py_Version 0x%x", versionHex)
+		return 0, 0, 0, fmt.Errorf("invalid Py_Version 0x%x", versionHex)
 	}
-	return major, minor, nil
+	return major, minor, patch, nil
 }
 
 //nolint:lll
 type pythonData struct {
 	version uint16
+
+	// fullVersion is the "major.minor" or "major.minor.patch" string reported by
+	// RuntimeInfo(); patch may be absent. Not used for offset selection.
+	fullVersion string
 
 	autoTLSKey libpf.SymbolValue
 
@@ -146,6 +160,10 @@ var _ interpreter.Data = &pythonData{}
 
 func (d *pythonData) String() string {
 	return fmt.Sprintf("Python %d.%d", d.version>>8, d.version&0xff)
+}
+
+func (p *pythonInstance) RuntimeInfo() (string, string, bool) {
+	return "cpython", p.d.fullVersion, true
 }
 
 func (d *pythonData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
@@ -804,13 +822,16 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	if err != nil {
 		return nil, err
 	}
-	if major == 0 {
-		majorFromSym, minorFromSym, versionErr := readPyVersionHex(ef)
-		if versionErr != nil {
-			return nil, nil
-		}
+
+	var patch uint8
+	patchKnown := false
+	if majorFromSym, minorFromSym, patchFromSym, versionErr := readPyVersionHex(ef); versionErr == nil {
 		major = uint16(majorFromSym)
 		minor = uint16(minorFromSym)
+		patch = patchFromSym
+		patchKnown = true
+	} else if major == 0 {
+		return nil, nil
 	}
 
 	if mainDSO {
@@ -877,8 +898,13 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		}
 	}
 
+	fullVersion := fmt.Sprintf("%d.%d", major, minor)
+	if patchKnown {
+		fullVersion = fmt.Sprintf("%d.%d.%d", major, minor, patch)
+	}
 	pd := &pythonData{
 		version:         version,
+		fullVersion:     fullVersion,
 		autoTLSKey:      autoTLSKey,
 		staticTLSOffset: staticTLSOffset,
 	}

--- a/interpreter/python/python_test.go
+++ b/interpreter/python/python_test.go
@@ -120,3 +120,32 @@ func TestPythonRegexs(t *testing.T) {
 		}
 	}
 }
+
+// TestDecodePyVersionHex verifies the PY_VERSION_HEX bit-decoding against
+// real CPython constants (the value stored in the Py_Version symbol). The
+// layout is (major<<24)|(minor<<16)|(micro<<8)|(releaselevel<<4)|serial, so the
+// low byte (release/serial) must not leak into major/minor/patch.
+func TestDecodePyVersionHex(t *testing.T) {
+	tests := map[string]struct {
+		hex                             uint32
+		wantMajor, wantMinor, wantPatch uint8
+	}{
+		// 0xMMmmppRS — RS = releaselevel(4b)+serial(4b); 0xF0 = final release.
+		"3.8.0 final":  {0x030800F0, 3, 8, 0},
+		"3.11.4 final": {0x030B04F0, 3, 11, 4},
+		"3.12.7 final": {0x030C07F0, 3, 12, 7},
+		"3.11.9 final": {0x030B09F0, 3, 11, 9},
+		// Pre-releases still carry the correct micro; only the low byte differs.
+		"3.14.0a1": {0x030E00A1, 3, 14, 0},
+		// Two-digit micro must survive the mask.
+		"3.9.19 final": {0x030913F0, 3, 9, 19},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			major, minor, patch := decodePyVersionHex(tt.hex)
+			assert.Equal(t, tt.wantMajor, major)
+			assert.Equal(t, tt.wantMinor, minor)
+			assert.Equal(t, tt.wantPatch, patch)
+		})
+	}
+}

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -306,6 +306,11 @@ func (r *rubyData) String() string {
 	return fmt.Sprintf("Ruby %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
 }
 
+func (r *rubyInstance) RuntimeInfo() (string, string, bool) {
+	ver := r.r.version
+	return "ruby", fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff), true
+}
+
 func (r *rubyData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,
 	rm remotememory.RemoteMemory,
 ) (interpreter.Instance, error) {

--- a/interpreter/types.go
+++ b/interpreter/types.go
@@ -174,4 +174,8 @@ type Instance interface {
 
 	// Release resources that are used to symbolize a stack.
 	ReleaseResources() error
+
+	// RuntimeInfo returns the runtime family name and full version for source
+	// resolution, e.g. ("cpython", "3.11.4"). Returns ok=false if not applicable.
+	RuntimeInfo() (name string, version string, ok bool)
 }

--- a/process/process.go
+++ b/process/process.go
@@ -41,6 +41,10 @@ var ErrCallbackStopped = errors.New("IterateMappings stopped by callback")
 // backing store (StoreCoredump bundle miss).
 var ErrMappingFileUnavailable = errors.New("mapping backing file unavailable")
 
+// deletedSuffix is appended by the kernel to the path of an unlinked file, in both
+// /proc/PID/maps and /proc/PID/exe; it is trimmed from both so they stay comparable.
+const deletedSuffix = " (deleted)"
+
 const (
 	containerSource = "[0-9a-f]{64}"
 	taskSource      = "[0-9a-f]{32}-\\d+"
@@ -109,7 +113,8 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 	if err != nil {
 		return libpf.NullString, err
 	}
-	return libpf.Intern(str), nil
+	// Trim the deleted indication from the executable path
+	return libpf.Intern(strings.TrimSuffix(str, deletedSuffix)), nil
 }
 
 func (sp *systemProcess) GetProcessMeta(enrichers []MetaEnricher) Meta {
@@ -279,7 +284,7 @@ func detectSelfContainerIDViaInode() (libpf.String, uint64, error) {
 func trimMappingPath(path string) string {
 	// Trim the deleted indication from the path.
 	// See path_with_deleted in linux/fs/d_path.c
-	path = strings.TrimSuffix(path, " (deleted)")
+	path = strings.TrimSuffix(path, deletedSuffix)
 	if path == "/dev/zero" {
 		// Some JIT engines map JIT area from /dev/zero
 		// make it anonymous.

--- a/process/types.go
+++ b/process/types.go
@@ -102,7 +102,8 @@ type ReadAtCloser = pfelf.ReadAtCloser
 
 // ProcessMeta contains metadata about a tracked process.
 type Meta struct {
-	// executable path retrieved from /proc/PID/exe
+	// executable path retrieved from /proc/PID/exe, with the
+	// " (deleted)" suffix removed
 	Executable libpf.String
 	// process env vars from /proc/PID/environ
 	EnvVariables map[libpf.String]libpf.String
@@ -110,6 +111,13 @@ type Meta struct {
 	ContainerID libpf.String
 	// process context
 	ProcessContextInfo processcontext.Info
+	// RuntimeName is the detected language runtime family (e.g. "cpython"),
+	// emitted as the process.runtime.name OTLP resource attribute. Empty until
+	// resolved.
+	RuntimeName string
+	// RuntimeVersion is the detected runtime version (e.g. "3.11.4"), emitted as
+	// the process.runtime.version OTLP resource attribute.
+	RuntimeVersion string
 
 	// ExtraMeta holds arbitrary key-value pairs populated by a MetaEnricher.
 	// It is nil unless an enricher is configured and explicitly sets values.
@@ -132,7 +140,8 @@ type Process interface {
 	// GetProcessMeta returns process specific metadata.
 	GetProcessMeta([]MetaEnricher) Meta
 
-	// GetExe returns the executable path of the process.
+	// GetExe returns the executable path of the process, with the
+	// " (deleted)" suffix removed
 	GetExe() (libpf.String, error)
 
 	// IterateMappings parses process memory mappings and calls the

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -394,6 +394,8 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *sa
 		TraceID:        bpfTrace.APMTraceID,
 		SpanID:         bpfTrace.APMTransactionID,
 		ExtraMeta:      procMeta.ExtraMeta,
+		RuntimeName:    procMeta.RuntimeName,
+		RuntimeVersion: procMeta.RuntimeVersion,
 	}
 
 	pid := bpfTrace.PID

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -224,6 +224,27 @@ func (pm *ProcessManager) handleNewInterpreter(pr process.Process, bias libpf.Ad
 	return anonymousMappingsWanted || instance.UsesAnonymousMappings(), nil
 }
 
+// selectProcessRuntime picks the runtime to emit as process.runtime.* for a
+// process that may have multiple runtimes. It prefers the top-level runtime,
+// i.e. the one whose DSO is the process's own executable (identified by exeOID).
+func selectProcessRuntime(interps map[util.OnDiskFileIdentifier]interpreter.Instance,
+	exeOID util.OnDiskFileIdentifier) (name, version string) {
+	if inst, ok := interps[exeOID]; ok {
+		if n, v, ok := inst.RuntimeInfo(); ok {
+			return n, v
+		}
+	}
+	// Pick the smallest (name, version) so a process with several non-exe runtimes
+	// always reports the same one
+	for _, inst := range interps {
+		if n, v, ok := inst.RuntimeInfo(); ok &&
+			(name == "" || n < name || (n == name && v < version)) {
+			name, version = n, v
+		}
+	}
+	return name, version
+}
+
 func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.RawMapping,
 	elfRef *pfelf.Reference,
 ) elfInfo {
@@ -617,6 +638,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	mappings := make([]Mapping, 0, capHint)
 	mpAdd := make([]*Mapping, 0, capHint)
 	var processContextInfo processcontext.Info
+	// exeOID is the on-disk identity of the process's main executable, used by
+	// the runtime recompute below to prefer the top-level runtime.
+	var exeOID util.OnDiskFileIdentifier
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
@@ -646,6 +670,11 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		m.Path = libpf.Intern(m.Path).String()
 
 		if mappingNeeded {
+			if exeOID == (util.OnDiskFileIdentifier{}) && exe != libpf.NullString &&
+				m.Path == exe.String() {
+				exeOID = m.GetOnDiskFileIdentifier()
+			}
+
 			var fm libpf.FrameMapping
 			if oldm, ok := mpRemove[m.Vaddr]; ok {
 				if oldm.Length == m.Length && oldm.Device == m.Device && oldm.Inode == m.Inode {
@@ -762,6 +791,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	// Sort and publish the new mappings and meta.
 	slices.SortFunc(mappings, compareMapping)
 
+	needRuntime := false
 	info = pm.getOrCreateProcessInfo(pid, pr)
 	pm.mu.Lock()
 	if info != nil {
@@ -770,6 +800,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			info.meta = meta
 		}
 		info.meta.ProcessContextInfo = processContextInfo
+		needRuntime = info.meta.RuntimeName == ""
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()
@@ -784,6 +815,17 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 				log.Debugf("Failed to handle new anonymous mapping for PID %d: process exited",
 					pid)
 			}
+		}
+	}
+
+	// Resolve the process runtime for OTLP process.runtime.* emission.
+	if needRuntime {
+		if name, version := selectProcessRuntime(interpreters, exeOID); name != "" {
+			pm.mu.Lock()
+			if info, ok := pm.pidToProcessInfo[pid]; ok && info.meta.RuntimeName == "" {
+				info.meta.RuntimeName, info.meta.RuntimeVersion = name, version
+			}
+			pm.mu.Unlock()
 		}
 	}
 

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -207,6 +207,78 @@ func (tp *testProcess) OpenELF(string) (*pfelf.File, error) {
 	return nil, errors.New("not implemented")
 }
 
+type runtimeInstance struct {
+	interpreter.InstanceStubs
+	name    string
+	version string
+	ok      bool
+}
+
+func (r *runtimeInstance) RuntimeInfo() (string, string, bool) {
+	return r.name, r.version, r.ok
+}
+
+func (r *runtimeInstance) Detach(interpreter.EbpfHandler, libpf.PID) error {
+	return nil
+}
+
+func TestSelectProcessRuntime(t *testing.T) {
+	exeOID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 1}
+	libOID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 2}
+
+	tests := map[string]struct {
+		interps     map[util.OnDiskFileIdentifier]interpreter.Instance
+		exeOID      util.OnDiskFileIdentifier
+		wantName    string
+		wantVersion string
+	}{
+		"exe runtime wins over embedded runtime": {
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &runtimeInstance{name: "go", version: "1.23.4", ok: true},
+				libOID: &runtimeInstance{name: "cpython", version: "3.11.4", ok: true},
+			},
+			exeOID:      exeOID,
+			wantName:    "go",
+			wantVersion: "1.23.4",
+		},
+		"falls back to sole HLL when exe is a launcher": {
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				libOID: &runtimeInstance{name: "openjdk", version: "17.0.8", ok: true},
+			},
+			exeOID:      exeOID,
+			wantName:    "openjdk",
+			wantVersion: "17.0.8",
+		},
+		"exe runtime opting out yields nothing": {
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &runtimeInstance{ok: false},
+			},
+			exeOID: exeOID,
+		},
+		"no interpreters yields nothing": {
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{},
+			exeOID:  exeOID,
+		},
+		"deterministically picks smallest (name, version) among non-exe runtimes": {
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				libOID:                     &runtimeInstance{name: "cpython", version: "3.11.4", ok: true},
+				{DeviceID: 1, InodeNum: 3}: &runtimeInstance{name: "ruby", version: "3.2.0", ok: true},
+			},
+			exeOID:      exeOID,    // absent from interps, so the fallback runs
+			wantName:    "cpython", // "cpython" < "ruby", independent of map order
+			wantVersion: "3.11.4",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotName, gotVersion := selectProcessRuntime(test.interps, test.exeOID)
+			assert.Equal(t, test.wantName, gotName)
+			assert.Equal(t, test.wantVersion, gotVersion)
+		})
+	}
+}
+
 func TestAssignLibcInfoMergesLibcInfo(t *testing.T) {
 	assert := assert.New(t)
 
@@ -488,6 +560,108 @@ func TestSynchronizeProcessSkipsDllMappingsWithoutAnonymousMappingInterest(t *te
 	})
 
 	require.Empty(instance.syncMappings)
+}
+
+func TestSynchronizeProcessResolvesTopLevelRuntime(t *testing.T) {
+	const exePath = "/opt/app/bin/agent"
+	exeOID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 1}
+	libOID := util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: 2}
+
+	rawMapping := func(vaddr uint64, oid util.OnDiskFileIdentifier, path string) process.RawMapping {
+		return process.RawMapping{
+			Vaddr:  vaddr,
+			Length: 0x1000,
+			Flags:  elf.PF_R | elf.PF_X,
+			Device: oid.DeviceID,
+			Inode:  oid.InodeNum,
+			Path:   path,
+		}
+	}
+	keptMapping := func(vaddr uint64, oid util.OnDiskFileIdentifier) Mapping {
+		return Mapping{
+			Vaddr:  libpf.Address(vaddr),
+			Length: 0x1000,
+			Device: oid.DeviceID,
+			Inode:  oid.InodeNum,
+			FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
+				File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+					FileID:   libpf.NewFileID(oid.DeviceID, oid.InodeNum),
+					FileName: libpf.Intern("x"),
+				}),
+				Start: 0,
+				End:   0x1000,
+			}),
+		}
+	}
+
+	tests := map[string]struct {
+		interps     map[util.OnDiskFileIdentifier]interpreter.Instance
+		preMeta     process.Meta
+		wantName    string
+		wantVersion string
+	}{
+		"top-level exe runtime wins over embedded runtime": {
+			// Go binary that dlopen'd CPython: report the runtime whose DSO is
+			// the executable, not the embedded one.
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &runtimeInstance{name: "go", version: "1.23.4", ok: true},
+				libOID: &runtimeInstance{name: "cpython", version: "3.11.4", ok: true},
+			},
+			wantName:    "go",
+			wantVersion: "1.23.4",
+		},
+		"runtime is not overwritten once set": {
+			// Executable unchanged (meta preserved) and runtime already resolved:
+			// the recompute must leave it untouched (fill-once).
+			interps: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &runtimeInstance{name: "go", version: "1.23.4", ok: true},
+			},
+			preMeta: process.Meta{
+				Executable:     libpf.Intern(exePath),
+				RuntimeName:    "cpython",
+				RuntimeVersion: "3.11.4",
+			},
+			wantName:    "cpython",
+			wantVersion: "3.11.4",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pid := libpf.PID(123)
+			mappings := make([]Mapping, 0, len(test.interps))
+			raws := make([]process.RawMapping, 0, len(test.interps))
+			vaddr := uint64(0x1000)
+			for oid := range test.interps {
+				path := "/usr/lib/libembedded.so"
+				if oid == exeOID {
+					path = exePath
+				}
+				mappings = append(mappings, keptMapping(vaddr, oid))
+				raws = append(raws, rawMapping(vaddr, oid, path))
+				vaddr += 0x1000
+			}
+			pm := &ProcessManager{
+				ebpf: &testEbpfHandler{},
+				interpreters: map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance{
+					pid: test.interps,
+				},
+				pidToProcessInfo: map[libpf.PID]*processInfo{
+					pid: {mappings: mappings, meta: test.preMeta},
+				},
+				exitEvents: make(map[libpf.PID]times.KTime),
+			}
+
+			pm.SynchronizeProcess(&testProcess{
+				pid:      pid,
+				exe:      libpf.Intern(exePath),
+				mappings: raws,
+			})
+
+			assert.Equal(t, test.wantName, pm.pidToProcessInfo[pid].meta.RuntimeName)
+			assert.Equal(t, test.wantVersion, pm.pidToProcessInfo[pid].meta.RuntimeVersion)
+		})
+	}
 }
 
 func TestIsInterpreterMapping(t *testing.T) {

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -69,12 +69,21 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 
 	if _, exists := (*eventsTree)[key]; !exists {
 		(*eventsTree)[key] = samples.ResourceToProfiles{
-			EnvVars: meta.EnvVars,
-			Events:  make(map[*samples.TypeMetadata]samples.SampleToEvents),
+			EnvVars:        meta.EnvVars,
+			RuntimeName:    meta.RuntimeName,
+			RuntimeVersion: meta.RuntimeVersion,
+			Events:         make(map[*samples.TypeMetadata]samples.SampleToEvents),
 		}
 	}
 
 	rtp := (*eventsTree)[key]
+	// Backfill the runtime when the resource bucket was created at a
+	// first sample that predated runtime resolution, and a later sample supplies it.
+	if rtp.RuntimeName == "" && meta.RuntimeName != "" {
+		rtp.RuntimeName = meta.RuntimeName
+		rtp.RuntimeVersion = meta.RuntimeVersion
+		(*eventsTree)[key] = rtp
+	}
 	if _, exists := rtp.Events[meta.ProfileType]; !exists {
 		rtp.Events[meta.ProfileType] = make(samples.SampleToEvents)
 	}

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -278,3 +278,73 @@ func TestProcessMetaEnricherPipeline(t *testing.T) {
 	}
 	assert.True(t, found, "expected process.name=myapp in the attribute table")
 }
+
+// TestReportTraceEventRuntimeBackfill verifies that the runtime name/version is
+// stored on the resource and backfilled when the first sample for a resource
+// arrived before the interpreter was detected.
+func TestReportTraceEventRuntimeBackfill(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+
+	trace := &libpf.Trace{
+		Frames: func() libpf.Frames {
+			frames := make(libpf.Frames, 0, 1)
+			frames.Append(&libpf.Frame{
+				Type:            libpf.PythonFrame,
+				AddressOrLineno: 42,
+				FunctionName:    libpf.Intern("main"),
+			})
+			return frames
+		}(),
+	}
+
+	now := time.Now()
+	baseMeta := func(ts time.Time, name, version string) *samples.TraceEventMeta {
+		return &samples.TraceEventMeta{
+			Timestamp:      libpf.UnixTime64(ts.UnixNano()),
+			Comm:           libpf.NewCommFromString("py"),
+			ExecutablePath: libpf.Intern("/usr/bin/python3"),
+			PID:            4242,
+			ProfileType:    profileTypeSampling,
+			RuntimeName:    name,
+			RuntimeVersion: version,
+		}
+	}
+
+	resourceRuntime := func() (string, string) {
+		eventsTreePtr := reporter.traceEvents.RLock()
+		defer reporter.traceEvents.RUnlock(&eventsTreePtr)
+		for _, rtp := range *eventsTreePtr {
+			return rtp.RuntimeName, rtp.RuntimeVersion
+		}
+		return "", ""
+	}
+
+	// First sample arrives before the interpreter attached: no runtime yet.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(now, "", "")))
+	name, version := resourceRuntime()
+	assert.Empty(t, name)
+	assert.Empty(t, version)
+
+	// A later sample carries the detected runtime; it should be backfilled onto
+	// the existing resource bucket.
+	require.NoError(t, reporter.ReportTraceEvent(trace,
+		baseMeta(now.Add(time.Second), "cpython", "3.11.4")))
+	name, version = resourceRuntime()
+	assert.Equal(t, "cpython", name)
+	assert.Equal(t, "3.11.4", version)
+
+	// Runtime is immutable once set: a later sample reporting a different
+	// non-empty runtime under the same resource bucket shouldn't overwrite it.
+	require.NoError(t, reporter.ReportTraceEvent(trace,
+		baseMeta(now.Add(2*time.Second), "cpython", "3.12.0")))
+	name, version = resourceRuntime()
+	assert.Equal(t, "cpython", name)
+	assert.Equal(t, "3.11.4", version)
+
+	// A later sample that lacks a runtime doesn't clobber the known runtime.
+	require.NoError(t, reporter.ReportTraceEvent(trace,
+		baseMeta(now.Add(3*time.Second), "", "")))
+	name, version = resourceRuntime()
+	assert.Equal(t, "cpython", name)
+	assert.Equal(t, "3.11.4", version)
+}

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -103,7 +103,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 		}
 
 		rp := profiles.ResourceProfiles().AppendEmpty()
-		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars)
+		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents)
 		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
@@ -303,7 +303,7 @@ func (p *Pdata) setProfile(
 	return nil
 }
 
-func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String) {
+func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, toProfiles samples.ResourceToProfiles) {
 	if resource.APMServiceName != "" {
 		attrs.PutStr(string(semconv.ServiceNameKey), resource.APMServiceName)
 	}
@@ -319,7 +319,14 @@ func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envV
 		attrs.PutStr(string(semconv.ProcessExecutableNameKey), exeName)
 	}
 
-	for key, value := range envVars {
+	if toProfiles.RuntimeName != "" {
+		attrs.PutStr(string(semconv.ProcessRuntimeNameKey), toProfiles.RuntimeName)
+	}
+	if toProfiles.RuntimeVersion != "" {
+		attrs.PutStr(string(semconv.ProcessRuntimeVersionKey), toProfiles.RuntimeVersion)
+	}
+
+	for key, value := range toProfiles.EnvVars {
 		attrs.PutStr("process.environment_variable."+key.String(), value.String())
 	}
 }

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -405,7 +405,9 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 			EnvVars: map[libpf.String]libpf.String{
 				libpf.Intern("FOO"): libpf.Intern("BAR"),
 			},
-			Events: events,
+			RuntimeName:    "cpython",
+			RuntimeVersion: "3.11.4",
+			Events:         events,
 		},
 	}
 
@@ -434,6 +436,60 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 		assert.Equal(t, "BAR", val.Str(),
 			"Environment variable value 'BAR' should be in the resource attributes")
 	})
+
+	t.Run("Check runtime version attributes", func(t *testing.T) {
+		rp := profiles.ResourceProfiles().At(0)
+		name, exists := rp.Resource().Attributes().Get(string(semconv.ProcessRuntimeNameKey))
+		assert.True(t, exists, "process.runtime.name should be in the resource attributes")
+		assert.Equal(t, "cpython", name.Str())
+		version, exists := rp.Resource().Attributes().Get(string(semconv.ProcessRuntimeVersionKey))
+		assert.True(t, exists, "process.runtime.version should be in the resource attributes")
+		assert.Equal(t, "3.11.4", version.Str())
+	})
+}
+
+func TestSetResourceAttributes_Runtime(t *testing.T) {
+	tests := map[string]struct {
+		toProfiles  samples.ResourceToProfiles
+		wantName    string
+		wantVersion string
+		wantPresent bool
+	}{
+		"present": {
+			toProfiles:  samples.ResourceToProfiles{RuntimeName: "ruby", RuntimeVersion: "3.2.0"},
+			wantName:    "ruby",
+			wantVersion: "3.2.0",
+			wantPresent: true,
+		},
+		"absent when unset": {
+			toProfiles:  samples.ResourceToProfiles{},
+			wantPresent: false,
+		},
+		"version omitted when only name set": {
+			toProfiles:  samples.ResourceToProfiles{RuntimeName: "go"},
+			wantName:    "go",
+			wantPresent: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			attrs := pcommon.NewMap()
+			setResourceAttributes(attrs, samples.ResourceKey{PID: 1}, tt.toProfiles)
+
+			gotName, nameExists := attrs.Get(string(semconv.ProcessRuntimeNameKey))
+			gotVersion, versionExists := attrs.Get(string(semconv.ProcessRuntimeVersionKey))
+
+			assert.Equal(t, tt.wantPresent, nameExists)
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantName, gotName.Str())
+			}
+			assert.Equal(t, tt.wantVersion != "", versionExists)
+			if tt.wantVersion != "" {
+				assert.Equal(t, tt.wantVersion, gotVersion.Str())
+			}
+		})
+	}
 }
 
 func TestGenerate_MultipleOriginsAndContainers(t *testing.T) {

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -17,6 +17,8 @@ type TraceEventMeta struct {
 	// SampleAttrProducer.CollectExtraSampleMeta to attach process-level attributes.
 	ExtraMeta      map[libpf.String]string
 	APMServiceName string
+	RuntimeName    string
+	RuntimeVersion string
 	Timestamp      libpf.UnixTime64
 	CPU            uint32
 	ProfileType    *TypeMetadata
@@ -43,7 +45,9 @@ type TraceEventsTree map[ResourceKey]ResourceToProfiles
 type ResourceToProfiles struct {
 	// EnvVars can not be part of ResourceKey as maps are not
 	// comparable.
-	EnvVars map[libpf.String]libpf.String
+	EnvVars        map[libpf.String]libpf.String
+	RuntimeName    string
+	RuntimeVersion string
 
 	// Events holds the actual profiling information.
 	Events map[*TypeMetadata]SampleToEvents


### PR DESCRIPTION
## Summary

Adds the `process.runtime.name` and `process.runtime.version` OTLP resource attributes, so exported profiles record which language runtime, and which version of it, a process was running.

The motivating use case is resolving standard-library source code: knowing a sample came from CPython 3.11.4 rather than just "CPython" allows us to know the precise runtime version of the frame.

## Design

- `interpreter.Instance` gains `RuntimeInfo() (name, version string, ok bool)`. Instances that can report a runtime return `ok=true`; the default `InstanceStubs` implementation returns `ok=false`.
- Implemented for CPython, Go, Ruby, HotSpot, .NET, Perl, PHP, BEAM and `MultiInstance`.
- `ProcessManager.SynchronizeProcess` resolves one runtime per process and stores it on `process.Meta`. 
- The reporter emits them as resource attributes in `setResourceAttributes`.

### Picking one runtime per process

A process can host more than one runtime, this PR:

1. **Prefer the top-level runtime.** The instance whose DSO is the process' own executable wins, identified by matching the mapping path against `/proc/PID/exe`. This is what makes a Go binary embedding CPython report `go` rather than `cpython`.
2. **Be deterministic otherwise.** When the executable itself reports no runtime, the lexicographically smallest `(name, version)` pair is chosen. Go map iteration is randomized, so without this a multi-runtime process would flip between values across sync rounds and split its samples across resources.

Once resolved the runtime is not overwritten; it is recomputed only when the executable changes.

### Late attachment

A process' first samples can arrive before its interpreter has been detected, which would otherwise strand those samples on a resource with no runtime recorded. `baseReporter.ReportTraceEvent` backfills the resource's runtime from the first later sample that carries one.

## Notes

- CPython's patch level is decoded from `PY_VERSION_HEX` (the micro byte) purely for this attribute. Offset selection still keys off major/minor only, so version-specific unwinding behavior is unchanged.
- `GetExe()` now trims the kernel's `" (deleted)"` suffix. `/proc/PID/maps` paths were already trimmed via `trimMappingPath`, so without this the executable-mapping comparison above would silently fail to match. Both now share a single `deletedSuffix` constant.

## Testing

New unit tests cover runtime selection (`TestSelectProcessRuntime`), end-to-end resolution through `SynchronizeProcess`(`TestSynchronizeProcessResolvesTopLevelRuntime`), the reporter backfill and immutability rules (`TestReportTraceEventRuntimeBackfill`), attribute emission (`TestSetResourceAttributes_Runtime`), and `PY_VERSION_HEX` decoding (`TestDecodePyVersionHex`).
