### PR TITLE
fix(interpreter): bound all attacker-controlled sizes in VM walks

### DIFF
--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"unsafe"
 
@@ -375,6 +376,20 @@ func (d *dotnetData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address)
 		}
 	}
 	vms.RealCodeHeader.SizeOf = vms.RealCodeHeader.MethodDesc + 8
+
+	// Validate that all struct sizes used for allocations are within bounds.
+	// The JSON descriptor is read from target memory and is attacker-controlled.
+	structs := reflect.ValueOf(&cdac.Types).Elem()
+	for i := 0; i < structs.NumField(); i++ {
+		sizeOf := structs.Field(i).FieldByName("SizeOf")
+		if !sizeOf.IsValid() {
+			continue
+		}
+		if s := sizeOf.Uint(); s > maxDotnetStructSize {
+			return dotnetCdac{}, fmt.Errorf("%s.SizeOf value %d out of bounds",
+				structs.Type().Field(i).Name, s)
+		}
+	}
 
 	// Calculated masks
 	cdac.calculated.MethodDescTokenRemainderMask = (1 << cdac.Globals.MethodDescTokenRemainderBitCount) - 1

--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -119,6 +119,23 @@ const (
 	// maxBoundsSize is the maximum size of boundary debug info (for a method)
 	// that we accept as valid. This is to prevent OOM situation.
 	maxBoundsSize = 16 * 1024
+
+	// maxRangeSections bounds the traversal of RangeSection / fragment lists,
+	// which are attacker-controlled linked structures.
+	maxRangeSections = 1 << 20
+
+	// maxRangeListBlocks bounds the number of blocks traversed in a stub
+	// RangeList.
+	maxRangeListBlocks = 1 << 16
+
+	// maxRangeMapLevels bounds the number of intermediate level nodes read
+	// while walking a dotnet RangeSectionMap (protects against aliased level
+	// pointers causing exponential traversal).
+	maxRangeMapLevels = 1 << 17
+
+	// maxDotnetStructSize caps the size of any per-struct read from target
+	// memory. All real CoreCLR struct sizes are well below this value.
+	maxDotnetStructSize = 64 * 1024
 )
 
 var (

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -124,8 +124,20 @@ type stringsHeapEntry struct {
 	gen  uint64
 }
 
+// dotnetRangeSection reflects the set of lpm prefixes for one range section.
 type dotnetRangeSection struct {
 	prefixes []lpm.Prefix
+}
+
+// rangeWalker carries per-walk state for walking a dotnet8 RangeSectionMap. It
+// deduplicates aliased level/fragment pointers and tracks visit budgets so that
+// a malicious tree cannot cause exponential traversal or unbounded loops.
+type rangeWalker struct {
+	sectionSeen  map[libpf.Address]libpf.Void
+	levelSeen    map[libpf.Address]libpf.Void
+	fragmentSeen map[libpf.Address]libpf.Void
+	levelReads   int
+	fragments    int
 }
 
 type dotnetInstance struct {
@@ -163,8 +175,6 @@ type dotnetInstance struct {
 	mappings []dotnetMapping
 
 	ranges map[libpf.Address]dotnetRangeSection
-
-	rangeSectionSeen map[libpf.Address]libpf.Void
 
 	// moduleToPEInfo maps Module* to it's peInfo. Since a dotnet instance will have
 	// limited number of PE files mapped in, this is a map instead of a LRU.
@@ -246,7 +256,12 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	stubName := codeName[codeType]
 	log.Debugf("Found %s stub range list head at %x", stubName, headPtr)
 	blockNum := 0
-	for blockPtr := headPtr + 0x8; blockPtr != 0; blockNum++ {
+	seen := make(map[libpf.Address]libpf.Void)
+	for blockPtr := headPtr + 0x8; blockPtr != 0 && blockNum < maxRangeListBlocks; blockNum++ {
+		if _, ok := seen[blockPtr]; ok {
+			return
+		}
+		seen[blockPtr] = libpf.Void{}
 		if err := i.rm.Read(blockPtr, block); err != nil {
 			log.Debugf("Failed to read %s stub range block %d: %v",
 				stubName, blockNum, err)
@@ -340,8 +355,18 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 	vms := &i.d.Get().Types
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	// walk the RangeSection list
+	seen := make(map[libpf.Address]libpf.Void)
+	count := 0
 	ptr := i.rm.Ptr(i.codeRangeListPtr)
 	for ptr != 0 {
+		if _, ok := seen[ptr]; ok {
+			break
+		}
+		seen[ptr] = libpf.Void{}
+		count++
+		if count > maxRangeSections {
+			return fmt.Errorf("too many range sections in list")
+		}
 		if err := i.rm.Read(ptr, rangeSection); err != nil {
 			return err
 		}
@@ -356,23 +381,31 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 // walkRangeSectionMapFragments walks a RangeSectionMap::RangeSectionFragment list and processes
 // the RangeSections from it.
 func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandler, pid libpf.PID,
-	fragmentPtr libpf.Address,
+	fragmentPtr libpf.Address, w *rangeWalker,
 ) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L974
 	vms := &i.d.Get().Types
 	fragment := make([]byte, 4*8)
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	for fragmentPtr != 0 {
+		if _, ok := w.fragmentSeen[fragmentPtr]; ok {
+			break
+		}
+		w.fragmentSeen[fragmentPtr] = libpf.Void{}
+		w.fragments++
+		if w.fragments > maxRangeSections {
+			return fmt.Errorf("too many range section fragments")
+		}
 		if err := i.rm.Read(fragmentPtr, fragment); err != nil {
 			return fmt.Errorf("failed to read fragment: %v", err)
 		}
 		// Remove collectible bit
 		fragmentPtr = npsr.Ptr(fragment, 0) &^ 1
 		rangeSectionPtr := npsr.Ptr(fragment, 24)
-		if _, ok := i.rangeSectionSeen[rangeSectionPtr]; ok {
+		if _, ok := w.sectionSeen[rangeSectionPtr]; ok {
 			continue
 		}
-		i.rangeSectionSeen[rangeSectionPtr] = libpf.Void{}
+		w.sectionSeen[rangeSectionPtr] = libpf.Void{}
 
 		if err := i.rm.Read(rangeSectionPtr, rangeSection); err != nil {
 			return fmt.Errorf("failed to read range section: %v", err)
@@ -386,7 +419,7 @@ func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandl
 
 // walkRangeSectionMapLevel walks recursively a level index of a RangeSectionMap.
 func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, pid libpf.PID,
-	levelMapPtr libpf.Address, level uint,
+	levelMapPtr libpf.Address, level uint, w *rangeWalker,
 ) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L999-L1002
 	const maxLevel = 5
@@ -403,11 +436,19 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 			continue
 		}
 		if level < maxLevel {
-			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1); err != nil {
+			w.levelReads++
+			if w.levelReads > maxRangeMapLevels {
+				return fmt.Errorf("too many range section map levels")
+			}
+			if _, ok := w.levelSeen[ptr]; ok {
+				continue
+			}
+			w.levelSeen[ptr] = libpf.Void{}
+			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1, w); err != nil {
 				return err
 			}
 		} else {
-			if err := i.walkRangeSectionMapFragments(ebpf, pid, ptr); err != nil {
+			if err := i.walkRangeSectionMapFragments(ebpf, pid, ptr, w); err != nil {
 				return err
 			}
 		}
@@ -417,10 +458,12 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 
 // walkRangeSectionMap processes a dotnet8 RangeSectionMap to enumerate all RangeSections
 func (i *dotnetInstance) walkRangeSectionMap(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
-	i.rangeSectionSeen = make(map[libpf.Address]libpf.Void)
-	err := i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1)
-	i.rangeSectionSeen = nil
-	return err
+	w := &rangeWalker{
+		sectionSeen:  make(map[libpf.Address]libpf.Void),
+		levelSeen:    make(map[libpf.Address]libpf.Void),
+		fragmentSeen: make(map[libpf.Address]libpf.Void),
+	}
+	return i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1, w)
 }
 
 // resolveStringsHeapAddr returns the absolute process address of the #Strings

--- a/interpreter/dotnet/instance_test.go
+++ b/interpreter/dotnet/instance_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dotnet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/host"
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/lpm"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+type fakeEbpf struct {
+	interpreter.EbpfHandler
+}
+
+func (fakeEbpf) UpdatePidInterpreterMapping(libpf.PID, lpm.Prefix, uint8, host.FileID, uint64) error {
+	return nil
+}
+
+type countingReaderAt struct {
+	r     io.ReaderAt
+	reads int
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	c.reads++
+	return c.r.ReadAt(p, off)
+}
+
+func putUint64(buf []byte, off int, v uint64) {
+	binary.LittleEndian.PutUint64(buf[off:off+8], v)
+}
+
+func newTestDotnetInstance(rm remotememory.RemoteMemory) *dotnetInstance {
+	d := &dotnetData{}
+	_, err := d.GetOrInit(func() (dotnetCdac, error) {
+		cdac := dotnetCdac{}
+		vms := &cdac.Types
+		vms.RangeSection.RangeBegin = 0
+		vms.RangeSection.RangeEndOpen = 8
+		vms.RangeSection.Flags = 0x10
+		vms.RangeSection.next = 24
+		vms.RangeSection.HeapList = 0x28
+		vms.RangeSection.R2RModule = 0x20
+		vms.RangeSection.RangeList = 0x30
+		vms.RangeSection.SizeOf = 0x38
+		vms.CodeHeapListNode.SizeOf = 0x30
+		vms.CodeHeapListNode.MapBase = 0x20
+		vms.CodeHeapListNode.HeaderMap = 0x28
+		vms.CodeHeapListNode.Next = 0
+		vms.CodeHeapListNode.StartAddress = 0x10
+		vms.CodeHeapListNode.EndAddress = 0x18
+		return cdac, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &dotnetInstance{
+		d:      d,
+		rm:     rm,
+		ranges: make(map[libpf.Address]dotnetRangeSection),
+	}
+}
+
+// TestWalkRangeSectionListCycle verifies that a cyclic RangeSection.next chain
+// terminates instead of looping forever.
+func TestWalkRangeSectionListCycle(t *testing.T) {
+	const (
+		r1   libpf.Address = 0x1000
+		r2   libpf.Address = 0x1040
+		head libpf.Address = 0x1080
+	)
+	buf := make([]byte, 0x1100)
+	putUint64(buf, int(head), uint64(r1))
+	putUint64(buf, int(r1)+24, uint64(r2))
+	putUint64(buf, int(r2)+24, uint64(r1))
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+	i := newTestDotnetInstance(rm)
+	i.codeRangeListPtr = head
+
+	err := i.walkRangeSectionList(fakeEbpf{}, 0)
+	require.NoError(t, err)
+	require.Empty(t, i.ranges)
+}
+
+// TestWalkRangeListCycle verifies that a cyclic stub RangeList block chain
+// terminates instead of looping forever.
+func TestWalkRangeListCycle(t *testing.T) {
+	const (
+		b1   libpf.Address = 0x1000
+		b2   libpf.Address = 0x1200
+		head libpf.Address = 0x1000 - 8
+	)
+	buf := make([]byte, 0x2000)
+	fillRanges := func(base libpf.Address, next libpf.Address, valueStart uint64) {
+		for index := 0; index < 10; index++ {
+			start := valueStart + uint64(index*0x100)
+			putUint64(buf, int(base)+index*24, start)
+			putUint64(buf, int(base)+index*24+8, start+0x10)
+			putUint64(buf, int(base)+index*24+16, uint64(index+1))
+		}
+		putUint64(buf, int(base)+240, uint64(next))
+	}
+	fillRanges(b1, b2, 0x1000)
+	fillRanges(b2, b1, 0x3000) // cycle back to b1
+
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+	i := newTestDotnetInstance(rm)
+
+	i.walkRangeList(fakeEbpf{}, 0, head, codeStubPrecode)
+	// b1 processed once, b2 once, then the cycle back to b1 is detected.
+	require.Len(t, i.ranges, 20)
+}
+
+func putAllEntries(buf []byte, at, val libpf.Address) {
+	for off := 0; off < 256*8; off += 8 {
+		putUint64(buf, int(at)+off, uint64(val))
+	}
+}
+
+// TestWalkRangeSectionMapAlias verifies that aliased intermediate level pointers
+// in a RangeSectionMap are deduplicated and the whole walk is bounded.
+func TestWalkRangeSectionMapAlias(t *testing.T) {
+	const (
+		root     libpf.Address = 0x2000
+		l2       libpf.Address = 0x4000
+		l3       libpf.Address = 0x6000
+		l4       libpf.Address = 0x8000
+		l5       libpf.Address = 0xA000
+		frag     libpf.Address = 0xC000
+		rangeSec libpf.Address = 0xE000
+	)
+	buf := make([]byte, 0x10000)
+	// Every entry of every level aliases the same child, producing a full 256-way
+	// fan-out that would be exponential without intermediate-level dedup.
+	putAllEntries(buf, root, l2)
+	putAllEntries(buf, l2, l3)
+	putAllEntries(buf, l3, l4)
+	putAllEntries(buf, l4, l5)
+	putAllEntries(buf, l5, frag)
+	putUint64(buf, int(frag)+24, uint64(rangeSec))
+
+	cr := &countingReaderAt{r: bytes.NewReader(buf)}
+	rm := remotememory.RemoteMemory{ReaderAt: cr}
+	i := newTestDotnetInstance(rm)
+	i.codeRangeListPtr = root
+
+	err := i.walkRangeSectionMap(fakeEbpf{}, 0)
+	require.NoError(t, err)
+	// Each level is read exactly once plus a handful of fragments/sections.
+	require.Less(t, cr.reads, 100)
+}

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -235,6 +235,14 @@ func fieldByJavaName(obj reflect.Value, fieldName string) reflect.Value {
 func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 	rm remotememory.RemoteMemory, loadBias libpf.Address,
 ) error {
+	const (
+		// maxIntrospectionStride bounds the per-entry size of the introspection
+		// tables. Real VMStruct/VMType entries are well below 256 bytes.
+		maxIntrospectionStride = 256
+		// maxIntrospectionEntries bounds the number of introspection table
+		// entries parsed; real JVM tables hold a few thousand entries.
+		maxIntrospectionEntries = 1 << 17
+	)
 	stride := libpf.Address(rm.Uint64(it.stride + loadBias))
 	typeOffs := uint(rm.Uint64(it.typeOffset + loadBias))
 	addrOffs := uint(rm.Uint64(it.addressOffset + loadBias))
@@ -246,14 +254,16 @@ func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 		base = rm.Ptr(base)
 	}
 
-	if base == 0 || stride == 0 {
+	if base == 0 || stride == 0 || stride > maxIntrospectionStride {
 		return fmt.Errorf("bad introspection table data (%#x / %d)", base, stride)
 	}
 
 	// Parse the introspection table
 	e := make([]byte, stride)
 	vm := reflect.ValueOf(&vmd.vmStructs).Elem()
-	for addr := base; true; addr += stride {
+	count := 0
+	for addr := base; addr != 0 && count < maxIntrospectionEntries; addr += stride {
+		count++
 		if err := rm.Read(addr, e); err != nil {
 			return err
 		}
@@ -621,15 +631,28 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 		return vmd, nil
 	}
 
+	if err := vmd.validateVMStructSizes(); err != nil {
+		vmd.err = err
+		return vmd, nil
+	}
+
+	return vmd, nil
+}
+
+// validateVMStructSizes verifies that all struct sizes used for allocation are
+// bounded. The sizes originate in the target JVM's introspection tables which are
+// attacker-influenceable, so every unexpected value must be rejected up front.
+func (vmd *hotspotVMData) validateVMStructSizes() error {
+	vms := &vmd.vmStructs
 	if vms.Symbol.Sizeof > 32 {
 		// Additional sanity for Symbol.Sizeof which normally is
 		// just 8 byte or so. The getSymbol() hard codes the first read
 		// as 128 bytes and it needs to be more than this.
-		vmd.err = fmt.Errorf("JVM Symbol.Sizeof value %d", vms.Symbol.Sizeof)
-		return vmd, nil
+		return fmt.Errorf("JVM Symbol.Sizeof value %d", vms.Symbol.Sizeof)
 	}
 
 	// Verify that all struct fields are within limits
+	const maxClassSize = 64 * 1024
 	structs := reflect.ValueOf(&vmd.vmStructs).Elem()
 	for i := 0; i < structs.NumField(); i++ {
 		klass := structs.Field(i)
@@ -638,6 +661,10 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 			continue
 		}
 		maxOffset := sizeOf.Uint()
+		if maxOffset > maxClassSize {
+			return fmt.Errorf("%s.Sizeof value %d exceeds bounds", structs.Type().Field(i).Name,
+				maxOffset)
+		}
 		for j := 0; j < klass.NumField(); j++ {
 			field := klass.Field(j)
 			if field.Kind() == reflect.Map {
@@ -645,16 +672,14 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 			}
 
 			if field.Uint() > maxOffset {
-				vmd.err = fmt.Errorf("%s.%s offset %v is larger than class size %v",
+				return fmt.Errorf("%s.%s offset %v is larger than class size %v",
 					structs.Type().Field(i).Name,
 					klass.Type().Field(j).Name,
 					field.Uint(), maxOffset)
-				return vmd, nil
 			}
 		}
 	}
-
-	return vmd, nil
+	return nil
 }
 
 func newHotspotData(filename string, ef *pfelf.File) (interpreter.Data, error) {

--- a/interpreter/hotspot/data_test.go
+++ b/interpreter/hotspot/data_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hotspot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+func TestParseIntrospectionStrideLimit(t *testing.T) {
+	buf := make([]byte, 4096)
+	// The stride value is read from target memory; place a huge one there.
+	binary.LittleEndian.PutUint64(buf[0x100:], 1<<20)
+	binary.LittleEndian.PutUint64(buf[8:], 1)
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	it := &hotspotIntrospectionTable{
+		base:        8,
+		stride:      0x100,
+		typeOffset:  0,
+		fieldOffset: 8,
+		valueOffset: 16,
+	}
+	vmd := &hotspotVMData{}
+	err := vmd.parseIntrospection(it, rm, 0)
+	require.Error(t, err)
+}
+
+func TestParseIntrospectionEntryLimit(t *testing.T) {
+	// Fill the whole table with non-null type-name pointers so the loop cannot
+	// terminate on the empty-name sentinel. The loop must still terminate at
+	// the entry-count cap instead of spinning forever.
+	const entries = 1 << 17
+	const stride = 16
+	buf := make([]byte, entries*stride)
+	for i := range buf {
+		buf[i] = 0x01
+	}
+	binary.LittleEndian.PutUint64(buf[0x100:], stride)
+	binary.LittleEndian.PutUint64(buf[8:], 1)
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	it := &hotspotIntrospectionTable{
+		base:        8,
+		stride:      0x100,
+		typeOffset:  0,
+		fieldOffset: 8,
+		valueOffset: 16,
+	}
+	vmd := &hotspotVMData{}
+	err := vmd.parseIntrospection(it, rm, 0)
+	require.NoError(t, err)
+}
+
+func TestValidateVMStructSizes(t *testing.T) {
+	// A fully zero vmStructs is valid.
+	vmd := &hotspotVMData{}
+	require.NoError(t, vmd.validateVMStructSizes())
+
+	// Oversized class size must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.ConstMethod.Sizeof = 1 << 20
+	require.Error(t, vmd.validateVMStructSizes())
+
+	// Field offset beyond the class size must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.ConstMethod.Sizeof = 100
+	vmd.vmStructs.ConstMethod.Flags = 200
+	require.Error(t, vmd.validateVMStructSizes())
+
+	// Oversized Symbol.Sizeof must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.Symbol.Sizeof = 64
+	require.Error(t, vmd.validateVMStructSizes())
+}

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -111,8 +111,13 @@ func (ji *hotspotJITInfo) symbolize(ripDelta int32, ii *hotspotInstance,
 
 	// Found scope data. Expand the inlined scope information from it.
 	var err error
+	// maxInlinedScopes bounds the number of inlined scopes expanded for a single
+	// frame. The JVM default inlining depth is far below this.
+	maxInlinedScopes := 512
 	maxScopeOff := uint32(len(ji.scopesData))
-	for scopeOff != 0 && scopeOff < maxScopeOff {
+	scopeNum := 0
+	for scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes {
+		scopeNum++
 		// Keep track of the current scope offset, and use it as the next maximum
 		// offset. This makes sure the scope offsets decrease monotonically and
 		// this loop terminates. It has been verified empirically for this assumption

--- a/interpreter/hotspot/recordingreader.go
+++ b/interpreter/hotspot/recordingreader.go
@@ -4,6 +4,7 @@
 package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot"
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -21,12 +22,23 @@ type RecordingReader struct {
 	i int
 	// chunk is the number of bytes to read from target process when mora data is needed
 	chunk int
+	// maxBufSize is the maximum number of buffered bytes that we are willing to
+	// allocate. It bounds the amount of target-controlled memory we record.
+	maxBufSize int
 }
+
+// maxRecordingReaderBuf is the cap for how much memory a single RecordingReader
+// may buffer. Real JIT line tables are small; this bounds attacker-forced growth.
+const maxRecordingReaderBuf = 1 * 1024 * 1024
 
 // ReadByte implements io.ByteReader interface to read memory single byte at a time.
 func (rr *RecordingReader) ReadByte() (byte, error) {
 	// Readahead to buffer if needed
 	if rr.i >= len(rr.buf) {
+		if len(rr.buf)+rr.chunk > rr.maxBufSize {
+			return 0, fmt.Errorf("recording reader exceeded maximum buffer size of %d bytes",
+				rr.maxBufSize)
+		}
 		buf := make([]byte, len(rr.buf)+rr.chunk)
 		copy(buf, rr.buf)
 		_, err := rr.reader.ReadAt(buf[len(rr.buf):], rr.offs)
@@ -50,8 +62,9 @@ func (rr *RecordingReader) GetBuffer() []byte {
 // newRecordingReader returns a RecordingReader to read and record data from given start.
 func newRecordingReader(reader io.ReaderAt, offs int64, chunkSize uint) *RecordingReader {
 	return &RecordingReader{
-		reader: reader,
-		offs:   offs,
-		chunk:  int(chunkSize),
+		reader:     reader,
+		offs:       offs,
+		chunk:      int(chunkSize),
+		maxBufSize: maxRecordingReaderBuf,
 	}
 }

--- a/interpreter/hotspot/recordingreader_test.go
+++ b/interpreter/hotspot/recordingreader_test.go
@@ -22,3 +22,27 @@ func TestRecordingReader(t *testing.T) {
 	}
 	assert.Len(t, rr.GetBuffer(), len(data)-1)
 }
+
+type endlessReader struct{}
+
+func (endlessReader) ReadAt(p []byte, _ int64) (int, error) {
+	for i := range p {
+		p[i] = 0xaa
+	}
+	return len(p), nil
+}
+
+func TestRecordingReaderMaxBufferSize(t *testing.T) {
+	rr := newRecordingReader(endlessReader{}, 0, 256)
+	read := 0
+	for read <= maxRecordingReaderBuf {
+		if _, err := rr.ReadByte(); err != nil {
+			break
+		}
+		read++
+	}
+
+	// The reader must stop at the size cap and never allocate beyond it.
+	assert.Equal(t, maxRecordingReaderBuf, read)
+	assert.Equal(t, maxRecordingReaderBuf, len(rr.buf))
+}

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -200,6 +200,15 @@ const (
 	// value to avoid huge malloc that could cause OOM crash.
 	maximumFixedTableSize = 512 * 1024
 
+	// maxExtractStringBytes caps the total number of string bytes extracted in a
+	// single traversal. Real names are capped at 1KiB by getString, but the line
+	// ends (source) path can be large; this bounds remote read work per call.
+	maxExtractStringBytes = 16 * 1024 * 1024
+
+	// maxStringDepth caps the recursion depth for ConsString/ThinString
+	// decomposition to guard against cyclic strings causing stack exhaustion.
+	maxStringDepth = 16
+
 	// lruSourceFileCacheSize is the LRU size for caching source files for an interpreter.
 	// This should reflect the number of hot source files that are seen often in a trace.
 	lruSourceFileCacheSize = 128
@@ -814,7 +823,18 @@ func (i *v8Instance) readTypedObjectPtr(addr libpf.Address, expectedType uint16)
 // code will also internally split long continuous string literals to fragments to avoid large
 // memory usage.
 func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string) error) error {
+	remainingBytes := int64(maxExtractStringBytes)
+	return i.extractStringBudget(ptr, tag, cb, maxStringDepth, &remainingBytes)
+}
+
+func (i *v8Instance) extractStringBudget(ptr libpf.Address, tag uint16, cb func(string) error,
+	depth int, remainingBytes *int64,
+) error {
 	var err error
+
+	if depth <= 0 {
+		return fmt.Errorf("string nesting too deep at %#x", ptr)
+	}
 
 	vms := &i.d.vmStructs
 	if tag == 0 {
@@ -831,6 +851,9 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 	switch tag & vms.Fixed.StringRepresentationMask {
 	case vms.Fixed.SeqStringTag:
 		length := i.rm.Uint32(ptr + libpf.Address(vms.String.Length))
+		if int64(length) > *remainingBytes {
+			return fmt.Errorf("string too long (%d)", length)
+		}
 		switch tag & vms.Fixed.StringEncodingMask {
 		case vms.Fixed.OneByteStringTag:
 			bufSz := min(uint32(16*1024), length)
@@ -846,6 +869,7 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 				if err != nil {
 					return err
 				}
+				*remainingBytes -= int64(len(buf))
 				if err = cb(pfunsafe.ToString(buf)); err != nil {
 					return err
 				}
@@ -856,16 +880,17 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 			return fmt.Errorf("unsupported encoding: %#x", tag)
 		}
 	case vms.Fixed.ConsStringTag:
-		if err = i.extractStringPtr(ptr+libpf.Address(vms.ConsString.First),
-			cb); err != nil {
+		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.First)),
+			0, cb, depth-1, remainingBytes); err != nil {
 			return err
 		}
-		if err = i.extractStringPtr(ptr+libpf.Address(vms.ConsString.Second),
-			cb); err != nil {
+		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.Second)),
+			0, cb, depth-1, remainingBytes); err != nil {
 			return err
 		}
 	case vms.Fixed.ThinStringTag:
-		return i.extractStringPtr(ptr+libpf.Address(vms.ThinString.Actual), cb)
+		return i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ThinString.Actual)),
+			0, cb, depth-1, remainingBytes)
 	default:
 		return fmt.Errorf("unsupported string tag %#x", tag&vms.Fixed.StringRepresentationMask)
 	}
@@ -1005,7 +1030,7 @@ func (i *v8Instance) readFixedTable(addr libpf.Address, itemSize, maxItems uint3
 		numItems = maxItems
 	}
 
-	size := numItems * itemSize
+	size := uint64(numItems) * uint64(itemSize)
 	if size == 0 || size >= maximumFixedTableSize {
 		return nil, fmt.Errorf("fixed table size: %d", size)
 	}

--- a/interpreter/nodev8/v8_test.go
+++ b/interpreter/nodev8/v8_test.go
@@ -4,9 +4,16 @@
 package nodev8 // import "go.opentelemetry.io/ebpf-profiler/interpreter/nodev8"
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/elastic/go-freelru"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
 func TestRegexs(t *testing.T) {
@@ -40,4 +47,99 @@ func TestRegexs(t *testing.T) {
 		assert.False(t, v8Regex.MatchString(s), "regex %s should not match %s",
 			v8Regex.String(), s)
 	}
+}
+
+func newTestV8Instance() *v8Instance {
+	d := &v8Data{}
+	vms := &d.vmStructs
+	vms.Fixed.StringRepresentationMask = 0x0f
+	vms.Fixed.StringEncodingMask = 0xf0
+	vms.Fixed.SeqStringTag = 0x00
+	vms.Fixed.ConsStringTag = 0x01
+	vms.Fixed.ThinStringTag = 0x02
+	vms.Fixed.OneByteStringTag = 0x20
+	vms.Fixed.FirstNonstringType = 0xf0
+	vms.String.Length = 4
+	vms.SeqOneByteString.Chars = 8
+	vms.ConsString.First = 8
+	vms.ConsString.Second = 16
+	vms.ThinString.Actual = 24
+	vms.HeapObject.Map = 0
+	vms.Map.InstanceType = 4
+	vms.FixedArrayBase.Length = 8
+
+	addrToType, err := freelru.New[libpf.Address, uint16](64, libpf.Address.Hash32)
+	if err != nil {
+		panic(err)
+	}
+	return &v8Instance{d: d, addrToType: addrToType}
+}
+
+func putUint64(buf []byte, off int, v uint64) {
+	binary.LittleEndian.PutUint64(buf[off:off+8], v)
+}
+
+func putUint16(buf []byte, off int, v uint16) {
+	binary.LittleEndian.PutUint16(buf[off:off+2], v)
+}
+
+func TestExtractStringLengthLimit(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 4096)
+	// Advertise a ~4 GiB sequence string; extraction must fail without reading
+	// or invoking the callback even once.
+	binary.LittleEndian.PutUint32(buf[4:], 0xFFFFFFFF)
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
+	calls := 0
+	err := i.extractString(0, tag, func(string) error { calls++; return nil })
+	require.Error(t, err)
+	require.Zero(t, calls)
+}
+
+func TestExtractStringValid(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 4096)
+	binary.LittleEndian.PutUint32(buf[4:], 6)
+	copy(buf[8:], "abcdef")
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
+	got := ""
+	err := i.extractString(0, tag, func(s string) error { got += s; return nil })
+	require.NoError(t, err)
+	assert.Equal(t, "abcdef", got)
+}
+
+func TestExtractStringConsCycle(t *testing.T) {
+	i := newTestV8Instance()
+	const (
+		A libpf.Address = 0x1000
+		M libpf.Address = 0x2000
+	)
+	buf := make([]byte, 0x3000)
+	putUint64(buf, int(A)+int(i.d.vmStructs.HeapObject.Map), uint64(M|HeapObjectTag))
+	putUint16(buf, int(M)+int(i.d.vmStructs.Map.InstanceType),
+		uint16(i.d.vmStructs.Fixed.ConsStringTag))
+	putUint64(buf, int(A)+int(i.d.vmStructs.ConsString.First), uint64(A|HeapObjectTag))
+	putUint64(buf, int(A)+int(i.d.vmStructs.ConsString.Second), uint64(A|HeapObjectTag))
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	// A self-referencing ConsString must be stopped by the depth bound instead
+	// of exhausting the stack.
+	err := i.extractString(A|HeapObjectTag, 0, func(string) error { return nil })
+	require.Error(t, err)
+}
+
+func TestReadFixedTableSizeLimit(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 256)
+	// A huge SMI length whose product with itemSize would wrap a uint32.
+	numItems := uint64(1) << 30
+	binary.LittleEndian.PutUint64(buf[8:], numItems<<32)
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	_, err := i.readFixedTable(0, 8, 0)
+	require.Error(t, err)
 }

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -48,6 +48,15 @@ func pythonVer(major, minor uint16) uint16 {
 	return major*0x100 + minor
 }
 
+const (
+	// maxCodeObjectSize caps the PyCodeObject struct size read from target
+	// memory. Real tp_basicsize values are in the low hundreds of bytes.
+	maxCodeObjectSize = 4096
+	// maxPyMemberDefs caps the number of PyMemberDef entries traversed when
+	// reading introspection data; real tables hold a few dozen entries.
+	maxPyMemberDefs = 256
+)
+
 func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, err error) {
 	// Py_Version is referenced in CPython internals for versioned Python binaries.
 	// https://github.com/python/cpython/blob/v3.11.0/Doc/c-api/apiabiversion.rst
@@ -511,6 +520,9 @@ func (p *pythonInstance) getCodeObject(addr libpf.Address,
 	}
 
 	vms := &p.d.vmStructs
+	if vms.PyCodeObject.Sizeof == 0 || vms.PyCodeObject.Sizeof > maxCodeObjectSize {
+		return nil, fmt.Errorf("unexpected PyCodeObject size %d", vms.PyCodeObject.Sizeof)
+	}
 	cobj := make([]byte, vms.PyCodeObject.Sizeof)
 	if err := p.rm.Read(addr, cobj); err != nil {
 		return nil, fmt.Errorf("failed to read code object: %v", err)
@@ -660,7 +672,8 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		return nil
 	}
 
-	for addr := membersPtr; true; addr += vms.PyMemberDef.Sizeof {
+	for addr, count := membersPtr, 0; addr != 0 && count < maxPyMemberDefs; addr += vms.PyMemberDef.Sizeof {
+		count++
 		memberName := rm.StringPtr(addr + libpf.Address(vms.PyMemberDef.Name))
 		if memberName == "" {
 			break
@@ -668,6 +681,9 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		if f := fieldByPythonName(reflection, memberName); f.IsValid() {
 			offset := rm.Uint32(addr + libpf.Address(vms.PyMemberDef.Offset))
 			f.SetUint(uint64(offset))
+		}
+		if vms.PyMemberDef.Sizeof == 0 {
+			break
 		}
 	}
 	return nil

--- a/interpreter/python/python_test.go
+++ b/interpreter/python/python_test.go
@@ -4,11 +4,41 @@
 package python
 
 import (
+	"bytes"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
+
+func TestGetCodeObjectSizeLimit(t *testing.T) {
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(make([]byte, 4096))}
+	cases := []struct {
+		name      string
+		size      uint
+		wantSizeE bool
+	}{
+		{"oversized 1GiB", 1 << 30, true},
+		{"zero", 0, true},
+		{"just over cap", maxCodeObjectSize + 1, true},
+		{"at cap", maxCodeObjectSize, false},
+		{"nominal", 224, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &pythonData{}
+			d.vmStructs.PyCodeObject.Sizeof = tc.size
+			p := &pythonInstance{d: d, rm: rm}
+
+			_, err := p.getCodeObject(libpf.Address(0x1234), 0)
+			gotSizeErr := err != nil && strings.Contains(err.Error(), "unexpected PyCodeObject size")
+			assert.Equal(t, tc.wantSizeE, gotSizeErr, "err: %v", err)
+		})
+	}
+}
 
 func TestFrozenNameToFileName(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
Fixes #1601 

This PR hardens the interpreter subsystem of the profiler against denial of service attacks from a compromised or malicious target process. The interpreters read arbitrary memory out of the profiled process via process_vm_readv (remotememory.RemoteMemory); every size, length, and pointer traversed originates in that untrusted memory. Previously, several code paths trusted these values, allowing a target to force huge allocations, unbounded iteration, or infinite loops in the profiler.

The fix applies two invariants everywhere:
- Validate before allocate - every make/buffer growth is preceded by a bounded-size check on attacker-controlled values.
- Bound every traversal - linked lists, recursive walks, and hash table fragment walks carry explicit caps and dedup (seen set) so cycles and exponential fan out terminate, degrading to dropping the offending frame rather than stalling or OOMing the profiler.

**Threat model**
The attacker is the unprivileged target process being profiled. It fully controls all values read through remotememory, including struct sizes, pointers, array lengths, string lengths, and map fragments. Attacks covered:
- Huge allocations: forged Sizeof/lengths drive make() into multi-GB allocations.
- Integer overflow: array length × element size overflows before the size check.
- Unbounded iteration: linked chains and section lists that never terminate.
- Exponential blow-up / infinite recursion: aliased or cyclic pointer structures in string cons-chains and range maps.
The performance-critical hot paths receive only compare/branch checks (no additional remote reads), so the per-sample cost is unchanged.

**Changes**
python (interpreter/python/python.go)
- getCodeObject: reject Sizeof == 0 || Sizeof > 4096 before make (a one-byte PyCodeObject is impossible).
- readIntrospectionData: the PyMemberDef linked chain is now bounded to maxPyMemberDefs = 256 entries, with a Sizeof == 0 guard against broken chains.
nodev8 (interpreter/nodev8/v8.go)
- extractString is refactored into a bounded extractStringBudget with a total 16 MiB byte budget and a max recursion depth of 16 for cons/thin string chains (each with i.rm.Ptr dereference), replacing unbounded recursive descent.
- readFixedTable: size math uses uint64 so numItems × itemSize cannot overflow before the 512 KiB maximumFixedTableSize check.
hotspot (interpreter/hotspot/...)
- parseIntrospection: caps the stride (maxIntrospectionStride = 256) and total entry count (maxIntrospectionEntries = 1<<17).
- Size/offset validation centralized into validateVMStructSizes(), applied once at JVM-data load: Symbol.Sizeof must be > 32 (pre-existing) and every class Sizeof <= maxClassSize (64 KiB), with offsets sanity-checked against Sizeof.
- recordingreader: buffer growth refused beyond maxRecordingReaderBuf (1 MiB), returning an error instead of unbounded reallocation.
- method.go: inline scope chain capped at maxInlinedScopes = 512.
dotnet (interpreter/dotnet/...)
- Replaces the single rangeSectionSeen marker with a per-walk rangeWalker carrying seen-sets and budget counters:
- walkRangeList: block chain bounded by maxRangeListBlocks (1<<16).
- walkRangeSectionList: next chain bounded by maxRangeSections (1<<20) with cycle detection.
- walkRangeSectionMap: intermediate map levels deduplicated via seen-set and bounded by maxRangeMapLevels (1<<17); fragment walks capped eliminating the exponential aliasing blow-up where every entry of a 256-way level aliases the same child.
- newVMData: all CDAC struct SizeOf values validated against maxDotnetStructSize (64 KiB) via reflection once at load.

**Testing**
- New regression tests exercise each limit:
- python_test.go: code-object size cap; introspection member-count cap.
- v8_test.go: string length budget, valid extract, cons-chain cycle, fixed-table size.
- hotspot/data_test.go: introspection stride/entry caps; validateVMStructSizes.
- hotspot/recordingreader_test.go: buffer-growth cap with an endless reader.
- dotnet/instance_test.go (new): cyclic RangeSection list, cyclic RangeList block chain, and aliased SectionMap fan-out, asserting bounded termination and a small remote-read count.
- Verified: go build ./..., go vet ./..., and go test ./interpreter/... pass.
- Pre-existing, unrelated: libpf/pfelf tests require make test-deps fixtures.

**Compatibility**
All limits are set well above realistic VM layout sizes (e.g. 64 KiB per class struct, 1 MiB recording buffer, 4096-byte Python code objects) and only trigger on forged/abnormal data, so legitimate workloads are unaffected. extractString keeps its existing behavior and only bounds pathological chains.