### PR TITLE
CI: allow PR authors to rerun failed CI

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -1,0 +1,33 @@
+name: "Rerun Failed Workflows"
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: read-all
+
+jobs:
+  rerun-failed:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/rerun') && github.repository_owner == 'open-telemetry' }}
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+      - name: Run rerun-failed-workflows.sh
+        run: ./.github/workflows/scripts/rerun-failed-workflows.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT: ${{ github.event.comment.body }}
+          SENDER: ${{ github.event.comment.user.login }}

--- a/.github/workflows/scripts/rerun-failed-workflows.sh
+++ b/.github/workflows/scripts/rerun-failed-workflows.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -euo pipefail
+
+if [[ -z "${PR_NUMBER:-}" || -z "${COMMENT:-}" || -z "${SENDER:-}" || -z "${ORG_TOKEN:-}" ]]; then
+    echo "PR_NUMBER, COMMENT, SENDER or ORG_TOKEN not set"
+    exit 0
+fi
+
+if [[ ${COMMENT:0:6} != "/rerun" ]]; then
+    echo "Not a rerun command"
+    exit 0
+fi
+
+PR_DATA=$(gh pr view "${PR_NUMBER}" --json headRefOid,author)
+HEAD_SHA=$(echo "${PR_DATA}" | jq -r '.headRefOid')
+PR_AUTHOR=$(echo "${PR_DATA}" | jq -r '.author.login')
+
+TEAMS=(
+    "ebpf-profiler-contributors"
+    "ebpf-profiler-approvers"
+    "ebpf-profiler-maintainers"
+)
+
+IS_AUTHORIZED="false"
+if [[ "${SENDER}" != "${PR_AUTHOR}" ]]; then
+    for TEAM in "${TEAMS[@]}"; do
+        if GH_TOKEN="${ORG_TOKEN}" gh api "orgs/open-telemetry/teams/${TEAM}/memberships/${SENDER}" --silent 2>/dev/null; then
+            IS_AUTHORIZED="true"
+            break
+        fi
+    done
+fi
+
+if [[ "${SENDER}" != "${PR_AUTHOR}" && "${IS_AUTHORIZED}" != "true" ]]; then
+    echo "Only the PR author or a member of an authorized team can rerun workflows"
+    exit 0
+fi
+
+echo "Finding failed workflows for commit: ${HEAD_SHA}"
+
+FAILED_RUNS=$(gh run list \
+    --commit "${HEAD_SHA}" \
+    --status failure \
+    --json databaseId \
+    --jq '.[].databaseId')
+
+if [[ -z "${FAILED_RUNS}" ]]; then
+    echo "No failed workflows found"
+    exit 0
+else
+    for RUN_ID in ${FAILED_RUNS}; do
+        echo "Rerunning workflow: ${RUN_ID}"
+        gh run rerun "${RUN_ID}" --failed
+    done
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,17 @@ Rewriting Git history makes it difficult to keep track of iterations during
 code review.
 All pull requests are squashed to a single commit upon merge to `main`.
 
+### Rerunning Failed Workflows
+
+PR authors can rerun failed GitHub Actions workflows by commenting `/rerun` on the pull
+request. This will automatically rerun all failed workflow runs for the PR's latest commit.
+
+Example rerun comment:
+
+```
+/rerun
+```
+
 ### How to Receive Comments
 
 * If the PR is not ready for review, please put `[WIP]` in the title,


### PR DESCRIPTION
The Github CI is not perfect and sometimes need to rerun. Allow PR authors to rerun failed CI.

This change is inspired by https://github.com/open-telemetry/opentelemetry-collector/pull/14314.