### PR TITLE
pfelf: determine "main executable" information, and use it

### DIFF
--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -4,7 +4,6 @@
 package golang // import "go.opentelemetry.io/ebpf-profiler/interpreter/go"
 
 import (
-	"debug/elf"
 	"errors"
 	"fmt"
 	"go/version"
@@ -98,24 +97,12 @@ func loader(cfg Config, info *interpreter.LoaderInfo) (interpreter.Data, error) 
 	if !file.IsGolang() {
 		return nil, nil
 	}
-
-	// Go plugins are shared objects that share the runtime with the main
-	// binary. The offsets we need are determined by the main binary so there
-	// is no reason to create a duplicate instance for a plugin. A shared
-	// library is ET_DYN without a PT_INTERP segment (PIE executables are also
-	// ET_DYN but have PT_INTERP).
-	if file.Type == elf.ET_DYN {
-		hasInterp := false
-		for i := range file.Progs {
-			if file.Progs[i].Type == elf.PT_INTERP {
-				hasInterp = true
-				break
-			}
-		}
-		if !hasInterp {
-			log.Debugf("file %s is a Go shared library, skipping", info.FileName())
-			return nil, nil
-		}
+	if !file.IsExecutable() {
+		// Go plugins are shared objects that share the runtime with the main
+		// binary. The offsets we need are determined by the main binary so there
+		// is no reason to create a duplicate instance for a plugin.
+		log.Debugf("file %s is a Go shared library, skipping", info.FileName())
+		return nil, nil
 	}
 
 	goVersion := file.GoVersion()

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -143,6 +143,9 @@ type File struct {
 	// InsideCore indicates that this ELF is mapped from a coredump ELF
 	InsideCore bool
 
+	// isExecutable is set for main executable program (not for shared libraries)
+	isExecutable bool
+
 	// Fields to mimic elf.debug
 	Type    elf.Type
 	Machine elf.Machine
@@ -342,6 +345,9 @@ func newFile(r io.ReaderAt, closer io.Closer,
 		return int(a.Flags&(elf.PF_R|elf.PF_X)) - int(b.Flags&(elf.PF_R|elf.PF_X))
 	})
 
+	if f.Type == elf.ET_EXEC {
+		f.isExecutable = true
+	}
 	for i := range f.Progs {
 		p := &f.Progs[i]
 		if p.Filesz <= 0 {
@@ -368,6 +374,10 @@ func newFile(r io.ReaderAt, closer io.Closer,
 					adjustedVal -= bias
 				}
 				switch elf.DynTag(dyn.Tag) {
+				case elf.DT_FLAGS_1:
+					if elf.DynFlag1(dyn.Val)&elf.DF_1_PIE != 0 {
+						f.isExecutable = true
+					}
 				case elf.DT_NEEDED:
 					f.neededIndexes = append(f.neededIndexes, int64(dyn.Val))
 				case elf.DT_SONAME:
@@ -383,6 +393,8 @@ func newFile(r io.ReaderAt, closer io.Closer,
 				}
 			}
 			pfbufio.PutReader(rdr)
+		case elf.PT_INTERP:
+			f.isExecutable = true
 		}
 	}
 
@@ -1259,6 +1271,11 @@ func (f *File) DynString(tag elf.DynTag) ([]string, error) {
 		dynStrings = append(dynStrings, rm.String(strAddr))
 	}
 	return dynStrings, nil
+}
+
+// IsExecutable returns true if this ELF is an executable program (and not a shared library).
+func (f *File) IsExecutable() bool {
+	return f.isExecutable
 }
 
 // IsGolang determines if this ELF is a Golang executable


### PR DESCRIPTION
The information can be determined efficiently when parsing headers, and there are pending additional future use case for this, so move it to pfelf.