### PR TITLE
fix(interpreter): harden python code object parsing against forged sizes

### DIFF
--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -49,9 +49,6 @@ func pythonVer(major, minor uint16) uint16 {
 }
 
 const (
-	// maxCodeObjectSize caps the PyCodeObject struct size read from target
-	// memory. Real tp_basicsize values are in the low hundreds of bytes.
-	maxCodeObjectSize = 4096
 	// maxPyMemberDefs caps the number of PyMemberDef entries traversed when
 	// reading introspection data; real tables hold a few dozen entries.
 	maxPyMemberDefs = 256
@@ -107,7 +104,9 @@ type pythonData struct {
 			Data uint `name:"data"`
 		}
 		PyCodeObject struct {
-			Sizeof         uint
+			// Sizeof is PyCode_Type.tp_basicsize read from target memory; the
+			// maxValue tag bounds it to prevent forged-size allocation bombs.
+			Sizeof         uint `maxValue:"4096"`
 			ArgCount       uint `name:"co_argcount"`
 			KwOnlyArgCount uint `name:"co_kwonlyargcount"`
 			Flags          uint `name:"co_flags"`
@@ -520,9 +519,6 @@ func (p *pythonInstance) getCodeObject(addr libpf.Address,
 	}
 
 	vms := &p.d.vmStructs
-	if vms.PyCodeObject.Sizeof == 0 || vms.PyCodeObject.Sizeof > maxCodeObjectSize {
-		return nil, fmt.Errorf("unexpected PyCodeObject size %d", vms.PyCodeObject.Sizeof)
-	}
 	cobj := make([]byte, vms.PyCodeObject.Sizeof)
 	if err := p.rm.Read(addr, cobj); err != nil {
 		return nil, fmt.Errorf("failed to read code object: %v", err)
@@ -651,6 +647,31 @@ func fieldByPythonName(obj reflect.Value, fieldName string) reflect.Value {
 	return reflect.Value{}
 }
 
+// maxValueTag is the struct tag that bounds an introspection field read from
+// target memory.
+const maxValueTag = "maxValue"
+
+// validateMaxValue rejects a value read from target memory that is 0 (a failed
+// read) or exceeds the field's maxValue struct tag, if any.
+func validateMaxValue(structType reflect.Type, fieldName string, value uint64) error {
+	field, ok := structType.FieldByName(fieldName)
+	if !ok {
+		return nil
+	}
+	maxStr, ok := field.Tag.Lookup(maxValueTag)
+	if !ok {
+		return nil
+	}
+	maxVal, err := strconv.ParseUint(maxStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid %s maxValue tag %q: %v", fieldName, maxStr, err)
+	}
+	if value == 0 || value > maxVal {
+		return fmt.Errorf("unexpected %s size %d (max %d)", fieldName, value, maxVal)
+	}
+	return nil
+}
+
 func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolName,
 	vmObj any,
 ) error {
@@ -664,6 +685,9 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 	reflection := reflect.ValueOf(vmObj).Elem()
 	if f := reflection.FieldByName("Sizeof"); f.IsValid() {
 		size := rm.Uint64(typedataAddress + vms.PyTypeObject.BasicSize)
+		if err := validateMaxValue(reflection.Type(), "Sizeof", size); err != nil {
+			return err
+		}
 		f.SetUint(size)
 	}
 
@@ -672,8 +696,8 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		return nil
 	}
 
-	for addr, count := membersPtr, 0; addr != 0 && count < maxPyMemberDefs; addr += vms.PyMemberDef.Sizeof {
-		count++
+	membersEnd := membersPtr + maxPyMemberDefs*vms.PyMemberDef.Sizeof
+	for addr := membersPtr; addr < membersEnd; addr += vms.PyMemberDef.Sizeof {
 		memberName := rm.StringPtr(addr + libpf.Address(vms.PyMemberDef.Name))
 		if memberName == "" {
 			break
@@ -681,9 +705,6 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		if f := fieldByPythonName(reflection, memberName); f.IsValid() {
 			offset := rm.Uint32(addr + libpf.Address(vms.PyMemberDef.Offset))
 			f.SetUint(uint64(offset))
-		}
-		if vms.PyMemberDef.Sizeof == 0 {
-			break
 		}
 	}
 	return nil

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -48,6 +48,15 @@ func pythonVer(major, minor uint16) uint16 {
 	return major*0x100 + minor
 }
 
+const (
+	// maxCodeObjectSize caps the PyCodeObject struct size read from target
+	// memory. Real tp_basicsize values are in the low hundreds of bytes.
+	maxCodeObjectSize = 4096
+	// maxPyMemberDefs caps the number of PyMemberDef entries traversed when
+	// reading introspection data; real tables hold a few dozen entries.
+	maxPyMemberDefs = 256
+)
+
 func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, err error) {
 	// Py_Version is referenced in CPython internals for versioned Python binaries.
 	// https://github.com/python/cpython/blob/v3.11.0/Doc/c-api/apiabiversion.rst
@@ -511,6 +520,9 @@ func (p *pythonInstance) getCodeObject(addr libpf.Address,
 	}
 
 	vms := &p.d.vmStructs
+	if vms.PyCodeObject.Sizeof == 0 || vms.PyCodeObject.Sizeof > maxCodeObjectSize {
+		return nil, fmt.Errorf("unexpected PyCodeObject size %d", vms.PyCodeObject.Sizeof)
+	}
 	cobj := make([]byte, vms.PyCodeObject.Sizeof)
 	if err := p.rm.Read(addr, cobj); err != nil {
 		return nil, fmt.Errorf("failed to read code object: %v", err)
@@ -660,7 +672,8 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		return nil
 	}
 
-	for addr := membersPtr; true; addr += vms.PyMemberDef.Sizeof {
+	for addr, count := membersPtr, 0; addr != 0 && count < maxPyMemberDefs; addr += vms.PyMemberDef.Sizeof {
+		count++
 		memberName := rm.StringPtr(addr + libpf.Address(vms.PyMemberDef.Name))
 		if memberName == "" {
 			break
@@ -668,6 +681,9 @@ func (d *pythonData) readIntrospectionData(ef *pfelf.File, symbol libpf.SymbolNa
 		if f := fieldByPythonName(reflection, memberName); f.IsValid() {
 			offset := rm.Uint32(addr + libpf.Address(vms.PyMemberDef.Offset))
 			f.SetUint(uint64(offset))
+		}
+		if vms.PyMemberDef.Sizeof == 0 {
+			break
 		}
 	}
 	return nil

--- a/interpreter/python/python_test.go
+++ b/interpreter/python/python_test.go
@@ -4,38 +4,38 @@
 package python
 
 import (
-	"bytes"
+	"reflect"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
-func TestGetCodeObjectSizeLimit(t *testing.T) {
-	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(make([]byte, 4096))}
+func TestValidateMaxValue(t *testing.T) {
+	type testStruct struct {
+		Sizeof uint `maxValue:"4096"`
+		Plain  uint
+	}
+	structType := reflect.TypeOf(testStruct{})
+
 	cases := []struct {
 		name      string
-		size      uint
+		fieldName string
+		value     uint64
 		wantSizeE bool
 	}{
-		{"oversized 1GiB", 1 << 30, true},
-		{"zero", 0, true},
-		{"just over cap", maxCodeObjectSize + 1, true},
-		{"at cap", maxCodeObjectSize, false},
-		{"nominal", 224, false},
+		{"oversized 1GiB", "Sizeof", 1 << 30, true},
+		{"zero", "Sizeof", 0, true},
+		{"just over cap", "Sizeof", 4096 + 1, true},
+		{"at cap", "Sizeof", 4096, false},
+		{"nominal", "Sizeof", 224, false},
+		{"untagged", "Plain", 1 << 40, false},
+		{"missing field", "Nope", 123, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := &pythonData{}
-			d.vmStructs.PyCodeObject.Sizeof = tc.size
-			p := &pythonInstance{d: d, rm: rm}
-
-			_, err := p.getCodeObject(libpf.Address(0x1234), 0)
-			gotSizeErr := err != nil && strings.Contains(err.Error(), "unexpected PyCodeObject size")
-			assert.Equal(t, tc.wantSizeE, gotSizeErr, "err: %v", err)
+			err := validateMaxValue(structType, tc.fieldName, tc.value)
+			assert.Equal(t, tc.wantSizeE, err != nil, "err: %v", err)
 		})
 	}
 }

--- a/interpreter/python/python_test.go
+++ b/interpreter/python/python_test.go
@@ -4,11 +4,41 @@
 package python
 
 import (
+	"bytes"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
+
+func TestGetCodeObjectSizeLimit(t *testing.T) {
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(make([]byte, 4096))}
+	cases := []struct {
+		name      string
+		size      uint
+		wantSizeE bool
+	}{
+		{"oversized 1GiB", 1 << 30, true},
+		{"zero", 0, true},
+		{"just over cap", maxCodeObjectSize + 1, true},
+		{"at cap", maxCodeObjectSize, false},
+		{"nominal", 224, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &pythonData{}
+			d.vmStructs.PyCodeObject.Sizeof = tc.size
+			p := &pythonInstance{d: d, rm: rm}
+
+			_, err := p.getCodeObject(libpf.Address(0x1234), 0)
+			gotSizeErr := err != nil && strings.Contains(err.Error(), "unexpected PyCodeObject size")
+			assert.Equal(t, tc.wantSizeE, gotSizeErr, "err: %v", err)
+		})
+	}
+}
 
 func TestFrozenNameToFileName(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
**Summary**
Harden the Python interpreter module against denial-of-service from forged struct metadata read out of the profiled process. Struct sizes and member-table lengths are attacker-controlled (the process can be manipulated while being profiled); previously a forged PyCodeObject.tp_basicsize could force a huge allocation and an unbounded PyMemberDef chain could spin the introspection reader.

**Changes**
- PyCodeObject size validated at read time (readIntrospectionData) — the Sizeof field now carries a maxValue:"4096" struct tag, mirroring the existing name-tag mechanism. The generic introspection reader validates tp_basicsize immediately after reading it: a value of 0 (failed read) or one exceeding the cap fails the loader, so Python symbolization is disabled for the offending process instead of failing per-frame in getCodeObject. The old maxCodeObjectSize const and the getCodeObject size check are removed.
- Bounded PyMemberDef traversal — the member-table loop now compares against a byte limit (maxPyMemberDefs * PyMemberDef.Sizeof) rather than a separate entry counter plus addr != 0 (already covered by the earlier null check). The unreachable PyMemberDef.Sizeof == 0 guard is dropped; the field is statically set (40).

**Testing**
- TestValidateMaxValue replaces TestGetCodeObjectSizeLimit and covers oversized (1 GiB, cap+1), zero, at-cap, nominal, untagged, and missing-field cases.

Verified: gofmt -l clean, go build ./interpreter/..., go vet, go test ./interpreter/python/... all pass.
Files: interpreter/python/python.go, interpreter/python/python_test.go