### PR TITLE
fix(interpreter): bound string extraction and fixed-table reads in v8

### DIFF
--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -200,6 +200,15 @@ const (
 	// value to avoid huge malloc that could cause OOM crash.
 	maximumFixedTableSize = 512 * 1024
 
+	// maxExtractStringBytes caps the total number of string bytes extracted in a
+	// single traversal. Real names are capped at 1KiB by getString, but the line
+	// ends (source) path can be large; this bounds remote read work per call.
+	maxExtractStringBytes = 16 * 1024 * 1024
+
+	// maxStringDepth caps the recursion depth for ConsString/ThinString
+	// decomposition to guard against cyclic strings causing stack exhaustion.
+	maxStringDepth = 16
+
 	// lruSourceFileCacheSize is the LRU size for caching source files for an interpreter.
 	// This should reflect the number of hot source files that are seen often in a trace.
 	lruSourceFileCacheSize = 128
@@ -814,7 +823,18 @@ func (i *v8Instance) readTypedObjectPtr(addr libpf.Address, expectedType uint16)
 // code will also internally split long continuous string literals to fragments to avoid large
 // memory usage.
 func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string) error) error {
+	remainingBytes := int64(maxExtractStringBytes)
+	return i.extractStringBudget(ptr, tag, cb, maxStringDepth, &remainingBytes)
+}
+
+func (i *v8Instance) extractStringBudget(ptr libpf.Address, tag uint16, cb func(string) error,
+	depth int, remainingBytes *int64,
+) error {
 	var err error
+
+	if depth <= 0 {
+		return fmt.Errorf("string nesting too deep at %#x", ptr)
+	}
 
 	vms := &i.d.vmStructs
 	if tag == 0 {
@@ -831,6 +851,9 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 	switch tag & vms.Fixed.StringRepresentationMask {
 	case vms.Fixed.SeqStringTag:
 		length := i.rm.Uint32(ptr + libpf.Address(vms.String.Length))
+		if int64(length) > *remainingBytes {
+			return fmt.Errorf("string too long (%d)", length)
+		}
 		switch tag & vms.Fixed.StringEncodingMask {
 		case vms.Fixed.OneByteStringTag:
 			bufSz := min(uint32(16*1024), length)
@@ -846,6 +869,7 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 				if err != nil {
 					return err
 				}
+				*remainingBytes -= int64(len(buf))
 				if err = cb(pfunsafe.ToString(buf)); err != nil {
 					return err
 				}
@@ -856,16 +880,17 @@ func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string
 			return fmt.Errorf("unsupported encoding: %#x", tag)
 		}
 	case vms.Fixed.ConsStringTag:
-		if err = i.extractStringPtr(ptr+libpf.Address(vms.ConsString.First),
-			cb); err != nil {
+		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.First)),
+			0, cb, depth-1, remainingBytes); err != nil {
 			return err
 		}
-		if err = i.extractStringPtr(ptr+libpf.Address(vms.ConsString.Second),
-			cb); err != nil {
+		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.Second)),
+			0, cb, depth-1, remainingBytes); err != nil {
 			return err
 		}
 	case vms.Fixed.ThinStringTag:
-		return i.extractStringPtr(ptr+libpf.Address(vms.ThinString.Actual), cb)
+		return i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ThinString.Actual)),
+			0, cb, depth-1, remainingBytes)
 	default:
 		return fmt.Errorf("unsupported string tag %#x", tag&vms.Fixed.StringRepresentationMask)
 	}
@@ -1005,7 +1030,7 @@ func (i *v8Instance) readFixedTable(addr libpf.Address, itemSize, maxItems uint3
 		numItems = maxItems
 	}
 
-	size := numItems * itemSize
+	size := uint64(numItems) * uint64(itemSize)
 	if size == 0 || size >= maximumFixedTableSize {
 		return nil, fmt.Errorf("fixed table size: %d", size)
 	}

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -200,10 +200,13 @@ const (
 	// value to avoid huge malloc that could cause OOM crash.
 	maximumFixedTableSize = 512 * 1024
 
-	// maxExtractStringBytes caps the total number of string bytes extracted in a
-	// single traversal. Real names are capped at 1KiB by getString, but the line
-	// ends (source) path can be large; this bounds remote read work per call.
-	maxExtractStringBytes = 16 * 1024 * 1024
+	// maxMemoizedStringBytes caps strings memoized in addrToString: file,
+	// function and class names. Real names are far below this.
+	maxMemoizedStringBytes = 1024
+
+	// maxSourceStringBytes caps the non-memoized path (reading Script.Source to
+	// compute line ends), which can legitimately be large.
+	maxSourceStringBytes = 16 * 1024 * 1024
 
 	// maxStringDepth caps the recursion depth for ConsString/ThinString
 	// decomposition to guard against cyclic strings causing stack exhaustion.
@@ -822,37 +825,33 @@ func (i *v8Instance) readTypedObjectPtr(addr libpf.Address, expectedType uint16)
 // fragments. Some V8 string representations (e.g. ConsString) is naturally fragmented, but this
 // code will also internally split long continuous string literals to fragments to avoid large
 // memory usage.
-func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string) error) error {
-	remainingBytes := int64(maxExtractStringBytes)
-	return i.extractStringBudget(ptr, tag, cb, maxStringDepth, &remainingBytes)
-}
-
-func (i *v8Instance) extractStringBudget(ptr libpf.Address, tag uint16, cb func(string) error,
-	depth int, remainingBytes *int64,
-) error {
-	var err error
-
+// limit caps the total number of string bytes read during this call. It returns
+// the number of bytes actually read.
+func (i *v8Instance) extractString(ptr libpf.Address, tag uint16, cb func(string) error,
+	limit int64, depth int,
+) (int64, error) {
 	if depth <= 0 {
-		return fmt.Errorf("string nesting too deep at %#x", ptr)
+		return 0, fmt.Errorf("string nesting too deep at %#x", ptr)
 	}
 
+	var err error
 	vms := &i.d.vmStructs
 	if tag == 0 {
 		ptr, tag, err = i.getObjectAddrAndType(ptr)
 		if err != nil {
-			return err
+			return 0, err
 		}
 	}
 
 	if tag >= vms.Fixed.FirstNonstringType {
-		return fmt.Errorf("not a string at %#x, tag is %#x", ptr, tag)
+		return 0, fmt.Errorf("not a string at %#x, tag is %#x", ptr, tag)
 	}
 
 	switch tag & vms.Fixed.StringRepresentationMask {
 	case vms.Fixed.SeqStringTag:
 		length := i.rm.Uint32(ptr + libpf.Address(vms.String.Length))
-		if int64(length) > *remainingBytes {
-			return fmt.Errorf("string too long (%d)", length)
+		if int64(length) > limit {
+			return 0, fmt.Errorf("string too long (%d)", length)
 		}
 		switch tag & vms.Fixed.StringEncodingMask {
 		case vms.Fixed.OneByteStringTag:
@@ -867,38 +866,41 @@ func (i *v8Instance) extractStringBudget(ptr libpf.Address, tag uint16, cb func(
 					libpf.Address(offs),
 					buf)
 				if err != nil {
-					return err
+					return 0, err
 				}
-				*remainingBytes -= int64(len(buf))
 				if err = cb(pfunsafe.ToString(buf)); err != nil {
-					return err
+					return 0, err
 				}
 			}
 		case vms.Fixed.TwoByteStringTag:
-			return errors.New("two byte string not supported")
+			return 0, errors.New("two byte string not supported")
 		default:
-			return fmt.Errorf("unsupported encoding: %#x", tag)
+			return 0, fmt.Errorf("unsupported encoding: %#x", tag)
 		}
+		return int64(length), nil
 	case vms.Fixed.ConsStringTag:
-		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.First)),
-			0, cb, depth-1, remainingBytes); err != nil {
-			return err
+		n, err := i.extractString(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.First)),
+			0, cb, limit, depth-1)
+		if err != nil {
+			return n, err
 		}
-		if err = i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.Second)),
-			0, cb, depth-1, remainingBytes); err != nil {
-			return err
+		m, err := i.extractString(i.rm.Ptr(ptr+libpf.Address(vms.ConsString.Second)),
+			0, cb, limit-n, depth-1)
+		if err != nil {
+			return n + m, err
 		}
+		return n + m, nil
 	case vms.Fixed.ThinStringTag:
-		return i.extractStringBudget(i.rm.Ptr(ptr+libpf.Address(vms.ThinString.Actual)),
-			0, cb, depth-1, remainingBytes)
+		return i.extractString(i.rm.Ptr(ptr+libpf.Address(vms.ThinString.Actual)),
+			0, cb, limit, depth-1)
 	default:
-		return fmt.Errorf("unsupported string tag %#x", tag&vms.Fixed.StringRepresentationMask)
+		return 0, fmt.Errorf("unsupported string tag %#x", tag&vms.Fixed.StringRepresentationMask)
 	}
-	return nil
 }
 
 func (i *v8Instance) extractStringPtr(ptr libpf.Address, cb func(string) error) error {
-	return i.extractString(i.rm.Ptr(ptr), 0, cb)
+	_, err := i.extractString(i.rm.Ptr(ptr), 0, cb, maxSourceStringBytes, maxStringDepth)
+	return err
 }
 
 // getString extracts and caches a small string object from given address.
@@ -909,15 +911,10 @@ func (i *v8Instance) getString(ptr libpf.Address, tag uint16) (libpf.String, err
 	}
 
 	str := ""
-	err := i.extractString(ptr, tag, func(fragment string) error {
-		// 1kB maximum for file, function and class names
-		if len(str)+len(fragment) >= 1024 {
-			return fmt.Errorf("string too long (at least %d+%d)",
-				len(str), len(fragment))
-		}
+	_, err := i.extractString(ptr, tag, func(fragment string) error {
 		str += fragment
 		return nil
-	})
+	}, maxMemoizedStringBytes, maxStringDepth)
 	if err != nil {
 		return libpf.NullString, err
 	}

--- a/interpreter/nodev8/v8_test.go
+++ b/interpreter/nodev8/v8_test.go
@@ -93,7 +93,8 @@ func TestExtractStringLengthLimit(t *testing.T) {
 
 	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
 	calls := 0
-	err := i.extractString(0, tag, func(string) error { calls++; return nil })
+	_, err := i.extractString(0, tag, func(string) error { calls++; return nil },
+		maxMemoizedStringBytes, maxStringDepth)
 	require.Error(t, err)
 	require.Zero(t, calls)
 }
@@ -107,7 +108,8 @@ func TestExtractStringValid(t *testing.T) {
 
 	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
 	got := ""
-	err := i.extractString(0, tag, func(s string) error { got += s; return nil })
+	_, err := i.extractString(0, tag, func(s string) error { got += s; return nil },
+		maxMemoizedStringBytes, maxStringDepth)
 	require.NoError(t, err)
 	assert.Equal(t, "abcdef", got)
 }
@@ -128,7 +130,8 @@ func TestExtractStringConsCycle(t *testing.T) {
 
 	// A self-referencing ConsString must be stopped by the depth bound instead
 	// of exhausting the stack.
-	err := i.extractString(A|HeapObjectTag, 0, func(string) error { return nil })
+	_, err := i.extractString(A|HeapObjectTag, 0, func(string) error { return nil },
+		maxSourceStringBytes, maxStringDepth)
 	require.Error(t, err)
 }
 

--- a/interpreter/nodev8/v8_test.go
+++ b/interpreter/nodev8/v8_test.go
@@ -4,9 +4,16 @@
 package nodev8 // import "go.opentelemetry.io/ebpf-profiler/interpreter/nodev8"
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
 
+	"github.com/elastic/go-freelru"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
 func TestRegexs(t *testing.T) {
@@ -40,4 +47,99 @@ func TestRegexs(t *testing.T) {
 		assert.False(t, v8Regex.MatchString(s), "regex %s should not match %s",
 			v8Regex.String(), s)
 	}
+}
+
+func newTestV8Instance() *v8Instance {
+	d := &v8Data{}
+	vms := &d.vmStructs
+	vms.Fixed.StringRepresentationMask = 0x0f
+	vms.Fixed.StringEncodingMask = 0xf0
+	vms.Fixed.SeqStringTag = 0x00
+	vms.Fixed.ConsStringTag = 0x01
+	vms.Fixed.ThinStringTag = 0x02
+	vms.Fixed.OneByteStringTag = 0x20
+	vms.Fixed.FirstNonstringType = 0xf0
+	vms.String.Length = 4
+	vms.SeqOneByteString.Chars = 8
+	vms.ConsString.First = 8
+	vms.ConsString.Second = 16
+	vms.ThinString.Actual = 24
+	vms.HeapObject.Map = 0
+	vms.Map.InstanceType = 4
+	vms.FixedArrayBase.Length = 8
+
+	addrToType, err := freelru.New[libpf.Address, uint16](64, libpf.Address.Hash32)
+	if err != nil {
+		panic(err)
+	}
+	return &v8Instance{d: d, addrToType: addrToType}
+}
+
+func putUint64(buf []byte, off int, v uint64) {
+	binary.LittleEndian.PutUint64(buf[off:off+8], v)
+}
+
+func putUint16(buf []byte, off int, v uint16) {
+	binary.LittleEndian.PutUint16(buf[off:off+2], v)
+}
+
+func TestExtractStringLengthLimit(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 4096)
+	// Advertise a ~4 GiB sequence string; extraction must fail without reading
+	// or invoking the callback even once.
+	binary.LittleEndian.PutUint32(buf[4:], 0xFFFFFFFF)
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
+	calls := 0
+	err := i.extractString(0, tag, func(string) error { calls++; return nil })
+	require.Error(t, err)
+	require.Zero(t, calls)
+}
+
+func TestExtractStringValid(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 4096)
+	binary.LittleEndian.PutUint32(buf[4:], 6)
+	copy(buf[8:], "abcdef")
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	tag := uint16(i.d.vmStructs.Fixed.SeqStringTag | i.d.vmStructs.Fixed.OneByteStringTag)
+	got := ""
+	err := i.extractString(0, tag, func(s string) error { got += s; return nil })
+	require.NoError(t, err)
+	assert.Equal(t, "abcdef", got)
+}
+
+func TestExtractStringConsCycle(t *testing.T) {
+	i := newTestV8Instance()
+	const (
+		A libpf.Address = 0x1000
+		M libpf.Address = 0x2000
+	)
+	buf := make([]byte, 0x3000)
+	putUint64(buf, int(A)+int(i.d.vmStructs.HeapObject.Map), uint64(M|HeapObjectTag))
+	putUint16(buf, int(M)+int(i.d.vmStructs.Map.InstanceType),
+		uint16(i.d.vmStructs.Fixed.ConsStringTag))
+	putUint64(buf, int(A)+int(i.d.vmStructs.ConsString.First), uint64(A|HeapObjectTag))
+	putUint64(buf, int(A)+int(i.d.vmStructs.ConsString.Second), uint64(A|HeapObjectTag))
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	// A self-referencing ConsString must be stopped by the depth bound instead
+	// of exhausting the stack.
+	err := i.extractString(A|HeapObjectTag, 0, func(string) error { return nil })
+	require.Error(t, err)
+}
+
+func TestReadFixedTableSizeLimit(t *testing.T) {
+	i := newTestV8Instance()
+	buf := make([]byte, 256)
+	// A huge SMI length whose product with itemSize would wrap a uint32.
+	numItems := uint64(1) << 30
+	binary.LittleEndian.PutUint64(buf[8:], numItems<<32)
+	i.rm = remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	_, err := i.readFixedTable(0, 8, 0)
+	require.Error(t, err)
 }


### PR DESCRIPTION
**Summary**
Harden the V8/Node.js interpreter module against the denial-of-service findings in #1601. String and fixed-table metadata is read from the target process via process_vm_readv; a malicious process can forge string lengths and build cyclic/deeply nested string graphs.

**Vulnerabilities addressed**
- #1601 finding 7 (excessive CPU, HIGH) — interpreter/nodev8/v8.go: extractString read a uint32 Length and copied it in 16 KiB chunks with no bound; 0xFFFFFFFF forced ~262K iterations per sample.
- #1601 finding 8 (stack exhaustion / unbounded CPU, HIGH) — interpreter/nodev8/v8.go: recursive descent through ConsString.First/.Second and ThinString.Actual had no depth limit; a cyclic string graph exhausted the stack.

**Fix**
- extractString now takes an explicit byte limit and recursion depth, and returns the number of bytes read. Cons/thin recursion passes the remaining budget (limit bytesRead) to its children, so total remote-read work per call is bounded replacing the earlier wrapper + shared-budget-pointer approach.
- Separate limits per use case: maxMemoizedStringBytes (1 KiB) for names memoized in addrToString (file, function, class names), and maxSourceStringBytes (16 MiB) for the non-memoized Script.Source/line-ends path, which can legitimately be large. The now-redundant 1 KiB check inside getString was removed.
- maxStringDepth (16) still terminates cyclic ConsString/ThinString chains instead of exhausting the stack.
- Additional hardening: readFixedTable uses 64-bit size math so numItems × itemSize cannot overflow before the existing 512 KiB maximumFixedTableSize check.
- Also fixes the import ordering (go-freelru sorts before stretchr/testify) that tripped the repo's make format CI check.

Performance: the limit/depth checks are local comparisons on already-read values; no extra remote reads on the hot path.

**Testing**
- TestExtractStringLengthLimit: forged 4 GiB length rejected with zero remote reads / callback calls.
- TestExtractStringValid: nominal extraction still works.
- TestExtractStringConsCycle: self-referencing ConsString terminates at the depth bound.
- TestReadFixedTableSizeLimit: overflow-sized table rejected.

Verified: gofmt -l clean, go build, go vet, go test ./interpreter/... all pass.
Files: interpreter/nodev8/v8.go, interpreter/nodev8/v8_test.go