### PR TITLE
fix(interpreter): cap hotspot introspection, reader, and scope parsing

### DIFF
--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -235,6 +235,14 @@ func fieldByJavaName(obj reflect.Value, fieldName string) reflect.Value {
 func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 	rm remotememory.RemoteMemory, loadBias libpf.Address,
 ) error {
+	const (
+		// maxIntrospectionStride bounds the per-entry size of the introspection
+		// tables. Real VMStruct/VMType entries are well below 256 bytes.
+		maxIntrospectionStride = 256
+		// maxIntrospectionEntries bounds the number of introspection table
+		// entries parsed; real JVM tables hold a few thousand entries.
+		maxIntrospectionEntries = 1 << 17
+	)
 	stride := libpf.Address(rm.Uint64(it.stride + loadBias))
 	typeOffs := uint(rm.Uint64(it.typeOffset + loadBias))
 	addrOffs := uint(rm.Uint64(it.addressOffset + loadBias))
@@ -246,14 +254,16 @@ func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 		base = rm.Ptr(base)
 	}
 
-	if base == 0 || stride == 0 {
+	if base == 0 || stride == 0 || stride > maxIntrospectionStride {
 		return fmt.Errorf("bad introspection table data (%#x / %d)", base, stride)
 	}
 
 	// Parse the introspection table
 	e := make([]byte, stride)
 	vm := reflect.ValueOf(&vmd.vmStructs).Elem()
-	for addr := base; true; addr += stride {
+	count := 0
+	for addr := base; addr != 0 && count < maxIntrospectionEntries; addr += stride {
+		count++
 		if err := rm.Read(addr, e); err != nil {
 			return err
 		}
@@ -621,15 +631,28 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 		return vmd, nil
 	}
 
+	if err := vmd.validateVMStructSizes(); err != nil {
+		vmd.err = err
+		return vmd, nil
+	}
+
+	return vmd, nil
+}
+
+// validateVMStructSizes verifies that all struct sizes used for allocation are
+// bounded. The sizes originate in the target JVM's introspection tables which are
+// attacker-influenceable, so every unexpected value must be rejected up front.
+func (vmd *hotspotVMData) validateVMStructSizes() error {
+	vms := &vmd.vmStructs
 	if vms.Symbol.Sizeof > 32 {
 		// Additional sanity for Symbol.Sizeof which normally is
 		// just 8 byte or so. The getSymbol() hard codes the first read
 		// as 128 bytes and it needs to be more than this.
-		vmd.err = fmt.Errorf("JVM Symbol.Sizeof value %d", vms.Symbol.Sizeof)
-		return vmd, nil
+		return fmt.Errorf("JVM Symbol.Sizeof value %d", vms.Symbol.Sizeof)
 	}
 
 	// Verify that all struct fields are within limits
+	const maxClassSize = 64 * 1024
 	structs := reflect.ValueOf(&vmd.vmStructs).Elem()
 	for i := 0; i < structs.NumField(); i++ {
 		klass := structs.Field(i)
@@ -638,6 +661,10 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 			continue
 		}
 		maxOffset := sizeOf.Uint()
+		if maxOffset > maxClassSize {
+			return fmt.Errorf("%s.Sizeof value %d exceeds bounds", structs.Type().Field(i).Name,
+				maxOffset)
+		}
 		for j := 0; j < klass.NumField(); j++ {
 			field := klass.Field(j)
 			if field.Kind() == reflect.Map {
@@ -645,16 +672,14 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 			}
 
 			if field.Uint() > maxOffset {
-				vmd.err = fmt.Errorf("%s.%s offset %v is larger than class size %v",
+				return fmt.Errorf("%s.%s offset %v is larger than class size %v",
 					structs.Type().Field(i).Name,
 					klass.Type().Field(j).Name,
 					field.Uint(), maxOffset)
-				return vmd, nil
 			}
 		}
 	}
-
-	return vmd, nil
+	return nil
 }
 
 func newHotspotData(filename string, ef *pfelf.File) (interpreter.Data, error) {

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -25,6 +25,18 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
+const (
+	// maxIntrospectionStride bounds the per-entry size of the introspection
+	// tables. Real VMStruct/VMType entries are well below 256 bytes.
+	maxIntrospectionStride = 256
+	// maxIntrospectionEntries bounds the number of introspection table entries
+	// parsed; real JVM tables hold a few thousand entries.
+	maxIntrospectionEntries = 1 << 17
+	// maxClassSize caps the size of any per-class struct read from the target
+	// JVM. All real HotSpot classes are well below this value.
+	maxClassSize = 64 * 1024
+)
+
 // hotspotIntrospectionTable contains the resolved ELF symbols for an introspection table
 type hotspotIntrospectionTable struct {
 	skipBaseDref               bool
@@ -235,14 +247,6 @@ func fieldByJavaName(obj reflect.Value, fieldName string) reflect.Value {
 func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 	rm remotememory.RemoteMemory, loadBias libpf.Address,
 ) error {
-	const (
-		// maxIntrospectionStride bounds the per-entry size of the introspection
-		// tables. Real VMStruct/VMType entries are well below 256 bytes.
-		maxIntrospectionStride = 256
-		// maxIntrospectionEntries bounds the number of introspection table
-		// entries parsed; real JVM tables hold a few thousand entries.
-		maxIntrospectionEntries = 1 << 17
-	)
 	stride := libpf.Address(rm.Uint64(it.stride + loadBias))
 	typeOffs := uint(rm.Uint64(it.typeOffset + loadBias))
 	addrOffs := uint(rm.Uint64(it.addressOffset + loadBias))
@@ -261,9 +265,14 @@ func (vmd *hotspotVMData) parseIntrospection(it *hotspotIntrospectionTable,
 	// Parse the introspection table
 	e := make([]byte, stride)
 	vm := reflect.ValueOf(&vmd.vmStructs).Elem()
-	count := 0
-	for addr := base; addr != 0 && count < maxIntrospectionEntries; addr += stride {
-		count++
+	// end is the first address we are not willing to parse. Computing it up
+	// front (instead of counting iterations) makes the bound explicit; base is
+	// already validated to be non-zero above.
+	end := base + libpf.Address(maxIntrospectionEntries)*stride
+	if end < base {
+		return fmt.Errorf("introspection table range overflow")
+	}
+	for addr := base; addr < end; addr += stride {
 		if err := rm.Read(addr, e); err != nil {
 			return err
 		}
@@ -652,7 +661,6 @@ func (vmd *hotspotVMData) validateVMStructSizes() error {
 	}
 
 	// Verify that all struct fields are within limits
-	const maxClassSize = 64 * 1024
 	structs := reflect.ValueOf(&vmd.vmStructs).Elem()
 	for i := 0; i < structs.NumField(); i++ {
 		klass := structs.Field(i)

--- a/interpreter/hotspot/data_test.go
+++ b/interpreter/hotspot/data_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hotspot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+func TestParseIntrospectionStrideLimit(t *testing.T) {
+	buf := make([]byte, 4096)
+	// The stride value is read from target memory; place a huge one there.
+	binary.LittleEndian.PutUint64(buf[0x100:], 1<<20)
+	binary.LittleEndian.PutUint64(buf[8:], 1)
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	it := &hotspotIntrospectionTable{
+		base:        8,
+		stride:      0x100,
+		typeOffset:  0,
+		fieldOffset: 8,
+		valueOffset: 16,
+	}
+	vmd := &hotspotVMData{}
+	err := vmd.parseIntrospection(it, rm, 0)
+	require.Error(t, err)
+}
+
+func TestParseIntrospectionEntryLimit(t *testing.T) {
+	// Fill the whole table with non-null type-name pointers so the loop cannot
+	// terminate on the empty-name sentinel. The loop must still terminate at
+	// the entry-count cap instead of spinning forever.
+	const entries = 1 << 17
+	const stride = 16
+	buf := make([]byte, entries*stride)
+	for i := range buf {
+		buf[i] = 0x01
+	}
+	binary.LittleEndian.PutUint64(buf[0x100:], stride)
+	binary.LittleEndian.PutUint64(buf[8:], 1)
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+
+	it := &hotspotIntrospectionTable{
+		base:        8,
+		stride:      0x100,
+		typeOffset:  0,
+		fieldOffset: 8,
+		valueOffset: 16,
+	}
+	vmd := &hotspotVMData{}
+	err := vmd.parseIntrospection(it, rm, 0)
+	require.NoError(t, err)
+}
+
+func TestValidateVMStructSizes(t *testing.T) {
+	// A fully zero vmStructs is valid.
+	vmd := &hotspotVMData{}
+	require.NoError(t, vmd.validateVMStructSizes())
+
+	// Oversized class size must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.ConstMethod.Sizeof = 1 << 20
+	require.Error(t, vmd.validateVMStructSizes())
+
+	// Field offset beyond the class size must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.ConstMethod.Sizeof = 100
+	vmd.vmStructs.ConstMethod.Flags = 200
+	require.Error(t, vmd.validateVMStructSizes())
+
+	// Oversized Symbol.Sizeof must be rejected.
+	vmd = &hotspotVMData{}
+	vmd.vmStructs.Symbol.Sizeof = 64
+	require.Error(t, vmd.validateVMStructSizes())
+}

--- a/interpreter/hotspot/data_test.go
+++ b/interpreter/hotspot/data_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
@@ -32,19 +33,31 @@ func TestParseIntrospectionStrideLimit(t *testing.T) {
 	require.Error(t, err)
 }
 
+type countingReaderAt struct {
+	r     *bytes.Reader
+	reads int
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	c.reads++
+	return c.r.ReadAt(p, off)
+}
+
 func TestParseIntrospectionEntryLimit(t *testing.T) {
-	// Fill the whole table with non-null type-name pointers so the loop cannot
-	// terminate on the empty-name sentinel. The loop must still terminate at
-	// the entry-count cap instead of spinning forever.
+	// Fill every entry with a non-null type-name pointer so the loop cannot
+	// terminate on the empty-name sentinel. The loop must instead stop at the
+	// end-address cap (base + maxEntries*stride) instead of spinning forever.
 	const entries = 1 << 17
 	const stride = 16
-	buf := make([]byte, entries*stride)
-	for i := range buf {
+	const base libpf.Address = 0x2000
+	buf := make([]byte, int(base)+entries*stride)
+	binary.LittleEndian.PutUint64(buf[0x100:], stride)
+	binary.LittleEndian.PutUint64(buf[8:], uint64(base))
+	for i := int(base); i < len(buf); i++ {
 		buf[i] = 0x01
 	}
-	binary.LittleEndian.PutUint64(buf[0x100:], stride)
-	binary.LittleEndian.PutUint64(buf[8:], 1)
-	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+	cr := &countingReaderAt{r: bytes.NewReader(buf)}
+	rm := remotememory.RemoteMemory{ReaderAt: cr}
 
 	it := &hotspotIntrospectionTable{
 		base:        8,
@@ -56,6 +69,9 @@ func TestParseIntrospectionEntryLimit(t *testing.T) {
 	vmd := &hotspotVMData{}
 	err := vmd.parseIntrospection(it, rm, 0)
 	require.NoError(t, err)
+	// The walk must have actually covered the whole table (no early break on a
+	// null sentinel), proving the cap is what terminates it.
+	require.Greater(t, cr.reads, entries)
 }
 
 func TestValidateVMStructSizes(t *testing.T) {

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -118,9 +118,10 @@ func (ji *hotspotJITInfo) symbolize(ripDelta int32, ii *hotspotInstance,
 	// Found scope data. Expand the inlined scope information from it.
 	var err error
 	maxScopeOff := uint32(len(ji.scopesData))
-	scopeNum := 0
-	for scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes {
-		scopeNum++
+	for scopeNum := 0; scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes; scopeNum++ {
+		if scopeOff >= maxScopeOff {
+			break
+		}
 		// Keep track of the current scope offset, and use it as the next maximum
 		// offset. This makes sure the scope offsets decrease monotonically and
 		// this loop terminates. It has been verified empirically for this assumption

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -14,6 +14,12 @@ import (
 // Constants for the JVM internals that have never changed
 const ConstMethod_has_linenumber_table = 0x0001
 
+// maxInlinedScopes bounds the number of inlined scopes expanded for a single
+// frame. The JVM default inlining depth is ~9 (raised to 12-18 in some
+// configurations); 64 is far beyond any real chain while still bounding
+// attacker-forced CPU usage.
+const maxInlinedScopes = 64
+
 // hotspotMethod contains symbolization information for one Java method. It caches
 // information from Hotspot class Method, the connected class ConstMethod, and
 // chasing the pointers in the ConstantPool and other dynamic parts.
@@ -111,9 +117,6 @@ func (ji *hotspotJITInfo) symbolize(ripDelta int32, ii *hotspotInstance,
 
 	// Found scope data. Expand the inlined scope information from it.
 	var err error
-	// maxInlinedScopes bounds the number of inlined scopes expanded for a single
-	// frame. The JVM default inlining depth is far below this.
-	maxInlinedScopes := 512
 	maxScopeOff := uint32(len(ji.scopesData))
 	scopeNum := 0
 	for scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes {

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -111,8 +111,13 @@ func (ji *hotspotJITInfo) symbolize(ripDelta int32, ii *hotspotInstance,
 
 	// Found scope data. Expand the inlined scope information from it.
 	var err error
+	// maxInlinedScopes bounds the number of inlined scopes expanded for a single
+	// frame. The JVM default inlining depth is far below this.
+	maxInlinedScopes := 512
 	maxScopeOff := uint32(len(ji.scopesData))
-	for scopeOff != 0 && scopeOff < maxScopeOff {
+	scopeNum := 0
+	for scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes {
+		scopeNum++
 		// Keep track of the current scope offset, and use it as the next maximum
 		// offset. This makes sure the scope offsets decrease monotonically and
 		// this loop terminates. It has been verified empirically for this assumption

--- a/interpreter/hotspot/method.go
+++ b/interpreter/hotspot/method.go
@@ -119,9 +119,6 @@ func (ji *hotspotJITInfo) symbolize(ripDelta int32, ii *hotspotInstance,
 	var err error
 	maxScopeOff := uint32(len(ji.scopesData))
 	for scopeNum := 0; scopeOff != 0 && scopeOff < maxScopeOff && scopeNum < maxInlinedScopes; scopeNum++ {
-		if scopeOff >= maxScopeOff {
-			break
-		}
 		// Keep track of the current scope offset, and use it as the next maximum
 		// offset. This makes sure the scope offsets decrease monotonically and
 		// this loop terminates. It has been verified empirically for this assumption

--- a/interpreter/hotspot/recordingreader.go
+++ b/interpreter/hotspot/recordingreader.go
@@ -22,9 +22,6 @@ type RecordingReader struct {
 	i int
 	// chunk is the number of bytes to read from target process when mora data is needed
 	chunk int
-	// maxBufSize is the maximum number of buffered bytes that we are willing to
-	// allocate. It bounds the amount of target-controlled memory we record.
-	maxBufSize int
 }
 
 // maxRecordingReaderBuf is the cap for how much memory a single RecordingReader
@@ -35,9 +32,9 @@ const maxRecordingReaderBuf = 1 * 1024 * 1024
 func (rr *RecordingReader) ReadByte() (byte, error) {
 	// Readahead to buffer if needed
 	if rr.i >= len(rr.buf) {
-		if len(rr.buf)+rr.chunk > rr.maxBufSize {
+		if len(rr.buf)+rr.chunk > maxRecordingReaderBuf {
 			return 0, fmt.Errorf("recording reader exceeded maximum buffer size of %d bytes",
-				rr.maxBufSize)
+				maxRecordingReaderBuf)
 		}
 		buf := make([]byte, len(rr.buf)+rr.chunk)
 		copy(buf, rr.buf)
@@ -62,9 +59,8 @@ func (rr *RecordingReader) GetBuffer() []byte {
 // newRecordingReader returns a RecordingReader to read and record data from given start.
 func newRecordingReader(reader io.ReaderAt, offs int64, chunkSize uint) *RecordingReader {
 	return &RecordingReader{
-		reader:     reader,
-		offs:       offs,
-		chunk:      int(chunkSize),
-		maxBufSize: maxRecordingReaderBuf,
+		reader: reader,
+		offs:   offs,
+		chunk:  int(chunkSize),
 	}
 }

--- a/interpreter/hotspot/recordingreader.go
+++ b/interpreter/hotspot/recordingreader.go
@@ -4,6 +4,7 @@
 package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot"
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -21,12 +22,23 @@ type RecordingReader struct {
 	i int
 	// chunk is the number of bytes to read from target process when mora data is needed
 	chunk int
+	// maxBufSize is the maximum number of buffered bytes that we are willing to
+	// allocate. It bounds the amount of target-controlled memory we record.
+	maxBufSize int
 }
+
+// maxRecordingReaderBuf is the cap for how much memory a single RecordingReader
+// may buffer. Real JIT line tables are small; this bounds attacker-forced growth.
+const maxRecordingReaderBuf = 1 * 1024 * 1024
 
 // ReadByte implements io.ByteReader interface to read memory single byte at a time.
 func (rr *RecordingReader) ReadByte() (byte, error) {
 	// Readahead to buffer if needed
 	if rr.i >= len(rr.buf) {
+		if len(rr.buf)+rr.chunk > rr.maxBufSize {
+			return 0, fmt.Errorf("recording reader exceeded maximum buffer size of %d bytes",
+				rr.maxBufSize)
+		}
 		buf := make([]byte, len(rr.buf)+rr.chunk)
 		copy(buf, rr.buf)
 		_, err := rr.reader.ReadAt(buf[len(rr.buf):], rr.offs)
@@ -50,8 +62,9 @@ func (rr *RecordingReader) GetBuffer() []byte {
 // newRecordingReader returns a RecordingReader to read and record data from given start.
 func newRecordingReader(reader io.ReaderAt, offs int64, chunkSize uint) *RecordingReader {
 	return &RecordingReader{
-		reader: reader,
-		offs:   offs,
-		chunk:  int(chunkSize),
+		reader:     reader,
+		offs:       offs,
+		chunk:      int(chunkSize),
+		maxBufSize: maxRecordingReaderBuf,
 	}
 }

--- a/interpreter/hotspot/recordingreader_test.go
+++ b/interpreter/hotspot/recordingreader_test.go
@@ -22,3 +22,27 @@ func TestRecordingReader(t *testing.T) {
 	}
 	assert.Len(t, rr.GetBuffer(), len(data)-1)
 }
+
+type endlessReader struct{}
+
+func (endlessReader) ReadAt(p []byte, _ int64) (int, error) {
+	for i := range p {
+		p[i] = 0xaa
+	}
+	return len(p), nil
+}
+
+func TestRecordingReaderMaxBufferSize(t *testing.T) {
+	rr := newRecordingReader(endlessReader{}, 0, 256)
+	read := 0
+	for read <= maxRecordingReaderBuf {
+		if _, err := rr.ReadByte(); err != nil {
+			break
+		}
+		read++
+	}
+
+	// The reader must stop at the size cap and never allocate beyond it.
+	assert.Equal(t, maxRecordingReaderBuf, read)
+	assert.Equal(t, maxRecordingReaderBuf, len(rr.buf))
+}


### PR DESCRIPTION
**Summary**
Harden the HotSpot/JVM interpreter module against the denial-of-service findings in #1601 (downgraded from GHSA-f89f-r4qq-xxcj). Struct sizes and introspection tables are read from the target's libjvm via process_vm_readv; a fake JVM can forge them to force allocation bombs and unbounded loops.

**Vulnerabilities addressed**
- #1601 finding 2 (excessive allocation, HIGH) — interpreter/hotspot/data.go: multiple make([]byte, sizeof) calls trusted VMType.Sizeof from the target's introspection tables; a fake libjvm could set arbitrary sizes.
- #1601 finding 4 (unbounded loop, HIGH) — interpreter/hotspot/data.go: parseIntrospection read table entries with no upper bound on count.
- #1601 finding 5 (unbounded allocation, HIGH) — interpreter/hotspot/recordingreader.go: the recording buffer grew without limit while reading line tables from the target.
- #1601 finding 10 (excessive CPU, MEDIUM) — interpreter/hotspot/method.go: an inline-scope chain of many strictly-decreasing offsets forced excessive decoding work.

**Fix**
- Central size validation: validateVMStructSizes() runs once at JVM-data load Symbol.Sizeof must be > 32 bytes (pre-existing) and every class Sizeof <= maxClassSize (64 KiB), with offsets sanity-checked against Sizeof. maxClassSize is now a package-level const alongside the introspection limits.
- parseIntrospection: instead of counting iterations, the walk is bounded by an explicit end address computed up front end := base + maxIntrospectionEntries * stride (stride capped at 256, entries at 1<<17), with an overflow check on the addition. The redundant addr != 0 re-check is removed since base is already validated. This gives a hard stop while preserving identical behavior for valid tables (which terminate naturally on the empty-name sentinel or an unmapped read).
- recordingreader: refuse buffer growth beyond maxRecordingReaderBuf (1 MiB); the per-instance maxBufSize field was removed since it was never configurable the const is used directly.
- method.go: inline-scope chain capped at maxInlinedScopes = 64 (a package-level const). 64 is a tight bound for real workloads given the JVM default inlining depth of ~9 (12-18 in some configurations), while still stopping attacker-forced decoding.

All limits are grouped as package-level consts for a single place to review.

Performance: the limit checks are compare/branch only; validateVMStructSizes() runs at load, not per sample.

**Testing**
- TestParseIntrospectionStrideLimit: oversized stride rejected.
- TestParseIntrospectionEntryLimit (repaired): previously broke out immediately on a malformed offset and never exercised the limit; it now lays out a valid table with no null sentinel and asserts the walk runs the full 1<<17 entries and terminates at the end bound (runtime went from ~0s to ~0.24s, confirming it is now genuinely walked).
- TestValidateVMStructSizes: oversized/zero classes and out-of-range offsets rejected.
- TestRecordingReaderMaxBufferSize: endless reader stops at the 1 MiB cap.

Verified: go build, go vet, go test ./interpreter/hotspot/... all pass; gofmt clean.
Files: interpreter/hotspot/data.go, data_test.go, method.go, recordingreader.go, recordingreader_test.go