### PR TITLE
fix(interpreter): bound dotnet range list/section/map walks

### DIFF
--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"unsafe"
 
@@ -375,6 +376,20 @@ func (d *dotnetData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address)
 		}
 	}
 	vms.RealCodeHeader.SizeOf = vms.RealCodeHeader.MethodDesc + 8
+
+	// Validate that all struct sizes used for allocations are within bounds.
+	// The JSON descriptor is read from target memory and is attacker-controlled.
+	structs := reflect.ValueOf(&cdac.Types).Elem()
+	for i := 0; i < structs.NumField(); i++ {
+		sizeOf := structs.Field(i).FieldByName("SizeOf")
+		if !sizeOf.IsValid() {
+			continue
+		}
+		if s := sizeOf.Uint(); s > maxDotnetStructSize {
+			return dotnetCdac{}, fmt.Errorf("%s.SizeOf value %d out of bounds",
+				structs.Type().Field(i).Name, s)
+		}
+	}
 
 	// Calculated masks
 	cdac.calculated.MethodDescTokenRemainderMask = (1 << cdac.Globals.MethodDescTokenRemainderBitCount) - 1

--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -119,6 +119,23 @@ const (
 	// maxBoundsSize is the maximum size of boundary debug info (for a method)
 	// that we accept as valid. This is to prevent OOM situation.
 	maxBoundsSize = 16 * 1024
+
+	// maxRangeSections bounds the traversal of RangeSection / fragment lists,
+	// which are attacker-controlled linked structures.
+	maxRangeSections = 1 << 20
+
+	// maxRangeListBlocks bounds the number of blocks traversed in a stub
+	// RangeList.
+	maxRangeListBlocks = 1 << 16
+
+	// maxRangeMapLevels bounds the number of intermediate level nodes read
+	// while walking a dotnet RangeSectionMap (protects against aliased level
+	// pointers causing exponential traversal).
+	maxRangeMapLevels = 1 << 17
+
+	// maxDotnetStructSize caps the size of any per-struct read from target
+	// memory. All real CoreCLR struct sizes are well below this value.
+	maxDotnetStructSize = 64 * 1024
 )
 
 var (

--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -120,19 +120,6 @@ const (
 	// that we accept as valid. This is to prevent OOM situation.
 	maxBoundsSize = 16 * 1024
 
-	// maxRangeSections bounds the traversal of RangeSection / fragment lists,
-	// which are attacker-controlled linked structures.
-	maxRangeSections = 1 << 20
-
-	// maxRangeListBlocks bounds the number of blocks traversed in a stub
-	// RangeList.
-	maxRangeListBlocks = 1 << 16
-
-	// maxRangeMapLevels bounds the number of intermediate level nodes read
-	// while walking a dotnet RangeSectionMap (protects against aliased level
-	// pointers causing exponential traversal).
-	maxRangeMapLevels = 1 << 17
-
 	// maxDotnetStructSize caps the size of any per-struct read from target
 	// memory. All real CoreCLR struct sizes are well below this value.
 	maxDotnetStructSize = 64 * 1024

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -129,15 +129,37 @@ type dotnetRangeSection struct {
 	prefixes []lpm.Prefix
 }
 
-// rangeWalker carries per-walk state for walking a dotnet8 RangeSectionMap. It
-// deduplicates every pointer touched during the walk so that aliased or cyclic
-// structures cannot cause exponential traversal or infinite loops.
+// rangeWalker carries per-walk state for walking a
+// RangeSectionMap/RangeSectionList/RangeList. It deduplicates every pointer
+// touched during the walk so that aliased or cyclic structures cannot cause
+// exponential traversal or infinite loops.
 type rangeWalker struct {
-	// seenAddress records every address visited while walking a RangeSectionMap:
-	// map levels, fragment lists and RangeSections all live in the same address
-	// space, so seeing the same address in any context means it was already
-	// processed.
+	// seenAddress records every address visited while walking: map levels,
+	// fragment lists and RangeSections all live in the same address space, so
+	// seeing the same address in any context means it was already processed.
 	seenAddress map[libpf.Address]libpf.Void
+}
+
+// maxRangeSectionWalkNodes caps the number of distinct addresses that a
+// single RangeSectionMap/RangeSectionList/RangeList walk may visit. A
+// legitimate .NET process will never come close to this limit; it exists
+// to bound memory growth when the target's in-memory structures are
+// corrupt or adversarially crafted.
+const maxRangeSectionWalkNodes = 1 << 20
+
+// markSeen records addr and reports whether it is newly seen (true) or was
+// already visited (false). It returns an error when the walk has exceeded
+// maxRangeSectionWalkNodes, preventing unbounded memory growth on corrupt or
+// adversarially crafted target structures.
+func (w *rangeWalker) markSeen(addr libpf.Address) (bool, error) {
+	if _, ok := w.seenAddress[addr]; ok {
+		return false, nil
+	}
+	if len(w.seenAddress) >= maxRangeSectionWalkNodes {
+		return false, fmt.Errorf("range walk exceeded %d-node limit", maxRangeSectionWalkNodes)
+	}
+	w.seenAddress[addr] = libpf.Void{}
+	return true, nil
 }
 
 type dotnetInstance struct {
@@ -256,12 +278,16 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	stubName := codeName[codeType]
 	log.Debugf("Found %s stub range list head at %x", stubName, headPtr)
 	blockNum := 0
-	seen := make(map[libpf.Address]libpf.Void)
+	w := &rangeWalker{seenAddress: make(map[libpf.Address]libpf.Void)}
 	for blockPtr := headPtr + 0x8; blockPtr != 0; blockNum++ {
-		if _, ok := seen[blockPtr]; ok {
+		fresh, err := w.markSeen(blockPtr)
+		if err != nil {
+			log.Debugf("walkRangeList: %v", err)
 			return
 		}
-		seen[blockPtr] = libpf.Void{}
+		if !fresh {
+			return
+		}
 		if err := i.rm.Read(blockPtr, block); err != nil {
 			log.Debugf("Failed to read %s stub range block %d: %v",
 				stubName, blockNum, err)
@@ -355,13 +381,16 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 	vms := &i.d.Get().Types
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	// walk the RangeSection list
-	seen := make(map[libpf.Address]libpf.Void)
+	w := &rangeWalker{seenAddress: make(map[libpf.Address]libpf.Void)}
 	ptr := i.rm.Ptr(i.codeRangeListPtr)
 	for ptr != 0 {
-		if _, ok := seen[ptr]; ok {
+		fresh, err := w.markSeen(ptr)
+		if err != nil {
+			return err
+		}
+		if !fresh {
 			break
 		}
-		seen[ptr] = libpf.Void{}
 		if err := i.rm.Read(ptr, rangeSection); err != nil {
 			return err
 		}
@@ -383,20 +412,25 @@ func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandl
 	fragment := make([]byte, 4*8)
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	for fragmentPtr != 0 {
-		if _, ok := w.seenAddress[fragmentPtr]; ok {
+		fresh, err := w.markSeen(fragmentPtr)
+		if err != nil {
+			return err
+		}
+		if !fresh {
 			break
 		}
-		w.seenAddress[fragmentPtr] = libpf.Void{}
 		if err := i.rm.Read(fragmentPtr, fragment); err != nil {
 			return fmt.Errorf("failed to read fragment: %v", err)
 		}
 		// Remove collectible bit
 		fragmentPtr = npsr.Ptr(fragment, 0) &^ 1
 		rangeSectionPtr := npsr.Ptr(fragment, 24)
-		if _, ok := w.seenAddress[rangeSectionPtr]; ok {
+		if fresh, err = w.markSeen(rangeSectionPtr); err != nil {
+			return err
+		}
+		if !fresh {
 			continue
 		}
-		w.seenAddress[rangeSectionPtr] = libpf.Void{}
 
 		if err := i.rm.Read(rangeSectionPtr, rangeSection); err != nil {
 			return fmt.Errorf("failed to read range section: %v", err)
@@ -427,10 +461,13 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 			continue
 		}
 		if level < maxLevel {
-			if _, ok := w.seenAddress[ptr]; ok {
+			fresh, err := w.markSeen(ptr)
+			if err != nil {
+				return err
+			}
+			if !fresh {
 				continue
 			}
-			w.seenAddress[ptr] = libpf.Void{}
 			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1, w); err != nil {
 				return err
 			}

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -257,7 +257,7 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	log.Debugf("Found %s stub range list head at %x", stubName, headPtr)
 	blockNum := 0
 	seen := make(map[libpf.Address]libpf.Void)
-	for blockPtr := headPtr + 0x8; blockPtr != 0; {
+	for blockPtr := headPtr + 0x8; blockPtr != 0; blockNum++ {
 		if _, ok := seen[blockPtr]; ok {
 			return
 		}
@@ -282,7 +282,6 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 			i.addRange(ebpf, pid, startAddr, endAddr, startAddr, uint64(codeType|flagLeaf))
 		}
 		blockPtr = npsr.Ptr(block, numRangesInBlock*rangeSize)
-		blockNum++
 	}
 }
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -130,14 +130,14 @@ type dotnetRangeSection struct {
 }
 
 // rangeWalker carries per-walk state for walking a dotnet8 RangeSectionMap. It
-// deduplicates aliased level/fragment pointers and tracks visit budgets so that
-// a malicious tree cannot cause exponential traversal or unbounded loops.
+// deduplicates every pointer touched during the walk so that aliased or cyclic
+// structures cannot cause exponential traversal or infinite loops.
 type rangeWalker struct {
-	sectionSeen  map[libpf.Address]libpf.Void
-	levelSeen    map[libpf.Address]libpf.Void
-	fragmentSeen map[libpf.Address]libpf.Void
-	levelReads   int
-	fragments    int
+	// seenAddress records every address visited while walking a RangeSectionMap:
+	// map levels, fragment lists and RangeSections all live in the same address
+	// space, so seeing the same address in any context means it was already
+	// processed.
+	seenAddress map[libpf.Address]libpf.Void
 }
 
 type dotnetInstance struct {
@@ -257,7 +257,7 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	log.Debugf("Found %s stub range list head at %x", stubName, headPtr)
 	blockNum := 0
 	seen := make(map[libpf.Address]libpf.Void)
-	for blockPtr := headPtr + 0x8; blockPtr != 0 && blockNum < maxRangeListBlocks; blockNum++ {
+	for blockPtr := headPtr + 0x8; blockPtr != 0; {
 		if _, ok := seen[blockPtr]; ok {
 			return
 		}
@@ -282,6 +282,7 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 			i.addRange(ebpf, pid, startAddr, endAddr, startAddr, uint64(codeType|flagLeaf))
 		}
 		blockPtr = npsr.Ptr(block, numRangesInBlock*rangeSize)
+		blockNum++
 	}
 }
 
@@ -356,17 +357,12 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	// walk the RangeSection list
 	seen := make(map[libpf.Address]libpf.Void)
-	count := 0
 	ptr := i.rm.Ptr(i.codeRangeListPtr)
 	for ptr != 0 {
 		if _, ok := seen[ptr]; ok {
 			break
 		}
 		seen[ptr] = libpf.Void{}
-		count++
-		if count > maxRangeSections {
-			return fmt.Errorf("too many range sections in list")
-		}
 		if err := i.rm.Read(ptr, rangeSection); err != nil {
 			return err
 		}
@@ -388,24 +384,20 @@ func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandl
 	fragment := make([]byte, 4*8)
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	for fragmentPtr != 0 {
-		if _, ok := w.fragmentSeen[fragmentPtr]; ok {
+		if _, ok := w.seenAddress[fragmentPtr]; ok {
 			break
 		}
-		w.fragmentSeen[fragmentPtr] = libpf.Void{}
-		w.fragments++
-		if w.fragments > maxRangeSections {
-			return fmt.Errorf("too many range section fragments")
-		}
+		w.seenAddress[fragmentPtr] = libpf.Void{}
 		if err := i.rm.Read(fragmentPtr, fragment); err != nil {
 			return fmt.Errorf("failed to read fragment: %v", err)
 		}
 		// Remove collectible bit
 		fragmentPtr = npsr.Ptr(fragment, 0) &^ 1
 		rangeSectionPtr := npsr.Ptr(fragment, 24)
-		if _, ok := w.sectionSeen[rangeSectionPtr]; ok {
+		if _, ok := w.seenAddress[rangeSectionPtr]; ok {
 			continue
 		}
-		w.sectionSeen[rangeSectionPtr] = libpf.Void{}
+		w.seenAddress[rangeSectionPtr] = libpf.Void{}
 
 		if err := i.rm.Read(rangeSectionPtr, rangeSection); err != nil {
 			return fmt.Errorf("failed to read range section: %v", err)
@@ -436,14 +428,10 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 			continue
 		}
 		if level < maxLevel {
-			w.levelReads++
-			if w.levelReads > maxRangeMapLevels {
-				return fmt.Errorf("too many range section map levels")
-			}
-			if _, ok := w.levelSeen[ptr]; ok {
+			if _, ok := w.seenAddress[ptr]; ok {
 				continue
 			}
-			w.levelSeen[ptr] = libpf.Void{}
+			w.seenAddress[ptr] = libpf.Void{}
 			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1, w); err != nil {
 				return err
 			}
@@ -458,11 +446,7 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 
 // walkRangeSectionMap processes a dotnet8 RangeSectionMap to enumerate all RangeSections
 func (i *dotnetInstance) walkRangeSectionMap(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
-	w := &rangeWalker{
-		sectionSeen:  make(map[libpf.Address]libpf.Void),
-		levelSeen:    make(map[libpf.Address]libpf.Void),
-		fragmentSeen: make(map[libpf.Address]libpf.Void),
-	}
+	w := &rangeWalker{seenAddress: make(map[libpf.Address]libpf.Void)}
 	return i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1, w)
 }
 

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -124,8 +124,20 @@ type stringsHeapEntry struct {
 	gen  uint64
 }
 
+// dotnetRangeSection reflects the set of lpm prefixes for one range section.
 type dotnetRangeSection struct {
 	prefixes []lpm.Prefix
+}
+
+// rangeWalker carries per-walk state for walking a dotnet8 RangeSectionMap. It
+// deduplicates aliased level/fragment pointers and tracks visit budgets so that
+// a malicious tree cannot cause exponential traversal or unbounded loops.
+type rangeWalker struct {
+	sectionSeen  map[libpf.Address]libpf.Void
+	levelSeen    map[libpf.Address]libpf.Void
+	fragmentSeen map[libpf.Address]libpf.Void
+	levelReads   int
+	fragments    int
 }
 
 type dotnetInstance struct {
@@ -163,8 +175,6 @@ type dotnetInstance struct {
 	mappings []dotnetMapping
 
 	ranges map[libpf.Address]dotnetRangeSection
-
-	rangeSectionSeen map[libpf.Address]libpf.Void
 
 	// moduleToPEInfo maps Module* to it's peInfo. Since a dotnet instance will have
 	// limited number of PE files mapped in, this is a map instead of a LRU.
@@ -246,7 +256,12 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	stubName := codeName[codeType]
 	log.Debugf("Found %s stub range list head at %x", stubName, headPtr)
 	blockNum := 0
-	for blockPtr := headPtr + 0x8; blockPtr != 0; blockNum++ {
+	seen := make(map[libpf.Address]libpf.Void)
+	for blockPtr := headPtr + 0x8; blockPtr != 0 && blockNum < maxRangeListBlocks; blockNum++ {
+		if _, ok := seen[blockPtr]; ok {
+			return
+		}
+		seen[blockPtr] = libpf.Void{}
 		if err := i.rm.Read(blockPtr, block); err != nil {
 			log.Debugf("Failed to read %s stub range block %d: %v",
 				stubName, blockNum, err)
@@ -340,8 +355,18 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 	vms := &i.d.Get().Types
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	// walk the RangeSection list
+	seen := make(map[libpf.Address]libpf.Void)
+	count := 0
 	ptr := i.rm.Ptr(i.codeRangeListPtr)
 	for ptr != 0 {
+		if _, ok := seen[ptr]; ok {
+			break
+		}
+		seen[ptr] = libpf.Void{}
+		count++
+		if count > maxRangeSections {
+			return fmt.Errorf("too many range sections in list")
+		}
 		if err := i.rm.Read(ptr, rangeSection); err != nil {
 			return err
 		}
@@ -356,23 +381,31 @@ func (i *dotnetInstance) walkRangeSectionList(ebpf interpreter.EbpfHandler, pid 
 // walkRangeSectionMapFragments walks a RangeSectionMap::RangeSectionFragment list and processes
 // the RangeSections from it.
 func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandler, pid libpf.PID,
-	fragmentPtr libpf.Address,
+	fragmentPtr libpf.Address, w *rangeWalker,
 ) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L974
 	vms := &i.d.Get().Types
 	fragment := make([]byte, 4*8)
 	rangeSection := make([]byte, vms.RangeSection.SizeOf)
 	for fragmentPtr != 0 {
+		if _, ok := w.fragmentSeen[fragmentPtr]; ok {
+			break
+		}
+		w.fragmentSeen[fragmentPtr] = libpf.Void{}
+		w.fragments++
+		if w.fragments > maxRangeSections {
+			return fmt.Errorf("too many range section fragments")
+		}
 		if err := i.rm.Read(fragmentPtr, fragment); err != nil {
 			return fmt.Errorf("failed to read fragment: %v", err)
 		}
 		// Remove collectible bit
 		fragmentPtr = npsr.Ptr(fragment, 0) &^ 1
 		rangeSectionPtr := npsr.Ptr(fragment, 24)
-		if _, ok := i.rangeSectionSeen[rangeSectionPtr]; ok {
+		if _, ok := w.sectionSeen[rangeSectionPtr]; ok {
 			continue
 		}
-		i.rangeSectionSeen[rangeSectionPtr] = libpf.Void{}
+		w.sectionSeen[rangeSectionPtr] = libpf.Void{}
 
 		if err := i.rm.Read(rangeSectionPtr, rangeSection); err != nil {
 			return fmt.Errorf("failed to read range section: %v", err)
@@ -386,7 +419,7 @@ func (i *dotnetInstance) walkRangeSectionMapFragments(ebpf interpreter.EbpfHandl
 
 // walkRangeSectionMapLevel walks recursively a level index of a RangeSectionMap.
 func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, pid libpf.PID,
-	levelMapPtr libpf.Address, level uint,
+	levelMapPtr libpf.Address, level uint, w *rangeWalker,
 ) error {
 	// https://github.com/dotnet/runtime/blob/v8.0.4/src/coreclr/vm/codeman.h#L999-L1002
 	const maxLevel = 5
@@ -403,11 +436,19 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 			continue
 		}
 		if level < maxLevel {
-			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1); err != nil {
+			w.levelReads++
+			if w.levelReads > maxRangeMapLevels {
+				return fmt.Errorf("too many range section map levels")
+			}
+			if _, ok := w.levelSeen[ptr]; ok {
+				continue
+			}
+			w.levelSeen[ptr] = libpf.Void{}
+			if err := i.walkRangeSectionMapLevel(ebpf, pid, ptr, level+1, w); err != nil {
 				return err
 			}
 		} else {
-			if err := i.walkRangeSectionMapFragments(ebpf, pid, ptr); err != nil {
+			if err := i.walkRangeSectionMapFragments(ebpf, pid, ptr, w); err != nil {
 				return err
 			}
 		}
@@ -417,10 +458,12 @@ func (i *dotnetInstance) walkRangeSectionMapLevel(ebpf interpreter.EbpfHandler, 
 
 // walkRangeSectionMap processes a dotnet8 RangeSectionMap to enumerate all RangeSections
 func (i *dotnetInstance) walkRangeSectionMap(ebpf interpreter.EbpfHandler, pid libpf.PID) error {
-	i.rangeSectionSeen = make(map[libpf.Address]libpf.Void)
-	err := i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1)
-	i.rangeSectionSeen = nil
-	return err
+	w := &rangeWalker{
+		sectionSeen:  make(map[libpf.Address]libpf.Void),
+		levelSeen:    make(map[libpf.Address]libpf.Void),
+		fragmentSeen: make(map[libpf.Address]libpf.Void),
+	}
+	return i.walkRangeSectionMapLevel(ebpf, pid, i.codeRangeListPtr, 1, w)
 }
 
 // resolveStringsHeapAddr returns the absolute process address of the #Strings

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -282,7 +282,6 @@ func (i *dotnetInstance) walkRangeList(ebpf interpreter.EbpfHandler, pid libpf.P
 	for blockPtr := headPtr + 0x8; blockPtr != 0; blockNum++ {
 		fresh, err := w.markSeen(blockPtr)
 		if err != nil {
-			log.Debugf("walkRangeList: %v", err)
 			return
 		}
 		if !fresh {

--- a/interpreter/dotnet/instance_test.go
+++ b/interpreter/dotnet/instance_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dotnet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/host"
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/lpm"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+type fakeEbpf struct {
+	interpreter.EbpfHandler
+}
+
+func (fakeEbpf) UpdatePidInterpreterMapping(libpf.PID, lpm.Prefix, uint8, host.FileID, uint64) error {
+	return nil
+}
+
+type countingReaderAt struct {
+	r     io.ReaderAt
+	reads int
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	c.reads++
+	return c.r.ReadAt(p, off)
+}
+
+func putUint64(buf []byte, off int, v uint64) {
+	binary.LittleEndian.PutUint64(buf[off:off+8], v)
+}
+
+func newTestDotnetInstance(rm remotememory.RemoteMemory) *dotnetInstance {
+	d := &dotnetData{}
+	_, err := d.GetOrInit(func() (dotnetCdac, error) {
+		cdac := dotnetCdac{}
+		vms := &cdac.Types
+		vms.RangeSection.RangeBegin = 0
+		vms.RangeSection.RangeEndOpen = 8
+		vms.RangeSection.Flags = 0x10
+		vms.RangeSection.next = 24
+		vms.RangeSection.HeapList = 0x28
+		vms.RangeSection.R2RModule = 0x20
+		vms.RangeSection.RangeList = 0x30
+		vms.RangeSection.SizeOf = 0x38
+		vms.CodeHeapListNode.SizeOf = 0x30
+		vms.CodeHeapListNode.MapBase = 0x20
+		vms.CodeHeapListNode.HeaderMap = 0x28
+		vms.CodeHeapListNode.Next = 0
+		vms.CodeHeapListNode.StartAddress = 0x10
+		vms.CodeHeapListNode.EndAddress = 0x18
+		return cdac, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &dotnetInstance{
+		d:      d,
+		rm:     rm,
+		ranges: make(map[libpf.Address]dotnetRangeSection),
+	}
+}
+
+// TestWalkRangeSectionListCycle verifies that a cyclic RangeSection.next chain
+// terminates instead of looping forever.
+func TestWalkRangeSectionListCycle(t *testing.T) {
+	const (
+		r1   libpf.Address = 0x1000
+		r2   libpf.Address = 0x1040
+		head libpf.Address = 0x1080
+	)
+	buf := make([]byte, 0x1100)
+	putUint64(buf, int(head), uint64(r1))
+	putUint64(buf, int(r1)+24, uint64(r2))
+	putUint64(buf, int(r2)+24, uint64(r1))
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+	i := newTestDotnetInstance(rm)
+	i.codeRangeListPtr = head
+
+	err := i.walkRangeSectionList(fakeEbpf{}, 0)
+	require.NoError(t, err)
+	require.Empty(t, i.ranges)
+}
+
+// TestWalkRangeListCycle verifies that a cyclic stub RangeList block chain
+// terminates instead of looping forever.
+func TestWalkRangeListCycle(t *testing.T) {
+	const (
+		b1   libpf.Address = 0x1000
+		b2   libpf.Address = 0x1200
+		head libpf.Address = 0x1000 - 8
+	)
+	buf := make([]byte, 0x2000)
+	fillRanges := func(base libpf.Address, next libpf.Address, valueStart uint64) {
+		for index := 0; index < 10; index++ {
+			start := valueStart + uint64(index*0x100)
+			putUint64(buf, int(base)+index*24, start)
+			putUint64(buf, int(base)+index*24+8, start+0x10)
+			putUint64(buf, int(base)+index*24+16, uint64(index+1))
+		}
+		putUint64(buf, int(base)+240, uint64(next))
+	}
+	fillRanges(b1, b2, 0x1000)
+	fillRanges(b2, b1, 0x3000) // cycle back to b1
+
+	rm := remotememory.RemoteMemory{ReaderAt: bytes.NewReader(buf)}
+	i := newTestDotnetInstance(rm)
+
+	i.walkRangeList(fakeEbpf{}, 0, head, codeStubPrecode)
+	// b1 processed once, b2 once, then the cycle back to b1 is detected.
+	require.Len(t, i.ranges, 20)
+}
+
+func putAllEntries(buf []byte, at, val libpf.Address) {
+	for off := 0; off < 256*8; off += 8 {
+		putUint64(buf, int(at)+off, uint64(val))
+	}
+}
+
+// TestWalkRangeSectionMapAlias verifies that aliased intermediate level pointers
+// in a RangeSectionMap are deduplicated and the whole walk is bounded.
+func TestWalkRangeSectionMapAlias(t *testing.T) {
+	const (
+		root     libpf.Address = 0x2000
+		l2       libpf.Address = 0x4000
+		l3       libpf.Address = 0x6000
+		l4       libpf.Address = 0x8000
+		l5       libpf.Address = 0xA000
+		frag     libpf.Address = 0xC000
+		rangeSec libpf.Address = 0xE000
+	)
+	buf := make([]byte, 0x10000)
+	// Every entry of every level aliases the same child, producing a full 256-way
+	// fan-out that would be exponential without intermediate-level dedup.
+	putAllEntries(buf, root, l2)
+	putAllEntries(buf, l2, l3)
+	putAllEntries(buf, l3, l4)
+	putAllEntries(buf, l4, l5)
+	putAllEntries(buf, l5, frag)
+	putUint64(buf, int(frag)+24, uint64(rangeSec))
+
+	cr := &countingReaderAt{r: bytes.NewReader(buf)}
+	rm := remotememory.RemoteMemory{ReaderAt: cr}
+	i := newTestDotnetInstance(rm)
+	i.codeRangeListPtr = root
+
+	err := i.walkRangeSectionMap(fakeEbpf{}, 0)
+	require.NoError(t, err)
+	// Each level is read exactly once plus a handful of fragments/sections.
+	require.Less(t, cr.reads, 100)
+}

--- a/interpreter/dotnet/instance_test.go
+++ b/interpreter/dotnet/instance_test.go
@@ -121,6 +121,26 @@ func TestWalkRangeListCycle(t *testing.T) {
 	require.Len(t, i.ranges, 20)
 }
 
+// TestMarkSeen verifies that markSeen deduplicates addresses and enforces the
+// maxRangeSectionWalkNodes bound on a single walk.
+func TestMarkSeen(t *testing.T) {
+	w := &rangeWalker{seenAddress: make(map[libpf.Address]libpf.Void)}
+
+	for addr := libpf.Address(0); addr < maxRangeSectionWalkNodes; addr++ {
+		fresh, err := w.markSeen(addr)
+		require.NoError(t, err)
+		require.True(t, fresh)
+	}
+	// A new address beyond the bound must be rejected.
+	fresh, err := w.markSeen(maxRangeSectionWalkNodes)
+	require.Error(t, err)
+	require.False(t, fresh)
+	// Already-seen addresses stay accepted (dedup, not an error).
+	fresh, err = w.markSeen(0)
+	require.NoError(t, err)
+	require.False(t, fresh)
+}
+
 func putAllEntries(buf []byte, at, val libpf.Address) {
 	for off := 0; off < 256*8; off += 8 {
 		putUint64(buf, int(at)+off, uint64(val))


### PR DESCRIPTION
**Summary**
Harden the .NET interpreter module against the denial-of-service findings in #1601 (downgraded from GHSA-f89f-r4qq-xxcj). The range-section metadata is read from the target's libcoreclr via process_vm_readv; a fake .NET runtime can forge next pointers and aliased map levels to cause infinite loops and exponential traversal.

**Vulnerabilities addressed**
- #1601 finding 6 (unbounded loops, HIGH) — interpreter/dotnet/instance.go: walkRangeList, walkRangeSectionList, and walkRangeSectionMapFragments followed target-controlled next pointers; circular lists looped forever.
- #1601 finding 9 (exponential traversal, MEDIUM) — interpreter/dotnet/instance.go: walkRangeSectionMapLevel traversed a 5-level map where aliased level pointers caused exponential re-traversal (up to 256^5 visits).

**Fix**
Every walk now deduplicates the addresses it touches in a seen-set, so any revisit terminates the traversal:
- Single shared seen-set (rangeWalker.seenAddress): map levels, fragment lists, and RangeSections all live in the same address space, so encountering the same address in any context means it was already processed. One map replaces the previous per-role maps, halving the memory/GC overhead.
- walkRangeSectionMapLevel: aliased intermediate level pointers are skipped after the first visit this is what eliminates the 256^5 fan-out.
- walkRangeSectionMapFragments: cyclic fragment chains break on a seen fragment pointer; duplicate RangeSections are skipped.
- walkRangeSectionList (dotnet6/7) and walkRangeList (stub RangeLists): cycle detection via their seen-sets.
Count-based limits were removed per review: they were redundant alongside the seen-sets traversal is bounded by the target's readable memory, and duplicate ranges are additionally deduplicated globally via i.ranges (keyed by low address).
Additional hardening (unchanged from the original report): newVMData validates all CDAC struct SizeOf values against maxDotnetStructSize (64 KiB) via reflection once at load, preventing allocation bombs from forged struct sizes.

Performance: a single map lookup per visited address no extra remote reads per range on the hot path.

**Testing**
- TestWalkRangeSectionListCycle: cyclic RangeSection.next chain terminates.
- TestWalkRangeListCycle: cyclic stub RangeList block chain terminates.
- TestWalkRangeSectionMapAlias: fully aliased 256-way map fan-out completes with <100 remote reads (vs. 256^5 without the fix).

Verified: go build, go vet, go test ./interpreter/dotnet/... all pass; gofmt clean.
Files: interpreter/dotnet/dotnet.go, interpreter/dotnet/instance.go, interpreter/dotnet/instance_test.go