### PR TITLE
tracer: drop tracer.ProbeLinks in favor of probes/kprobe

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -177,7 +177,18 @@ func parseArgs() (*controller.Config, error) {
 	fs.StringVar(&args.BPFFSRoot, "bpffs-root", defaultBPFFSRoot, bpffsHelp)
 
 	fs.Func("probe-link", probeLinkHelper, func(link string) error {
-		args.ProbeLinks = append(args.ProbeLinks, link)
+		probeSpec, err := tracer.ParseProbe(link)
+		if err != nil {
+			return err
+		}
+		args.Probes = append(args.Probes, config.Probe{
+			Type: "kprobe",
+			Config: map[string]any{
+				"mode":   probeSpec.Mode.String(),
+				"symbol": probeSpec.Symbol,
+				"target": probeSpec.Target,
+			},
+		})
 		return nil
 	})
 

--- a/collector/config/config_linux.go
+++ b/collector/config/config_linux.go
@@ -74,7 +74,6 @@ type Config struct {
 	VerboseMode             bool                     `mapstructure:"verbose_mode"`
 	OffCPUThreshold         float64                  `mapstructure:"off_cpu_threshold"`
 	IncludeEnvVars          string                   `mapstructure:"include_env_vars"`
-	ProbeLinks              []string                 `mapstructure:"probe_links"`
 	LoadProbe               bool                     `mapstructure:"load_probe"`
 	MapScaleFactor          uint                     `mapstructure:"map_scale_factor"`
 	BPFVerifierLogLevel     uint                     `mapstructure:"bpf_verifier_log_level"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -104,7 +104,6 @@ func (c *Controller) Start(ctx context.Context) error {
 		ProbabilisticThreshold:  c.config.ProbabilisticThreshold,
 		OffCPUThreshold:         uint32(c.config.OffCPUThreshold * float64(math.MaxUint32)),
 		IncludeEnvVars:          envVars,
-		ProbeLinks:              c.config.ProbeLinks,
 		LoadProbe:               c.config.LoadProbe || len(c.config.Probes) > 0,
 		ExecutableReporter:      c.config.ExecutableReporter,
 		BPFFSRoot:               c.config.BPFFSRoot,
@@ -135,13 +134,6 @@ func (c *Controller) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to start off-cpu profiling: %v", err)
 		}
 		log.Infof("Enabled off-cpu profiling with p=%f", c.config.OffCPUThreshold)
-	}
-
-	if len(c.config.ProbeLinks) > 0 {
-		if err := trc.AttachProbes(c.config.ProbeLinks); err != nil {
-			return fmt.Errorf("failed to attach probes: %v", err)
-		}
-		log.Info("Attached probes")
 	}
 
 	if c.config.ProbabilisticThreshold < tracer.ProbabilisticThresholdMax {

--- a/tracer/probes.go
+++ b/tracer/probes.go
@@ -243,7 +243,7 @@ type Probe interface {
 //
 // Enable requires that the kprobe tail-call unwinder chain was loaded at tracer
 // startup. Set LoadProbe: true in the Config passed to NewTracer (or enable
-// off-CPU profiling or ProbeLinks, which also trigger the chain load).
+// off-CPU profiling, which also triggers the chain load).
 // Without the chain the probe attaches successfully but its tail calls into
 // kprobe_progs silently miss, producing no stack samples.
 //

--- a/tracer/systemconfig.go
+++ b/tracer/systemconfig.go
@@ -455,7 +455,7 @@ func probeVMALookupSupport(cfg *Config) (bool, string) {
 	defer restoreRlimit()
 
 	progTypes := []cebpf.ProgramType{cebpf.PerfEvent}
-	if cfg.OffCPUThreshold > 0 || len(cfg.ProbeLinks) > 0 || cfg.LoadProbe {
+	if cfg.OffCPUThreshold > 0 || cfg.LoadProbe {
 		progTypes = append(progTypes, cebpf.Kprobe)
 	}
 
@@ -708,23 +708,6 @@ func setOriginIDs(coll *cebpf.CollectionSpec, cfg *Config, origins *originRegist
 		}
 		if err := coll.Variables["origin_id_off_cpu"].Set(uint16(offCPU)); err != nil {
 			return fmt.Errorf("failed to set origin_id_off_cpu: %v", err)
-		}
-	}
-
-	// ProbeLinks use the generic eBPF program loaded at startup and need their
-	// origin ID baked into RODATA here. Custom probes (the Enable path) skip
-	// this block: they register their own origin IDs dynamically in Tracer.Enable
-	// before calling Probe.Load, so LoadProbe alone does not require a static ID.
-	if len(cfg.ProbeLinks) > 0 {
-		probe, err := origins.Register(&samples.TypeMetadata{
-			SampleType: "events",
-			SampleUnit: "count",
-		})
-		if err != nil {
-			return err
-		}
-		if err := coll.Variables["origin_id_probe"].Set(uint16(probe)); err != nil {
-			return fmt.Errorf("failed to set origin_id_probe: %v", err)
 		}
 	}
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -208,9 +208,6 @@ type Config struct {
 	// IncludeEnvVars holds a list of environment variables that should be captured and reported
 	// from processes
 	IncludeEnvVars libpf.Set[string]
-	// Probes holds a list of probe_type:target[:symbol] elements to which
-	// a probe will be attached.
-	ProbeLinks []string
 	// LoadProbe indicates whether the generic eBPF program should be loaded
 	// without being attached to something.
 	LoadProbe bool
@@ -362,7 +359,7 @@ func (t *Tracer) Close() {
 // It is the single source of truth consulted both during initialization and when recording
 // kprobeChainLoaded on the Tracer.
 func kprobeChainRequired(cfg *Config) bool {
-	return cfg.OffCPUThreshold > 0 || len(cfg.ProbeLinks) > 0 || cfg.LoadProbe
+	return cfg.OffCPUThreshold > 0 || cfg.LoadProbe
 }
 
 // initializeMapsAndPrograms loads the definitions for the eBPF maps and programs provided
@@ -539,24 +536,6 @@ func initializeMapsAndPrograms(kmod *kallsyms.Module, cfg *Config, origins *orig
 			cfg.BPFVerifierLogLevel, ebpfMaps["perf_progs"].FD(),
 			ebpfMaps["per_cpu_records"].FD(), ebpfMaps["per_cpu_records_kp"]); err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to load kprobe eBPF programs: %v", err)
-		}
-	}
-
-	if len(cfg.ProbeLinks) > 0 {
-		// kprobe__generic is only needed in ebpfProgs when ProbeLinks are configured:
-		// AttachProbes retrieves it from there. Custom probes (Enable path) load their
-		// own fresh instance via ProbeContext.LoadProbeUnwinders, so we skip it here.
-		probeProgs := []ProgLoaderHelper{
-			{
-				Name:             genericProgName,
-				NoTailCallTarget: true,
-				Enable:           true,
-			},
-		}
-		if err = loadProbeUnwinders(coll, ebpfProgs, ebpfMaps["kprobe_progs"], probeProgs,
-			cfg.BPFVerifierLogLevel, ebpfMaps["perf_progs"].FD(),
-			ebpfMaps["per_cpu_records"].FD(), ebpfMaps["per_cpu_records_kp"]); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load uprobe eBPF programs: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Reduce complexity and duplicate code by removing tracer.ProbeLinks in favor of probes/kprobe. probes/kprobe is the successor and covers all cases that were possible with tracer.ProbeLinks.