### PR TITLE
probes: update Load() API signature for multi-hook and per-process support

### DIFF
--- a/probes/kprobe/kprobe.go
+++ b/probes/kprobe/kprobe.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	cebpf "github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
 
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/tracer"
@@ -80,51 +79,56 @@ func parseProbeMode(s string) (tracer.ProbeMode, error) {
 	}
 }
 
-func (g *probe) Load(_ context.Context, reg tracer.ProbeRegistrar, ctx *tracer.ProbeContext) (link.Link, error) {
+func (g *probe) Load(_ context.Context, reg tracer.ProbeRegistrar, probeCtx *tracer.ProbeContext) error {
 	originID, err := reg.Register(&samples.TypeMetadata{
 		SampleType: "events",
 		SampleUnit: "count",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("registering probe origin: %w", err)
+		return fmt.Errorf("registering probe origin: %w", err)
 	}
 
-	coll, err := ctx.CollectionSpecWith(
+	coll, err := probeCtx.CollectionSpecWith(
 		nil,
 		[]string{progName},
 		[]string{"origin_id_probe"},
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	v, ok := coll.Variables["origin_id_probe"]
 	if !ok {
-		return nil, fmt.Errorf("origin_id_probe variable not found in collection spec")
+		return fmt.Errorf("origin_id_probe variable not found in collection spec")
 	}
 	if err := v.Set(originID); err != nil {
-		return nil, err
+		return err
 	}
 
-	if err := ctx.RewriteMaps(coll, nil); err != nil {
-		return nil, err
+	if err := probeCtx.RewriteMaps(coll, nil); err != nil {
+		return err
 	}
 
 	ebpfProgs := make(map[string]*cebpf.Program)
-	if err := ctx.LoadProbeUnwinders(coll, ebpfProgs, []tracer.ProgLoaderHelper{
+	if err := probeCtx.LoadProbeUnwinders(coll, ebpfProgs, []tracer.ProgLoaderHelper{
 		{
 			Name:             progName,
 			NoTailCallTarget: true,
 			Enable:           true,
 		},
 	}, 0); err != nil {
-		return nil, err
+		return err
 	}
 
 	prog, ok := ebpfProgs[progName]
 	if !ok {
-		return nil, fmt.Errorf("program %q not found after loading", progName)
+		return fmt.Errorf("program %q not found after loading", progName)
 	}
 
-	return tracer.AttachProbe(prog, g.spec)
+	lnk, err := tracer.AttachProbe(prog, g.spec)
+	if err != nil {
+		return err
+	}
+	probeCtx.AddLink(lnk)
+	return nil
 }

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -141,6 +141,7 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
 		metaEnrichers:            metaEnrichers,
+		attachedProbes:           make(map[libpf.PID][]ProbeAttacher),
 	}
 
 	collectInterpreterMetrics(ctx, pm, cfg.MonitorInterval)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -141,7 +141,7 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
 		metaEnrichers:            metaEnrichers,
-		attachedProbes:           make(map[libpf.PID][]ProbeAttacher),
+		attachedProbes:           make(map[libpf.PID]map[ProbeAttacher]libpf.Void),
 	}
 
 	collectInterpreterMetrics(ctx, pm, cfg.MonitorInterval)

--- a/processmanager/probeattacher.go
+++ b/processmanager/probeattacher.go
@@ -10,8 +10,8 @@ import (
 
 // ProbeAttacher is implemented by probes that need to attach to individual processes.
 // ProcessManager calls Match for each new executable mapping; if Match returns true,
-// Attach is called once for that PID (subsequent matching mappings for the same PID
-// are deduplicated — Attach is only ever called once per PID per attacher).
+// Attach is called for that mapping. Attach may therefore be called multiple times for
+// the same PID if the process has more than one matching mapping.
 // Detach is called exactly once per PID when the process exits.
 //
 // Implementations must not call back into ProcessManager during Attach or Detach,
@@ -21,7 +21,7 @@ type ProbeAttacher interface {
 	// given executable mapping. Must be cheap and must not block.
 	Match(pr process.Process, mapping *process.RawMapping) bool
 
-	// Attach is called the first time a matching mapping is seen for a PID.
+	// Attach is called for each matching mapping seen for a PID.
 	// The implementation is responsible for opening and managing per-PID
 	// kernel resources (e.g. a uprobe link restricted to that PID).
 	Attach(pr process.Process) error

--- a/processmanager/probeattacher.go
+++ b/processmanager/probeattacher.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package processmanager // import "go.opentelemetry.io/ebpf-profiler/processmanager"
+
+import (
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+)
+
+// ProbeAttacher is implemented by probes that need to attach to individual processes.
+// ProcessManager calls Match for each new executable mapping; if Match returns true,
+// Attach is called once for that PID (subsequent matching mappings for the same PID
+// are deduplicated — Attach is only ever called once per PID per attacher).
+// Detach is called exactly once per PID when the process exits.
+//
+// Implementations must not call back into ProcessManager during Attach or Detach,
+// as those methods are invoked while the ProcessManager's internal lock is held.
+type ProbeAttacher interface {
+	// Match returns true if this probe wants to attach to a process that has the
+	// given executable mapping. Must be cheap and must not block.
+	Match(pr process.Process, mapping *process.RawMapping) bool
+
+	// Attach is called the first time a matching mapping is seen for a PID.
+	// The implementation is responsible for opening and managing per-PID
+	// kernel resources (e.g. a uprobe link restricted to that PID).
+	Attach(pr process.Process) error
+
+	// Detach is called when a matched process exits. The implementation must
+	// close all per-process resources opened in Attach.
+	Detach(pid libpf.PID)
+}
+
+// RegisterProbeAttacher registers a per-process probe attacher. SynchronizeProcess
+// calls Match for each new executable mapping; Attach is called once for any PID
+// that has at least one matching mapping. Detach is called on process exit.
+func (pm *ProcessManager) RegisterProbeAttacher(a ProbeAttacher) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.probeAttachers = append(pm.probeAttachers, a)
+}

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -224,6 +224,24 @@ func (pm *ProcessManager) handleNewInterpreter(pr process.Process, bias libpf.Ad
 	return anonymousMappingsWanted || instance.UsesAnonymousMappings(), nil
 }
 
+// attachProbesForMapping iterates the registered ProbeAttachers and calls Attach
+// for every attacher whose Match returns true for the given mapping.
+// Attach may therefore be called multiple times for the same attacher if the process
+// has more than one matching mapping. The caller must hold pm.mu for writing.
+func (pm *ProcessManager) attachProbesForMapping(pr process.Process, m *process.RawMapping) {
+	pid := pr.PID()
+	for _, a := range pm.probeAttachers {
+		if !a.Match(pr, m) {
+			continue
+		}
+		if err := a.Attach(pr); err != nil {
+			log.Errorf("Failed to attach probe for PID %d, mapping %s: %v", pid, m.Path, err)
+			continue
+		}
+		pm.attachedProbes[pid] = append(pm.attachedProbes[pid], a)
+	}
+}
+
 func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.RawMapping,
 	elfRef *pfelf.Reference,
 ) elfInfo {
@@ -421,6 +439,7 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapp
 			anonymousMappingsWanted = updatedAnonymousMappingsWanted
 		}
 	}
+	pm.attachProbesForMapping(pr, m)
 	pm.mu.Unlock()
 
 	return libpf.NewFrameMapping(libpf.FrameMappingData{
@@ -494,6 +513,11 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 	}
 	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, deleted)
 	pm.processRemovedInterpreters(pid, libpf.Set[util.OnDiskFileIdentifier]{})
+
+	for _, a := range pm.attachedProbes[pid] {
+		a.Detach(pid)
+	}
+	delete(pm.attachedProbes, pid)
 }
 
 // isInterpreterMapping reports whether a mapping should be passed to interpreter

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -226,7 +226,7 @@ func (pm *ProcessManager) handleNewInterpreter(pr process.Process, bias libpf.Ad
 
 // attachProbesForMapping iterates the registered ProbeAttachers and calls Attach
 // for every attacher whose Match returns true for the given mapping.
-// Attach may therefore be called multiple times for the same attacher if the process
+// Attach may be called multiple times for the same attacher if the process
 // has more than one matching mapping. The caller must hold pm.mu for writing.
 func (pm *ProcessManager) attachProbesForMapping(pr process.Process, m *process.RawMapping) {
 	pid := pr.PID()

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -238,7 +238,10 @@ func (pm *ProcessManager) attachProbesForMapping(pr process.Process, m *process.
 			log.Errorf("Failed to attach probe for PID %d, mapping %s: %v", pid, m.Path, err)
 			continue
 		}
-		pm.attachedProbes[pid] = append(pm.attachedProbes[pid], a)
+		if pm.attachedProbes[pid] == nil {
+			pm.attachedProbes[pid] = make(map[ProbeAttacher]libpf.Void)
+		}
+		pm.attachedProbes[pid][a] = libpf.Void{}
 	}
 }
 
@@ -514,7 +517,7 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, deleted)
 	pm.processRemovedInterpreters(pid, libpf.Set[util.OnDiskFileIdentifier]{})
 
-	for _, a := range pm.attachedProbes[pid] {
+	for a := range pm.attachedProbes[pid] {
 		a.Detach(pid)
 	}
 	delete(pm.attachedProbes, pid)

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -136,10 +136,10 @@ type ProcessManager struct {
 	// RegisterProbeAttacher. Protected by mu.
 	probeAttachers []ProbeAttacher
 
-	// attachedProbes tracks which attachers have been successfully attached to each PID
-	// (as a set, so each attacher is Detach-called exactly once per PID regardless of
-	// how many matching mappings triggered Attach). Protected by mu.
-	attachedProbes map[libpf.PID][]ProbeAttacher
+	// attachedProbes tracks which ProbeAttacher have been successfully attached to each PID.
+	// Using a set ensures each attacher is Detach-called exactly once per PID
+	// regardless of how many matching mappings triggered Attach. Protected by mu.
+	attachedProbes map[libpf.PID]map[ProbeAttacher]libpf.Void
 }
 
 // Mapping represents an executable memory mapping of a process.

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -131,6 +131,15 @@ type ProcessManager struct {
 	filterErrorFrames bool
 
 	metaEnrichers []process.MetaEnricher
+
+	// probeAttachers is the set of per-process probe attachers registered via
+	// RegisterProbeAttacher. Protected by mu.
+	probeAttachers []ProbeAttacher
+
+	// attachedProbes tracks which attachers have been successfully attached to each PID
+	// (as a set, so each attacher is Detach-called exactly once per PID regardless of
+	// how many matching mappings triggered Attach). Protected by mu.
+	attachedProbes map[libpf.PID][]ProbeAttacher
 }
 
 // Mapping represents an executable memory mapping of a process.

--- a/tracer/probes.go
+++ b/tracer/probes.go
@@ -9,6 +9,7 @@ import (
 
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	pm "go.opentelemetry.io/ebpf-profiler/processmanager"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/support"
 )
@@ -16,8 +17,10 @@ import (
 // ProbeContext bundles the tracer's shared state and provides helpers for building eBPF
 // collections inside Probe.Load() implementations.
 type ProbeContext struct {
-	maps    map[string]*cebpf.Map
-	sysVars SysConfigVars
+	maps             map[string]*cebpf.Map
+	sysVars          SysConfigVars
+	links            []link.Link
+	registerAttacher func(pm.ProbeAttacher)
 }
 
 // CollectionSpecWith returns a filtered CollectionSpec built from the tracer's embedded
@@ -222,6 +225,18 @@ func (c *ProbeContext) LoadProbeUnwinders(
 		bpfVerifierLogLevel, perfProgs.FD(), perCPURecords.FD(), perCPURecordsKp)
 }
 
+// AddLink registers a global link to be stored and closed by the tracer on shutdown.
+// Use this for system-wide hooks, like kprobes, perf events and tracepoints.
+func (c *ProbeContext) AddLink(lnk link.Link) {
+	c.links = append(c.links, lnk)
+}
+
+// AddAttacher registers a per-process attacher with the process manager.
+// ProcessManager calls Match/Attach as new mappings appear and Detach on process exit.
+func (c *ProbeContext) AddAttacher(a pm.ProbeAttacher) {
+	c.registerAttacher(a)
+}
+
 // ProbeRegistrar lets a Probe register one or more origin IDs during Load.
 // Each call to Register allocates a unique ID backed by the supplied metadata;
 type ProbeRegistrar interface {
@@ -230,16 +245,16 @@ type ProbeRegistrar interface {
 
 // Probe defines the interface that allows custom stack unwinding trigger points.
 type Probe interface {
-	// Load attaches a probe that triggers stack unwinding.
-	// The probe calls reg.Register for each origin ID it needs, then uses
-	// those IDs when configuring its eBPF programs.
-	// Returns the link that keeps the probe attached; the caller owns its lifetime.
-	Load(ctx context.Context, reg ProbeRegistrar, probeCtx *ProbeContext) (link.Link, error)
+	// Load configures the probe. It registers one or more origin IDs via reg,
+	// then registers its kernel attachment via probeCtx: call AddLink for a
+	// system-wide hook, or AddAttacher for per-process PID-filtered attachment.
+	Load(ctx context.Context, reg ProbeRegistrar, probeCtx *ProbeContext) error
 }
 
-// Enable builds a ProbeContext from the tracer's current state and calls p.Load,
-// which is responsible for registering its own origin IDs via the supplied
-// ProbeRegistrar. The returned links are stored and closed when the tracer shuts down.
+// Enable builds a ProbeContext from the tracer's current state and calls p.Load.
+// Links registered via AddLink are stored and closed on tracer shutdown. Attachers
+// registered via AddAttacher receive per-process lifecycle callbacks from the
+// ProcessManager.
 //
 // Enable requires that the kprobe tail-call unwinder chain was loaded at tracer
 // startup, which happens when off-CPU profiling is enabled (OffCPUThreshold > 0).
@@ -258,22 +273,28 @@ func (t *Tracer) Enable(ctx context.Context, p Probe) error {
 	probeCtx := &ProbeContext{
 		maps:    t.ebpfMaps,
 		sysVars: t.sysConfigVars,
+		registerAttacher: func(a pm.ProbeAttacher) {
+			t.processManager.RegisterProbeAttacher(a)
+		},
 	}
 
-	lnk, err := p.Load(ctx, t.origins, probeCtx)
-	if err != nil {
+	if err := p.Load(ctx, t.origins, probeCtx); err != nil {
 		return fmt.Errorf("failed to load probe: %w", err)
 	}
 
-	if lnk != nil {
-		key := hookPoint{group: "probe", name: fmt.Sprintf("%p", p)}
+	if len(probeCtx.links) > 0 {
 		h := t.hooks.WLock()
 		if h.closed {
 			t.hooks.WUnlock(&h)
-			lnk.Close()
+			for _, lnk := range probeCtx.links {
+				lnk.Close()
+			}
 			return fmt.Errorf("tracer is already closed")
 		}
-		h.m[key] = lnk
+		for i, lnk := range probeCtx.links {
+			key := hookPoint{group: "probe", name: fmt.Sprintf("%p/%d", p, i)}
+			h.m[key] = lnk
+		}
 		t.hooks.WUnlock(&h)
 	}
 	return nil

--- a/tracer/probes.go
+++ b/tracer/probes.go
@@ -265,11 +265,6 @@ type Probe interface {
 // subsequently fails; they cannot be reclaimed.
 // Enable returns an error if the tracer has already been closed.
 func (t *Tracer) Enable(ctx context.Context, p Probe) error {
-	if !t.kprobeChainLoaded {
-		return fmt.Errorf("Enable requires the kprobe unwinder chain to be loaded at startup: " +
-			"enable off-CPU profiling (OffCPUThreshold > 0) to load the chain")
-	}
-
 	probeCtx := &ProbeContext{
 		maps:    t.ebpfMaps,
 		sysVars: t.sysConfigVars,

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -143,11 +143,6 @@ type Tracer struct {
 	// to custom probes via Enable so they can reference the same layout.
 	sysConfigVars SysConfigVars
 
-	// kprobeChainLoaded records whether the kprobe tail-call unwinder chain was
-	// loaded at startup. Enable requires this; without it a custom probe's tail
-	// calls into kprobe_progs silently miss at runtime.
-	kprobeChainLoaded bool
-
 	// origins is the tracer-wide registry origin IDs are assigned from and
 	// profile type metadata is looked up by.
 	origins *originRegistry
@@ -327,7 +322,6 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		done:                   make(chan libpf.Void),
 		origins:                origins,
 		sysConfigVars:          sysConfigVars,
-		kprobeChainLoaded:      kprobeChainRequired(cfg),
 	}
 
 	return tracer, nil
@@ -355,13 +349,6 @@ func (t *Tracer) Close() {
 	t.processManager.Close()
 	t.kernelSymbolizer.Close()
 	t.signalDone()
-}
-
-// kprobeChainRequired reports whether the kprobe tail-call unwinder chain must be loaded.
-// It is the single source of truth consulted both during initialization and when recording
-// kprobeChainLoaded on the Tracer.
-func kprobeChainRequired(cfg *Config) bool {
-	return cfg.OffCPUThreshold > 0
 }
 
 // initializeMapsAndPrograms loads the definitions for the eBPF maps and programs provided
@@ -509,16 +496,14 @@ func initializeMapsAndPrograms(kmod *kallsyms.Module, cfg *Config, origins *orig
 		return nil, nil, nil, fmt.Errorf("failed to load perf eBPF programs: %v", err)
 	}
 
-	if kprobeChainRequired(cfg) {
-		// Load the tail call destinations if any kind of event profiling is enabled.
-		// loadProbeUnwinders repoints the probe unwinder's per_cpu_records references
-		// to per_cpu_records_kp so a perf sampler can't clobber an in-flight uprobe unwind;
-		// the perf unwinder keeps per_cpu_records.
-		if err = loadProbeUnwinders(coll, ebpfProgs, ebpfMaps["kprobe_progs"], tailCallProgs,
-			cfg.BPFVerifierLogLevel, ebpfMaps["perf_progs"].FD(),
-			ebpfMaps["per_cpu_records"].FD(), ebpfMaps["per_cpu_records_kp"]); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load kprobe eBPF programs: %v", err)
-		}
+	// Load the tail call destinations if any kind of event profiling is enabled.
+	// loadProbeUnwinders repoints the probe unwinder's per_cpu_records references
+	// to per_cpu_records_kp so a perf sampler can't clobber an in-flight uprobe unwind;
+	// the perf unwinder keeps per_cpu_records.
+	if err = loadProbeUnwinders(coll, ebpfProgs, ebpfMaps["kprobe_progs"], tailCallProgs,
+		cfg.BPFVerifierLogLevel, ebpfMaps["perf_progs"].FD(),
+		ebpfMaps["per_cpu_records"].FD(), ebpfMaps["per_cpu_records_kp"]); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to load kprobe eBPF programs: %v", err)
 	}
 
 	if cfg.OffCPUThreshold > 0 {


### PR DESCRIPTION
As the Probes API matures to handle broader use cases, the existing contract of `Load(...) (link.Link, error)` of the `tracer.Probe` interface is no longer sufficient.

Specifically, it creates friction in two primary scenarios:

- Multiple hooks per probe: While existing features like off-CPU profiling manage to work around the single-link return constraint, the implementations are clunky and introduce unnecessary limitations.

- Per-process probes: Transitioning from strictly system-wide hooks to per-process attachment requires a design capable of managing multiple link instances or broader lifetime scopes.

This patch refactors the `Load()` signature to eliminate these constraints and cleanly accommodate both multi-hook attachment and per-process target scoping.



`processmanager.ProbeAttacher` is cherry-picked for that purpose from https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1693 and https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1744.