### PR TITLE
procmeta: add a ResourceEnricher interface

### DIFF
--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -8,6 +8,7 @@ package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 import (
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
 
@@ -18,6 +19,7 @@ type Option interface {
 type controllerOption struct {
 	executableReporter   reporter.ExecutableReporter
 	processMetaEnrichers []process.MetaEnricher
+	resourceEnrichers    []procmeta.ResourceEnricher
 	reporterFactory      func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)
 	onShutdown           func() error
 }
@@ -59,6 +61,19 @@ func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer
 func WithProcessMetaEnricher(enrichers ...process.MetaEnricher) Option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.processMetaEnrichers = append(option.processMetaEnrichers, enrichers...)
+		return option
+	})
+}
+
+// WithResourceEnricher registers a hook contributing OTel resource attributes to a
+// process. Unlike WithProcessMetaEnricher it runs on every mapping
+// resynchronization, so it can supply attributes that resolve after first
+// observation: a memory region published later, a runtime whose interpreter
+// attaches. It declares what it needs through procmeta.ResourceConfig, and its
+// contribution is merged into the resource of that process's profiles.
+func WithResourceEnricher(enrichers ...procmeta.ResourceEnricher) Option {
+	return optFunc(func(option *controllerOption) *controllerOption {
+		option.resourceEnrichers = append(option.resourceEnrichers, enrichers...)
 		return option
 	})
 }

--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -76,6 +76,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 			Config:               *cfg,
 			ExecutableReporter:   controllerOption.executableReporter,
 			ProcessMetaEnrichers: controllerOption.processMetaEnrichers,
+			ResourceEnrichers:    controllerOption.resourceEnrichers,
 			ReporterFactory:      controllerOption.reporterFactory,
 			OnShutdown:           controllerOption.onShutdown,
 		}

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/collector/config"
@@ -24,7 +25,12 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery and executable change time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
-	OnShutdown           func() error
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process. They are called on every process synchronization,
+	// so they can supply attributes that resolve later than process discovery.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
+	OnShutdown        func() error
 
 	// If ReporterFactory is set, it will be used to create a Reporter and set it as the Reporter field.
 	// Either ReporterFactory or Reporter must be set. If both are set, ReporterFactory will be used.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -109,6 +109,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		OBIProcessCtx:           c.config.OBIProcessCtx,
 		PIDNamespaceTranslation: c.config.PIDNamespaceTranslation,
 		ProcessMetaEnrichers:    c.config.ProcessMetaEnrichers,
+		ResourceEnrichers:       c.config.ResourceEnrichers,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load eBPF tracer: %w", err)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -71,6 +72,20 @@ type Config struct {
 	FilterErrorFrames     bool
 	IncludeEnvVars        libpf.Set[string]
 	ProcessMetaEnrichers  []process.MetaEnricher
+	ResourceEnrichers     []procmeta.ResourceEnricher
+}
+
+// newMappingFilters resolves each enricher's mapping requirements once, so the
+// mapping pass need not re-read them, pairing every non-nil filter with the index of
+// the enricher that declared it — the index the selected mappings are delivered by.
+func newMappingFilters(enrichers []procmeta.ResourceEnricher) []mappingFilter {
+	var filters []mappingFilter
+	for i, e := range enrichers {
+		if want := e.ResourceConfig().WantMapping; want != nil {
+			filters = append(filters, mappingFilter{enricher: i, want: want})
+		}
+	}
+	return filters
 }
 
 // New creates a new ProcessManager which is responsible for keeping track of loading
@@ -82,6 +97,9 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 	if cfg.FrameCacheSize == 0 {
 		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
+
+	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
+	mappingFilters := newMappingFilters(resourceEnrichers)
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
 		util.OnDiskFileIdentifier.Hash32)
@@ -141,6 +159,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
 		metaEnrichers:            metaEnrichers,
+		resourceEnrichers:        resourceEnrichers,
+		mappingFilters:           mappingFilters,
 		attachedProbes:           make(map[libpf.PID]map[ProbeAttacher]libpf.Void),
 	}
 
@@ -379,7 +399,7 @@ func hashFrameCacheKey(fk frameCacheKey) uint32 {
 // trace handling to a goroutine pool, the caching strategy needs to be updated
 // accordingly.
 func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *samples.TypeMetadata) {
-	procMeta := pm.metaForPID(bpfTrace.PID)
+	procMeta, resource := pm.metaForPID(bpfTrace.PID)
 	meta := &samples.TraceEventMeta{
 		Timestamp:      libpf.UnixTime64(times.KTime(bpfTrace.KTime).UnixNano()),
 		Comm:           bpfTrace.Comm,
@@ -392,6 +412,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *sa
 		ProfileType:    profileType,
 		Value:          bpfTrace.Value,
 		EnvVars:        procMeta.EnvVariables,
+		Resource:       resource,
 		TraceID:        bpfTrace.APMTraceID,
 		SpanID:         bpfTrace.APMTransactionID,
 		ExtraMeta:      procMeta.ExtraMeta,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"golang.org/x/sys/unix"
 
@@ -33,6 +34,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/processcontext"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -120,15 +122,19 @@ func (pm *ProcessManager) getLibcInfo(pid libpf.PID) *libc.LibcInfo {
 // metadata is gathered (including configured process MetaEnrichers) without
 // the processmanager lock held.
 //
+// created reports whether this call created the processInfo, i.e. the first
+// observation of the process. That is the lifecycle signal to use: a process may be
+// synchronized many times without ever retaining a mapping.
+//
 // Returns nil on failure.
 // Caller must not hold the pm.mu lock.
 func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
-	pr process.Process) *processInfo {
+	pr process.Process) (info *processInfo, created bool) {
 	pm.mu.RLock()
 	info, ok := pm.pidToProcessInfo[pid]
 	pm.mu.RUnlock()
 	if ok {
-		return info
+		return info, false
 	}
 
 	// Gather metadata without holding the processmanager lock:
@@ -140,21 +146,80 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 
 	// Check if another goroutine registered the PID in-between.
 	if info, ok = pm.pidToProcessInfo[pid]; ok {
-		return info
+		return info, false
 	}
 
 	if err := pm.ebpf.UpdatePidPageMappingInfo(pid, dummyPrefix, 0, 0); err != nil {
-		return nil
+		return nil, false
 	}
 
 	pm.pidPageToMappingInfoSize++
 	info = &processInfo{
 		meta:     meta,
 		libcInfo: nil,
+		// Sole allocation site of the slots, so they are always as long as the
+		// registered enrichers, which index them.
+		contributions: make([]*pcommon.Resource, len(pm.resourceEnrichers)),
+		enricherState: make([]any, len(pm.resourceEnrichers)),
 	}
 	pm.pidToProcessInfo[pid] = info
 
-	return info
+	return info, true
+}
+
+// enrichResources runs the resource enrichers for a process and publishes the merge
+// of their contributions. One that reports no change keeps its previous
+// contribution, so data that has become unreadable is not lost.
+//
+// Caller must not hold pm.mu: enrichers run arbitrary code and read /proc and
+// remote process memory.
+func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
+	interpreters map[util.OnDiskFileIdentifier]interpreter.Instance,
+	enricherMappings [][]process.RawMapping, newProcessOrExec bool,
+) {
+	if info == nil || len(pm.resourceEnrichers) == 0 {
+		return
+	}
+
+	// Only meta and resource are read from another goroutine (metaForPID); the slots
+	// belong to the synchronizing one. So the enrichers update the slots in place,
+	// and pm.mu is taken once, to publish resource.
+	if newProcessOrExec {
+		// Nothing derived from the replaced program can carry over: "no change" means
+		// "my contribution still holds", which after an exec it cannot. Otherwise an
+		// enricher resolving nothing for the new executable would keep the old
+		// program's attributes, and a fill-once one would never look again.
+		clear(info.contributions)
+		clear(info.enricherState)
+	}
+
+	req := procmeta.ResourceRequest{
+		Process:      pr,
+		Interpreters: interpreters,
+	}
+
+	// A new or execed process starts from cleared state, so the merge is due even if
+	// no enricher reports a change.
+	changed := newProcessOrExec
+	for i, e := range pm.resourceEnrichers {
+		if enricherMappings != nil {
+			req.Mappings = enricherMappings[i]
+		}
+		req.State = &info.enricherState[i]
+		if res, ok := e.EnrichResource(&req); ok {
+			info.contributions[i] = res
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+
+	merged := procmeta.MergeResources(nil, info.contributions)
+
+	pm.mu.Lock()
+	info.resource = merged
+	pm.mu.Unlock()
 }
 
 // assignInterpreter will update the interpreters maps with given interpreter.Instance.
@@ -601,13 +666,16 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		// the case of main thread exit. Ignore it.
 	}
 
-	info := pm.getOrCreateProcessInfo(pid, pr)
+	info, firstObservation := pm.getOrCreateProcessInfo(pid, pr)
 	if info == nil {
 		return
 	}
 
 	pm.mu.Lock()
-	// Check if process meta needs an update
+	// Check if process meta needs an update. execve preserves the tgid, so a
+	// re-exec of the same path is invisible here and leaves env vars and the
+	// process context unrefreshed. Detecting it needs a sched_process_exec
+	// tracepoint.
 	updateProcessMeta := exe != libpf.NullString && exe != info.meta.Executable
 	oldProcessContextInfo := info.meta.ProcessContextInfo
 
@@ -645,10 +713,21 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	capHint := max(32, min(len(oldMappings), 256))
 	mappings := make([]Mapping, 0, capHint)
 	mpAdd := make([]*Mapping, 0, capHint)
-	var processContextInfo processcontext.Info
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
+
+	// enricherMappings collects, per enricher, the mappings its filter selected, and
+	// is nil when none wants any. The filters are hoisted so the callback below,
+	// which runs once per mapping, captures a slice header instead of reaching
+	// through pm each iteration.
+	mappingFilters := pm.mappingFilters
+	var enricherMappings [][]process.RawMapping
+	if len(mappingFilters) > 0 {
+		enricherMappings = make([][]process.RawMapping, len(pm.resourceEnrichers))
+	}
+
+	var processContextInfo processcontext.Info
 
 	// This callback processes each memory mapping, keeping only executable
 	// file-backed mappings and executable/prctl-named anonymous or DLL mappings
@@ -660,6 +739,15 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			processContextInfo = readProcessContext(m.Vaddr, pr, oldProcessContextInfo)
 			// The eBPF hook on prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME) will trigger a
 			// PID resynchronization when the process names its context mapping "OTEL_CTX".
+		}
+
+		for _, f := range mappingFilters {
+			if f.want(&m) {
+				// Detach Path from the recycled scanner buffer before storing.
+				selected := m
+				selected.Path = libpf.Intern(selected.Path).String()
+				enricherMappings[f.enricher] = append(enricherMappings[f.enricher], selected)
+			}
 		}
 
 		interpreterMapping := isInterpreterMapping(&m)
@@ -793,17 +881,27 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	// Sort and publish the new mappings and meta.
 	slices.SortFunc(mappings, compareMapping)
 
-	info = pm.getOrCreateProcessInfo(pid, pr)
+	// A concurrent ProcessedUntil may have dropped the processInfo since this
+	// synchronization started; recreating it starts from empty enricher state.
+	info, recreated := pm.getOrCreateProcessInfo(pid, pr)
 	pm.mu.Lock()
 	if info != nil {
 		info.mappings = mappings
 		if updateProcessMeta {
 			info.meta = meta
+			// Reset resource to nil to avoid pairing the replaced program's samples with
+			// the old one.
+			info.resource = nil
 		}
 		info.meta.ProcessContextInfo = processContextInfo
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()
+
+	// Contribute resource attributes, now that the mappings and the interpreters
+	// attached this round are known.
+	pm.enrichResources(pr, info, interpreters, enricherMappings,
+		updateProcessMeta || firstObservation || recreated)
 
 	// Synchronize all interpreters with updated mappings
 	for _, instance := range interpreters {
@@ -862,14 +960,15 @@ func (pm *ProcessManager) CleanupPIDs() {
 	}
 }
 
-// metaForPID returns the process metadata for given PID.
-func (pm *ProcessManager) metaForPID(pid libpf.PID) process.Meta {
+// metaForPID returns a consistent snapshot of a PID's metadata and of the resource
+// the enrichers contributed for it.
+func (pm *ProcessManager) metaForPID(pid libpf.PID) (process.Meta, *pcommon.Resource) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		return procInfo.meta
+		return procInfo.meta, procInfo.resource
 	}
-	return process.Meta{}
+	return process.Meta{}, nil
 }
 
 // findMappingForTrace locates the mapping for a given host trace.

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libc"
@@ -19,6 +20,7 @@ import (
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -161,7 +163,7 @@ func (tp *testProcess) GetMachineData() process.MachineData {
 func (tp *testProcess) GetProcessMeta(enrichers []process.MetaEnricher) process.Meta {
 	meta := process.Meta{Executable: tp.exe}
 	for _, e := range enrichers {
-		e.EnrichMeta(fmt.Sprintf("/proc/%d", tp.pid), &meta)
+		e.EnrichMeta(fmt.Sprintf("/proc/%d/", tp.pid), &meta)
 	}
 	return meta
 }
@@ -570,22 +572,17 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	enricherCalls := 0
 	enricher := process.MetaEnricherFunc(func(procBase string, meta *process.Meta) {
 		enricherCalls++
-		require.Equal(fmt.Sprintf("/proc/%d", pid), procBase)
+		require.Equal(fmt.Sprintf("/proc/%d/", pid), procBase)
 		meta.ExtraMeta = map[libpf.String]string{key: meta.Executable.String()}
 	})
 
-	pm := &ProcessManager{
-		ebpf:             &testEbpfHandler{},
-		interpreters:     make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
-		pidToProcessInfo: make(map[libpf.PID]*processInfo),
-		exitEvents:       make(map[libpf.PID]times.KTime),
-		metaEnrichers:    []process.MetaEnricher{enricher},
-	}
+	pm := newTestProcessManager([]process.MetaEnricher{enricher}, nil)
 
 	// Process first seen: gather and enrich metadata.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
 	require.Equal(1, enricherCalls)
-	require.Equal("foobar", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ := pm.metaForPID(pid)
+	require.Equal("foobar", meta.ExtraMeta[key])
 
 	// Unchanged executable: don't refetch metadata, don't enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
@@ -594,5 +591,405 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	// Executable changed: refetch metadata and enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobarbaz")})
 	require.Equal(2, enricherCalls)
-	require.Equal("foobarbaz", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ = pm.metaForPID(pid)
+	require.Equal("foobarbaz", meta.ExtraMeta[key])
+}
+
+// testResourceEnricher is a ResourceEnricher whose behaviour each test controls
+// through enrich.
+type testResourceEnricher struct {
+	cfg    procmeta.ResourceConfig
+	calls  int
+	reqs   []procmeta.ResourceRequest
+	enrich func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool)
+}
+
+func (e *testResourceEnricher) ResourceConfig() procmeta.ResourceConfig {
+	return e.cfg
+}
+
+func (e *testResourceEnricher) EnrichResource(req *procmeta.ResourceRequest) (
+	*pcommon.Resource, bool,
+) {
+	e.calls++
+	e.reqs = append(e.reqs, *req)
+	if e.enrich == nil {
+		return nil, false
+	}
+	return e.enrich(req, e.calls)
+}
+
+// resourceWithAttr builds a single-attribute resource.
+func resourceWithAttr(key, value string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	r.Attributes().PutStr(key, value)
+	return &r
+}
+
+// resourceAttrs flattens a resource's string attributes, or returns nil.
+func resourceAttrs(r *pcommon.Resource) map[string]string {
+	if r == nil {
+		return nil
+	}
+	attrs := make(map[string]string, r.Attributes().Len())
+	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+		attrs[k] = v.Str()
+		return true
+	})
+	return attrs
+}
+
+func newTestProcessManager(metaEnrichers []process.MetaEnricher,
+	resourceEnrichers []procmeta.ResourceEnricher,
+) *ProcessManager {
+	return &ProcessManager{
+		ebpf:              &testEbpfHandler{},
+		interpreters:      make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
+		pidToProcessInfo:  make(map[libpf.PID]*processInfo),
+		exitEvents:        make(map[libpf.PID]times.KTime),
+		metaEnrichers:     metaEnrichers,
+		resourceEnrichers: resourceEnrichers,
+		mappingFilters:    newMappingFilters(resourceEnrichers),
+	}
+}
+
+// TestSynchronizeProcessRunsResourceEnrichers verifies that resource enrichers run
+// on every synchronization, unlike meta enrichers, so attributes resolving after
+// first observation are still picked up.
+func TestSynchronizeProcessRunsResourceEnrichers(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	// Contributes nothing on the first call, then an attribute on the second, as a
+	// late-resolving enricher would.
+	enricher := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				return nil, false
+			}
+			return resourceWithAttr("late.attr", "resolved"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(1, enricher.calls)
+	_, resource := pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Equal(pid, enricher.reqs[0].Process.PID())
+
+	// Same executable: the meta enrichers would not run, but this one does.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(2, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting no change keeps the published contribution.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, false
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(3, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting a change with a nil resource withdraws it.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, true
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptUntilExec verifies that derived
+// state is kept across synchronizations of one program and dropped on the one after
+// an exec — an empty slot being the whole signal an enricher gets, and needs.
+func TestSynchronizeProcessResourceEnricherStateKeptUntilExec(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	// The state each call was handed, which is how the exec handling is observable.
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Seed a known process with a mapping the sync below can match and reuse, which
+	// keeps it out of the ELF-parsing path that needs a fuller ProcessManager.
+	rawMapping := process.RawMapping{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R | elf.PF_X,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}
+	pm.pidToProcessInfo[pid] = &processInfo{
+		meta: process.Meta{Executable: exe},
+		mappings: []Mapping{{
+			Vaddr:  libpf.Address(rawMapping.Vaddr),
+			Length: rawMapping.Length,
+			Device: rawMapping.Device,
+			Inode:  rawMapping.Inode,
+			FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
+				File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+					FileID:   libpf.NewFileID(1, 0),
+					FileName: libpf.Intern("foobar"),
+				}),
+				Start: 0,
+				End:   libpf.Address(rawMapping.Length),
+			}),
+		}},
+		contributions: make([]*pcommon.Resource, 1),
+		enricherState: make([]any, 1),
+	}
+
+	// Known process, unchanged executable: what the previous call stored is still
+	// there, the seeded record included.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{rawMapping}}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]any{nil, 1}, seen)
+
+	// Executable changed: the state derived from the program that is gone goes too.
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid, exe: libpf.Intern("/bin/other"),
+		mappings: []process.RawMapping{rawMapping},
+	})
+	require.Equal([]any{nil, 1, nil}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings verifies that a
+// process retaining no mapping keeps its derived state all the same. Retained
+// mappings say nothing about the lifecycle — a fully JIT-compiled process keeps
+// none — and looking execed every sync would resolve fill-once enrichers forever.
+func TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Non-executable, so no mapping is retained for the process.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}}}
+
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+
+	pm.mu.RLock()
+	mappings := pm.pidToProcessInfo[pid].mappings
+	pm.mu.RUnlock()
+	require.Empty(mappings)
+
+	// New once, on first observation, and never again.
+	require.Equal([]any{nil, 1, 2}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherExecDropsContributions verifies that an exec
+// drops what the enrichers derived from the previous program. Otherwise an enricher
+// resolving nothing for the new executable — runtime info once a Python process
+// execs a native binary — would keep the old attributes indefinitely.
+func TestSynchronizeProcessResourceEnricherExecDropsContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				*req.State = "resolved"
+				return resourceWithAttr("process.runtime.name", "cpython"), true
+			}
+			// Nothing to report for the new executable.
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"process.runtime.name": "cpython"}, resourceAttrs(resource))
+
+	// Exec: the contribution and the state derived from the old program go.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Nil(*enricher.reqs[1].State)
+}
+
+// TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource verifies that a
+// replaced program's resource is never readable beside the new executable's
+// metadata, which is published before the enrichers run and the resource after. An
+// enricher runs in exactly that window, so it can observe what a trace would see.
+func TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	type observation struct {
+		exe      string
+		resource *pcommon.Resource
+	}
+	var observed []observation
+
+	enricher := &testResourceEnricher{}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		meta, resource := pm.metaForPID(pid)
+		observed = append(observed, observation{meta.Executable.String(), resource})
+		// Identify the program, so a contribution carried across the exec shows up.
+		return resourceWithAttr("exe", meta.Executable.String()), true
+	}
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/python3"}, resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/native"}, resourceAttrs(resource))
+
+	require.Len(observed, 2)
+	// First observation: the process has no resource yet.
+	require.Equal("/usr/bin/python3", observed[0].exe)
+	require.Nil(observed[0].resource)
+	// Second: metadata is already the new program's, so the old resource is gone.
+	require.Equal("/usr/bin/native", observed[1].exe)
+	require.Nil(observed[1].resource)
+}
+
+// TestSynchronizeProcessMergesResourceContributions verifies that contributions
+// from several enrichers are merged, with later enrichers winning on key
+// collisions, and that each enricher's contribution is tracked independently.
+func TestSynchronizeProcessMergesResourceContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	first := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			r := pcommon.NewResource()
+			r.Attributes().PutStr("shared", "first")
+			r.Attributes().PutStr("only.first", "1")
+			return &r, true
+		},
+	}
+	second := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			// Contribute only on the first call, to check the stored contribution
+			// still takes part in later merges.
+			if call > 1 {
+				return nil, false
+			}
+			return resourceWithAttr("shared", "second"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{first, second})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+}
+
+// TestSynchronizeProcessResourceEnricherState verifies that per-process enricher
+// state survives across synchronizations and is dropped, and closed, on exit.
+func TestSynchronizeProcessResourceEnricherState(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	var seen []int
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			state, _ := (*req.State).(*testEnricherState)
+			if state == nil {
+				state = &testEnricherState{}
+				*req.State = state
+			}
+			state.counter++
+			seen = append(seen, state.counter)
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	proc := &testProcess{pid: pid, exe: libpf.Intern("foobar")}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3}, seen)
+
+	pm.mu.RLock()
+	state, _ := pm.pidToProcessInfo[pid].enricherState[0].(*testEnricherState)
+	pm.mu.RUnlock()
+	require.NotNil(state)
+
+	// Process exit drops the state along with the processInfo holding it.
+	pm.processPIDExit(pid)
+	pm.ProcessedUntil(times.GetKTime())
+
+	pm.mu.RLock()
+	_, tracked := pm.pidToProcessInfo[pid]
+	pm.mu.RUnlock()
+	require.False(tracked)
+
+	// A process observed again under the same PID starts from empty state.
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3, 1}, seen)
+}
+
+type testEnricherState struct {
+	counter int
+}
+
+// TestSynchronizeProcessResourceEnricherMappings verifies that only the mappings
+// an enricher's WantMapping filter selects are delivered to it, and that each
+// enricher gets its own selection.
+func TestSynchronizeProcessResourceEnricherMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	wantsNamed := &testResourceEnricher{
+		cfg: procmeta.ResourceConfig{
+			WantMapping: func(m *process.RawMapping) bool { return m.Path == "[anon:MY_REGION]" },
+		},
+	}
+	wantsNothing := &testResourceEnricher{}
+	pm := newTestProcessManager(nil,
+		[]procmeta.ResourceEnricher{wantsNamed, wantsNothing})
+
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid,
+		exe: libpf.Intern("foobar"),
+		mappings: []process.RawMapping{
+			{Vaddr: 0x1000, Flags: elf.PF_R, Path: "/bin/foobar"},
+			{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+			{Vaddr: 0x3000, Flags: elf.PF_R | elf.PF_W},
+		},
+	})
+
+	require.Len(wantsNamed.reqs, 1)
+	require.Equal([]process.RawMapping{
+		{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+	}, wantsNamed.reqs[0].Mappings)
+
+	require.Len(wantsNothing.reqs, 1)
+	require.Empty(wantsNothing.reqs[0].Mappings)
 }

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	lru "github.com/elastic/go-freelru"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -132,6 +134,16 @@ type ProcessManager struct {
 
 	metaEnrichers []process.MetaEnricher
 
+	// resourceEnrichers contribute OTel resource attributes on every process
+	// synchronization. Their index is the index into processInfo.contributions
+	// and processInfo.enricherState.
+	resourceEnrichers []procmeta.ResourceEnricher
+
+	// mappingFilters holds the non-nil WantMapping filters of resourceEnrichers,
+	// in the same order, so the mapping pass can dispatch without re-reading each
+	// enricher's config. Empty when no enricher wants mappings.
+	mappingFilters []mappingFilter
+
 	// probeAttachers is the set of per-process probe attachers registered via
 	// RegisterProbeAttacher. Protected by mu.
 	probeAttachers []ProbeAttacher
@@ -168,11 +180,26 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 	}
 }
 
+// mappingFilter pairs a WantMapping predicate with the enricher that declared it.
+type mappingFilter struct {
+	enricher int
+	want     func(m *process.RawMapping) bool
+}
+
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
 	// process metadata, updated on executable changes
 	meta process.Meta
+	// resource is the merge of the contributions, published under ProcessManager.mu
+	// and immutable once it is. Nil until something contributes.
+	resource *pcommon.Resource
+	// contributions holds each enricher's latest contribution, indexed by
+	// ProcessManager.resourceEnrichers. Entries are immutable once stored.
+	contributions []*pcommon.Resource
+	// enricherState holds each enricher's per-process state, indexed the same way.
+	// Dropped, with no teardown call, when the process exits.
+	enricherState []any
 	// executable mappings sorted by FileID and mapping start address
 	mappings []Mapping
 	// C-library Thread Specific Data information

--- a/procmeta/procmeta.go
+++ b/procmeta/procmeta.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package procmeta provides the extension point for contributing OTel resource
+// attributes to a profiled process.
+//
+// It complements process.MetaEnricher, which collects metadata once when a process
+// is first observed. Attributes that resolve later — a memory region published
+// after startup, a runtime whose interpreter attaches once its mapping appears —
+// need a ResourceEnricher, called on every resynchronization, contributing an
+// immutable resource rather than writing to shared metadata.
+package procmeta // import "go.opentelemetry.io/ebpf-profiler/procmeta"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/util"
+)
+
+// ResourceConfig declares what a ResourceEnricher needs. The zero value asks for
+// nothing; new requirements are added as new fields.
+type ResourceConfig struct {
+	// WantMapping selects the mappings delivered in ResourceRequest.Mappings, nil
+	// selecting none. Called for every mapping of every synchronized process, so it
+	// must be cheap: no allocation, no syscalls.
+	WantMapping func(m *process.RawMapping) bool
+}
+
+// ResourceRequest describes a process and what the process manager observed for it
+// this synchronization. Valid only for the duration of the EnrichResource call:
+// enrichers must not retain it, or anything reachable from it.
+type ResourceRequest struct {
+	// Process gives access to remote memory, mappings and the executable.
+	Process process.Process
+
+	// Mappings holds the mappings selected by ResourceConfig.WantMapping, in
+	// /proc/<pid>/maps order.
+	Mappings []process.RawMapping
+
+	// Interpreters holds the instances attached to the process, keyed by the on-disk
+	// identity of the DSO each was detected in, and is nil until one attaches.
+	// Read-only: driving the instances belongs to the process manager.
+	Interpreters map[util.OnDiskFileIdentifier]interpreter.Instance
+
+	// State points at the manager's per-process storage slot for this enricher:
+	// *State is what the previous call stored, nil on the first. Keep per-process
+	// state here rather than in enricher-owned maps, so it is dropped with the
+	// process. Storage, not a lifecycle — the value is dropped with no teardown
+	// call, so it must not own anything needing an explicit release.
+	State *any
+}
+
+// ResourceEnricher contributes OTel resource attributes for a process.
+type ResourceEnricher interface {
+	// ResourceConfig returns the enricher's requirements. It is called once, when
+	// the enricher is registered.
+	ResourceConfig() ResourceConfig
+
+	// EnrichResource returns the enricher's contribution for the process described
+	// by req, freshly built and treated as immutable by the caller, which retains it
+	// across synchronizations.
+	//
+	// changed reports whether it differs from the previous call's: false keeps the
+	// stored contribution and ignores res, (nil, true) withdraws it. Withdrawing a
+	// process's last contribution takes effect at the next reporting period, since
+	// samples already collected keep the attribution they were collected with.
+	//
+	// A first call, and the one after an exec, arrive with State and the stored
+	// contribution already dropped, so an execed process needs no special handling:
+	// it looks exactly like one never seen before.
+	EnrichResource(req *ResourceRequest) (res *pcommon.Resource, changed bool)
+}
+
+// MergeResources combines a base resource with enricher contributions, applied in
+// order, so a contribution wins over the base and a later one over an earlier one
+// on key collisions. Any input may be nil.
+//
+// Returns nil if all are nil, and shares a single non-nil input as-is: inputs are
+// immutable, so copying is unnecessary.
+func MergeResources(base *pcommon.Resource,
+	contributions []*pcommon.Resource,
+) *pcommon.Resource {
+	count, single := 0, base
+	if base != nil {
+		count = 1
+	}
+	for _, c := range contributions {
+		if c != nil {
+			count++
+			single = c
+		}
+	}
+	if count <= 1 {
+		return single
+	}
+
+	merged := pcommon.NewResource()
+	attrs := merged.Attributes()
+	add := func(r *pcommon.Resource) {
+		if r == nil {
+			return
+		}
+		r.Attributes().Range(func(k string, v pcommon.Value) bool {
+			v.CopyTo(attrs.PutEmpty(k))
+			return true
+		})
+	}
+	add(base)
+	for _, c := range contributions {
+		add(c)
+	}
+	return &merged
+}

--- a/procmeta/procmeta_test.go
+++ b/procmeta/procmeta_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// resourceWith builds a resource from string attributes.
+func resourceWith(attrs map[string]string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	for k, v := range attrs {
+		r.Attributes().PutStr(k, v)
+	}
+	return &r
+}
+
+func TestMergeResources(t *testing.T) {
+	tests := map[string]struct {
+		base          *pcommon.Resource
+		contributions []*pcommon.Resource
+		expected      map[string]string
+		expectNil     bool
+	}{
+		"no contributions": {
+			contributions: nil,
+			expectNil:     true,
+		},
+		"all nil": {
+			contributions: []*pcommon.Resource{nil, nil},
+			expectNil:     true,
+		},
+		"base only": {
+			base:     resourceWith(map[string]string{"a": "1"}),
+			expected: map[string]string{"a": "1"},
+		},
+		"contribution wins over base": {
+			base: resourceWith(map[string]string{"a": "from-base", "c": "3"}),
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "contributed"}),
+			},
+			expected: map[string]string{"a": "contributed", "c": "3"},
+		},
+		"single contribution": {
+			contributions: []*pcommon.Resource{nil, resourceWith(map[string]string{"a": "1"})},
+			expected:      map[string]string{"a": "1"},
+		},
+		"disjoint keys": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "1"}),
+				resourceWith(map[string]string{"b": "2"}),
+			},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		"later contribution wins on collision": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "first", "b": "2"}),
+				resourceWith(map[string]string{"a": "second"}),
+			},
+			expected: map[string]string{"a": "second", "b": "2"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			merged := MergeResources(test.base, test.contributions)
+			if test.expectNil {
+				require.Nil(t, merged)
+				return
+			}
+			require.NotNil(t, merged)
+
+			got := make(map[string]string, merged.Attributes().Len())
+			merged.Attributes().Range(func(k string, v pcommon.Value) bool {
+				got[k] = v.Str()
+				return true
+			})
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+// TestMergeResourcesDoesNotModifyContributions verifies that merging leaves the
+// inputs untouched: the process manager retains them across synchronizations and
+// re-merges them, so a merge that mutated them would corrupt later merges.
+func TestMergeResourcesDoesNotModifyContributions(t *testing.T) {
+	first := resourceWith(map[string]string{"a": "first"})
+	second := resourceWith(map[string]string{"a": "second"})
+
+	merged := MergeResources(first, []*pcommon.Resource{second})
+	require.NotNil(t, merged)
+
+	v, ok := merged.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+
+	v, ok = first.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "first", v.Str())
+	v, ok = second.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+}
+
+// TestMergeResourcesSharesSingleContribution documents that a lone contribution
+// is returned as-is rather than copied. Contributions are immutable, so sharing
+// is safe and avoids an allocation on the common single-enricher path.
+func TestMergeResourcesSharesSingleContribution(t *testing.T) {
+	only := resourceWith(map[string]string{"a": "1"})
+	require.Same(t, only, MergeResources(nil, []*pcommon.Resource{nil, only, nil}))
+	// Likewise a base with no contribution to merge onto it.
+	require.Same(t, only, MergeResources(only, nil))
+}

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -75,6 +75,14 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	rtp := (*eventsTree)[key]
+	// Refresh so a resource resolved late applies to the samples already collected
+	// for this PID this period. Only non-nil overwrites, so a process whose
+	// attributes become unreadable keeps what it had; the next period starts from an
+	// empty tree, which is where a withdrawal takes effect.
+	if meta.Resource != nil && meta.Resource != rtp.Resource {
+		rtp.Resource = meta.Resource
+		(*eventsTree)[key] = rtp
+	}
 	if _, exists := rtp.Events[meta.ProfileType]; !exists {
 		rtp.Events[meta.ProfileType] = make(samples.SampleToEvents)
 	}

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -175,6 +176,69 @@ func TestBaseReporterGenerate(t *testing.T) {
 	// Verify profiles exist
 	assert.Greater(t, scopeProfile.Profiles().Len(), 0,
 		"Should have at least one profile")
+}
+
+// TestReportTraceEventLateResourceAppliesRetroactively verifies that a context
+// published after sampling started applies to that PID's earlier samples: one
+// bucket, the late resource applied, and a later nil not stripping it.
+func TestReportTraceEventLateResourceAppliesRetroactively(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+
+	makeResource := func(name string) *pcommon.Resource {
+		r := pcommon.NewResource()
+		r.Attributes().PutStr("service.name", name)
+		return &r
+	}
+
+	trace := &libpf.Trace{
+		Frames: func() libpf.Frames {
+			frames := make(libpf.Frames, 0, 1)
+			frames.Append(&libpf.Frame{
+				Type:            libpf.NativeFrame,
+				AddressOrLineno: 0x100,
+				FunctionName:    libpf.Intern("f"),
+			})
+			return frames
+		}(),
+	}
+
+	now := libpf.UnixTime64(time.Now().UnixNano())
+	baseMeta := func(resource *pcommon.Resource) *samples.TraceEventMeta {
+		return &samples.TraceEventMeta{
+			Timestamp:      now,
+			Comm:           libpf.NewCommFromString("svc"),
+			ExecutablePath: libpf.Intern("/usr/bin/svc"),
+			ContainerID:    libpf.Intern("c1"),
+			PID:            1234,
+			TID:            1235,
+			ProfileType:    profileTypeSampling,
+			Resource:       resource,
+		}
+	}
+
+	// Samples collected before the process context is detected.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	// The context is published and detected: later samples carry the resource.
+	resource := makeResource("svc")
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(resource)))
+
+	// Process tears down and the context mapping disappears.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	tree := *treePtr
+
+	require.Len(t, tree, 1, "all samples for one PID belong to a single bucket")
+	for _, rtp := range tree {
+		require.NotNil(t, rtp.Resource,
+			"late-detected resource should apply to the whole period")
+		serviceName, ok := rtp.Resource.Attributes().Get("service.name")
+		require.True(t, ok)
+		assert.Equal(t, "svc", serviceName.Str())
+	}
 }
 
 // processNameAttrProducer is a test SampleAttrProducer that reads "process.name" from

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -103,7 +103,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 		}
 
 		rp := profiles.ResourceProfiles().AppendEmpty()
-		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars)
+		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars, toEvents.Resource)
 		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
@@ -303,7 +303,10 @@ func (p *Pdata) setProfile(
 	return nil
 }
 
-func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String) {
+func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String, res *pcommon.Resource) {
+	if res != nil {
+		res.Attributes().CopyTo(attrs)
+	}
 	if resource.APMServiceName != "" {
 		attrs.PutStr(string(semconv.ServiceNameKey), resource.APMServiceName)
 	}

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -866,3 +866,84 @@ func TestGenerate_Validate(t *testing.T) {
 		CheckSampleTimestampShape: true}).Check(&data)
 	require.NoError(t, err)
 }
+
+func singleEventTree(rk samples.ResourceKey, res *pcommon.Resource) samples.TraceEventsTree {
+	filePath := libpf.Intern("/bin/svc")
+	mapping := libpf.NewFrameMapping(libpf.FrameMappingData{
+		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+			FileID:   libpf.NewFileID(7, 8),
+			FileName: filePath,
+		}),
+	})
+	return samples.TraceEventsTree{
+		rk: samples.ResourceToProfiles{
+			Resource: res,
+			Events: map[*samples.TypeMetadata]samples.SampleToEvents{
+				profileTypeSampling: {
+					{}: &samples.TraceEvents{
+						Frames:     singleFrameTrace(libpf.NativeFrame, mapping, 0x10, "f", filePath, 1),
+						Timestamps: []uint64{uint64(time.Unix(1010, 0).UnixNano())},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGenerate_Resource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	res := pcommon.NewResource()
+	res.Attributes().PutStr("service.namespace", "team-a")
+	res.Attributes().PutStr("service.instance.id", "instance-42")
+	res.Attributes().PutStr("deployment.environment", "prod")
+	res.Attributes().PutInt("not-a-string", 7)
+	res.Attributes().PutStr(string(semconv.ServiceNameKey), "proto-svc")
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            42,
+	}, &res)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		"service.namespace":                      "team-a",
+		"service.instance.id":                    "instance-42",
+		"deployment.environment":                 "prod",
+		"not-a-string":                           int64(7),
+		string(semconv.ServiceNameKey):           "proto-svc",
+		string(semconv.ProcessPIDKey):            int64(42),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}
+
+func TestGenerate_NilResource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            99,
+		APMServiceName: "apm-svc",
+	}, nil)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		string(semconv.ServiceNameKey):           "apm-svc",
+		string(semconv.ProcessPIDKey):            int64(99),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -4,6 +4,7 @@
 package samples // import "go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
@@ -17,6 +18,7 @@ type TraceEventMeta struct {
 	// SampleAttrProducer.CollectExtraSampleMeta to attach process-level attributes.
 	ExtraMeta      map[libpf.String]string
 	APMServiceName string
+	Resource       *pcommon.Resource
 	Timestamp      libpf.UnixTime64
 	CPU            uint32
 	ProfileType    *TypeMetadata
@@ -44,6 +46,11 @@ type ResourceToProfiles struct {
 	// EnvVars can not be part of ResourceKey as maps are not
 	// comparable.
 	EnvVars map[libpf.String]libpf.String
+
+	// Resource holds the OTel resource attributed to the process, if any.
+	// Deliberately not part of ResourceKey: refreshing it as samples arrive lets
+	// a resource resolved late apply to the whole reporting period.
+	Resource *pcommon.Resource
 
 	// Events holds the actual profiling information.
 	Events map[*TypeMetadata]SampleToEvents

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -211,6 +212,10 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process, called on every process synchronization.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
 	// PIDNamespaceTranslation toggles translation of host-level PIDs/TGIDs into
 	// their container-namespace equivalents. Useful for sidecar deployments where
 	// the profiler and the target application share a PID namespace but not host PIDs.
@@ -298,6 +303,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		FilterErrorFrames:     cfg.FilterErrorFrames,
 		IncludeEnvVars:        cfg.IncludeEnvVars,
 		ProcessMetaEnrichers:  cfg.ProcessMetaEnrichers,
+		ResourceEnrichers:     cfg.ResourceEnrichers,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)


### PR DESCRIPTION
   ## Motivation

   `process.MetaEnricher` (#1500) is the extension point for per-process metadata. It is called once when a process is first observed, and again if its executable changes, and it writes into a `process.Meta` the caller owns. That fits metadata read from procfs while the process is certainly alive.

  Some attributes cannot be collected that early:

   - the OTel process context region (OTEP 4719) a process publishes into its own memory can appear at any point in its life, and can be republished.
   - the language runtime is only known once an interpreter attaches, which is usually after the first samples have been collected (#1716).

   The first case is already half-implemented in tree: `processcontext` reads the `OTEL_CTX` region during the mapping pass and stores the result in `process.Meta.ProcessContextInfo`, and an on-going PR implements the propagation to profiles (#1343).

   Stretching `MetaEnricher` to cover the late cases means re-running enrichers against a `Meta` that has already been published and is read concurrently by the trace-processing goroutine: copy-on-write discipline, ownership rules, and a mechanism for an enricher to declare when it wants re-running,   all enforced by documentation only.

   ## What this PR adds

   A second, complementary extension point for that late phase:

   ```go
   type ResourceEnricher interface {
           ResourceConfig() ResourceConfig
           EnrichResource(req *ResourceRequest) (res *pcommon.Resource, changed bool)
   }
   ```

   - Called at the end of every `SynchronizeProcess`, once the mapping pass and the interpreter attach are done, so attributes resolving after first observation are picked up.
   - Returns a freshly built, immutable `*pcommon.Resource` instead of writing into shared metadata, so nothing is shared mutably with the reporting path.
   - Declares what it needs through `ResourceConfig`.  A `WantMapping` predicate selects the mappings delivered in the request, so the manager collects them during the pass it already runs instead of each enricher walking `/proc/<pid>/maps` itself.
   - Receives a per-process state slot, which the manager drops when the process exits. It is storage, not a lifecycle: there is no teardown call.
   - `changed=false` keeps the previous contribution, so data that became temporarily unreadable is not lost. `(nil, true)` withdraws it.

   The manager keeps one contribution per enricher and publishes their merge (`MergeResources`, applied in registration order, later ones winning on key collisions). It reaches the profile through`samples.TraceEventMeta.Resource` and `setResourceAttributes`. Since a resource can resolve mid-interval, `base_reporter` refreshes a PID's resource when a newer one arrives, so it also applies to the samples already buffered for that PID in the current reporting period.

   Exec is handled by the manager rather than by each enricher: it drops the stored contribution and state, making a first call and a post-exec call indistinguishable. 

   ## What it does not change

   No enricher is registered here, so behaviour is unchanged: `TraceEventMeta.Resource` stays nil and no  resource attributes are added to any profile. `MetaEnricher` keeps its shape and its built-in  implementations, so existing implementations compile and behave as before. The inline process-context  read and `Meta.ProcessContextInfo` are left exactly as they are, and the follow-up that propagates  process context replaces them.

   Cost on the mapping pass: with no enricher declaring `WantMapping` the dispatch is skipped behind a length check. With one, it adds a single indirect call per mapping to a loop that already runs `isInterpreterMapping`, interning, and potentially an ELF open plus file-ID computation. If cost of an indirect call per mapping is deemed to high, a less generic, declarative filter declaring the expected mapping flags and path names would let the manager match mappings itself, calling into the enricher only for those that matched

   ## Relation to MetaEnricher

   `ResourceEnricher` is presented as its own interface to make clear what it brings over `MetaEnricher`: a different call time, different inputs, and an immutable return value instead of writes into shared metadata. It does not have to stay separate. The two could equally be one interface with two distinct methods, `EnrichMeta` and `EnrichResource`, plus embeddable stubs for the one an enricher does not implement, the way `interpreter.InstanceStubs` already provides empty
implementations of the optional `Instance` hooks. That is a mechanical change, and I am happy to make  it here if a single extension point is preferred.
  
 ## Follow-ups

   1. Propagate process context as the first enricher, removing the `Meta.ProcessContextInfo` -> implemented as draft PR #1771 .
   2. Report `process.runtime.name` and `process.runtime.version` instances -> implemented as draft PR #1770.
