### PR TITLE
procmeta/runtimeinfo: report process.runtime.name and process.runtime.version

### DIFF
--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -8,6 +8,7 @@ package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 import (
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
 
@@ -18,6 +19,7 @@ type Option interface {
 type controllerOption struct {
 	executableReporter   reporter.ExecutableReporter
 	processMetaEnrichers []process.MetaEnricher
+	resourceEnrichers    []procmeta.ResourceEnricher
 	reporterFactory      func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)
 	onShutdown           func() error
 }
@@ -59,6 +61,19 @@ func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer
 func WithProcessMetaEnricher(enrichers ...process.MetaEnricher) Option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.processMetaEnrichers = append(option.processMetaEnrichers, enrichers...)
+		return option
+	})
+}
+
+// WithResourceEnricher registers a hook contributing OTel resource attributes to a
+// process. Unlike WithProcessMetaEnricher it runs on every mapping
+// resynchronization, so it can supply attributes that resolve after first
+// observation: a memory region published later, a runtime whose interpreter
+// attaches. It declares what it needs through procmeta.ResourceConfig, and its
+// contribution is merged into the resource of that process's profiles.
+func WithResourceEnricher(enrichers ...procmeta.ResourceEnricher) Option {
+	return optFunc(func(option *controllerOption) *controllerOption {
+		option.resourceEnrichers = append(option.resourceEnrichers, enrichers...)
 		return option
 	})
 }

--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -76,6 +76,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 			Config:               *cfg,
 			ExecutableReporter:   controllerOption.executableReporter,
 			ProcessMetaEnrichers: controllerOption.processMetaEnrichers,
+			ResourceEnrichers:    controllerOption.resourceEnrichers,
 			ReporterFactory:      controllerOption.reporterFactory,
 			OnShutdown:           controllerOption.onShutdown,
 		}

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/collector/config"
@@ -24,7 +25,12 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery and executable change time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
-	OnShutdown           func() error
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process. They are called on every process synchronization,
+	// so they can supply attributes that resolve later than process discovery.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
+	OnShutdown        func() error
 
 	// If ReporterFactory is set, it will be used to create a Reporter and set it as the Reporter field.
 	// Either ReporterFactory or Reporter must be set. If both are set, ReporterFactory will be used.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -109,6 +109,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		OBIProcessCtx:           c.config.OBIProcessCtx,
 		PIDNamespaceTranslation: c.config.PIDNamespaceTranslation,
 		ProcessMetaEnrichers:    c.config.ProcessMetaEnrichers,
+		ResourceEnrichers:       c.config.ResourceEnrichers,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load eBPF tracer: %w", err)

--- a/interpreter/beam/beam.go
+++ b/interpreter/beam/beam.go
@@ -281,6 +281,12 @@ func (d *beamData) String() string {
 	return fmt.Sprintf("BEAM OTP %d, ERTS %s", d.otpRelease, d.ertsVersion)
 }
 
+func (i *beamInstance) RuntimeInfo() (string, string, bool) {
+	// The OTP release (e.g. 26) keys the erlang/otp source and not the finer ERTS
+	// version (i.data.ertsVersion)
+	return "erlang", fmt.Sprintf("%d", i.data.otpRelease), true
+}
+
 func hashMFA(key beamMfa) uint32 {
 	mfhash := uint32(hash.Uint64(uint64(key.module)<<32 | uint64(key.function)))
 	return uint32(hash.Uint64(uint64(mfhash)<<32 | uint64(key.arity)))

--- a/interpreter/dotnet/data.go
+++ b/interpreter/dotnet/data.go
@@ -200,9 +200,14 @@ type dotnetData struct {
 	xsync.Once[dotnetCdac]
 }
 
-func (d *dotnetData) String() string {
+// versionString renders the version as major.minor.build.
+func (d *dotnetData) versionString() string {
 	ver := d.version
-	return fmt.Sprintf("dotnet %d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff)
+	return fmt.Sprintf("%d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff)
+}
+
+func (d *dotnetData) String() string {
+	return "dotnet " + d.versionString()
 }
 
 func (d *dotnetData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,

--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -874,6 +874,10 @@ func (i *dotnetInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
 	}, nil
 }
 
+func (i *dotnetInstance) RuntimeInfo() (string, string, bool) {
+	return "dotnet", i.d.versionString(), true
+}
+
 func (i *dotnetInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	if !ef.Type().IsInterpType(libpf.Dotnet) {
 		return interpreter.ErrMismatchInterpreterType

--- a/interpreter/go/go.go
+++ b/interpreter/go/go.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go/version"
+	"strings"
 	"sync/atomic"
 	"unsafe"
 
@@ -59,6 +60,13 @@ func (d *goData) unref() {
 
 func (d *goData) String() string {
 	return "Go " + d.goVersion
+}
+
+func (g *goInstance) RuntimeInfo() (string, string, bool) {
+	if g.d.goVersion == "" {
+		return "", "", false
+	}
+	return "go", strings.TrimPrefix(g.d.goVersion, "go"), true
 }
 
 func (d *goData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID,

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -347,12 +347,17 @@ func (d *hotspotData) newUnsigned5Decoder(r io.ByteReader) *unsigned5Decoder {
 	}
 }
 
+// versionString renders the version as feature.interim.update, leaving out the
+// build number that follows it in the JVM's own version string.
+func (v *hotspotVMData) versionString() string {
+	return fmt.Sprintf("%d.%d.%d",
+		(v.version>>24)&0xff, (v.version>>16)&0xff, (v.version>>8)&0xff)
+}
+
 func (d *hotspotData) String() string {
 	if vmd := d.Get(); vmd != nil {
-		return fmt.Sprintf("Java HotSpot VM %d.%d.%d+%d (%v)",
-			(vmd.version>>24)&0xff, (vmd.version>>16)&0xff,
-			(vmd.version>>8)&0xff, vmd.version&0xff,
-			vmd.versionStr)
+		return fmt.Sprintf("Java HotSpot VM %s+%d (%v)",
+			vmd.versionString(), vmd.version&0xff, vmd.versionStr)
 	}
 	return "<unintrospected JVM>"
 }

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -853,6 +853,14 @@ func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 	}
 }
 
+func (d *hotspotInstance) RuntimeInfo() (string, string, bool) {
+	vmd := d.d.Get()
+	if vmd == nil {
+		return "", "", false
+	}
+	return "openjdk", vmd.versionString(), true
+}
+
 func (d *hotspotInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 	_ reporter.ExecutableReporter, pr process.Process, _ []process.RawMapping,
 ) error {

--- a/interpreter/instancestubs.go
+++ b/interpreter/instancestubs.go
@@ -40,3 +40,7 @@ func (is *InstanceStubs) GetAndResetMetrics() ([]metrics.Metric, error) {
 func (is *InstanceStubs) ReleaseResources() error {
 	return nil
 }
+
+func (is *InstanceStubs) RuntimeInfo() (string, string, bool) {
+	return "", "", false
+}

--- a/interpreter/multi.go
+++ b/interpreter/multi.go
@@ -162,3 +162,14 @@ func (m *MultiInstance) ReleaseResources() error {
 	}
 	return errors.Join(errs...)
 }
+
+// RuntimeInfo returns the runtime info of the first wrapped instance that
+// reports one (ok=true), or ok=false if none do.
+func (m *MultiInstance) RuntimeInfo() (string, string, bool) {
+	for _, instance := range m.instances {
+		if name, version, ok := instance.RuntimeInfo(); ok {
+			return name, version, true
+		}
+	}
+	return "", "", false
+}

--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -1810,9 +1810,20 @@ func (i *v8Instance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf
 	return nil
 }
 
-func (d *v8Data) String() string {
+// versionString renders the version as major.minor.build.
+func (d *v8Data) versionString() string {
 	ver := d.version
-	return fmt.Sprintf("V8 %d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff)
+	return fmt.Sprintf("%d.%d.%d", (ver>>24)&0xff, (ver>>16)&0xff, ver&0xffff)
+}
+
+func (d *v8Data) String() string {
+	return "V8 " + d.versionString()
+}
+
+func (i *v8Instance) RuntimeInfo() (string, string, bool) {
+	// The version read from the binary is V8's own, not the Node.js release that
+	// embeds it, so report the runtime as V8.
+	return "v8", i.d.versionString(), true
 }
 
 // mapFramePointerOffset converts the frame pointer offset in bytes to eBPF used

--- a/interpreter/perl/data.go
+++ b/interpreter/perl/data.go
@@ -114,9 +114,14 @@ type perlData struct {
 	stateInTSD bool
 }
 
-func (d *perlData) String() string {
+// versionString renders the version as major.minor.release.
+func (d *perlData) versionString() string {
 	ver := d.version
-	return fmt.Sprintf("Perl %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+	return fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+}
+
+func (d *perlData) String() string {
+	return "Perl " + d.versionString()
 }
 
 func (d *perlData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,

--- a/interpreter/perl/instance.go
+++ b/interpreter/perl/instance.go
@@ -398,6 +398,10 @@ func (i *perlInstance) getCOP(copAddr libpf.Address, funcName libpf.String) (
 	return c, nil
 }
 
+func (i *perlInstance) RuntimeInfo() (string, string, bool) {
+	return "perl", i.d.versionString(), true
+}
+
 func (i *perlInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	if !ef.Type().IsInterpType(libpf.Perl) {
 		return interpreter.ErrMismatchInterpreterType

--- a/interpreter/php/instance.go
+++ b/interpreter/php/instance.go
@@ -185,6 +185,10 @@ func (i *phpInstance) getFunction(addr libpf.Address, typeInfo uint32) (*phpFunc
 	return pf, nil
 }
 
+func (i *phpInstance) RuntimeInfo() (string, string, bool) {
+	return "php", i.d.versionString(), true
+}
+
 func (i *phpInstance) Symbolize(ef libpf.EbpfFrame, frames *libpf.Frames, _ libpf.FrameMapping) error {
 	// With Symbolize() in opcacheInstance there is a dedicated function to symbolize JITTed
 	// PHP frames. But as we also attach phpInstance to PHP processes with JITTed frames, we

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -96,9 +96,14 @@ type phpData struct {
 	}
 }
 
-func (d *phpData) String() string {
+// versionString renders the version as major.minor.release.
+func (d *phpData) versionString() string {
 	ver := d.version
-	return fmt.Sprintf("PHP %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+	return fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+}
+
+func (d *phpData) String() string {
+	return "PHP " + d.versionString()
 }
 
 func (d *phpData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -54,26 +54,40 @@ const (
 	maxPyMemberDefs = 256
 )
 
-func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, err error) {
+// decodePyVersionHex extracts major.minor.micro from the CPython PY_VERSION_HEX
+// layout: (major<<24) | (minor<<16) | (micro<<8) | (releaselevel<<4) | serial.
+// The micro/patch byte is used only for RuntimeInfo() source resolution, not for
+// offset selection
+// https://docs.python.org/3/c-api/apiabiversion.html
+func decodePyVersionHex(versionHex uint32) (major uint8, minor uint8, patch uint8) {
+	return uint8((versionHex >> 24) & 0xff),
+		uint8((versionHex >> 16) & 0xff),
+		uint8((versionHex >> 8) & 0xff)
+}
+
+func readPyVersionHex(ef *pfelf.File) (major uint8, minor uint8, patch uint8, err error) {
 	// Py_Version is referenced in CPython internals for versioned Python binaries.
 	// https://github.com/python/cpython/blob/v3.11.0/Doc/c-api/apiabiversion.rst
 	addr, err := ef.LookupSymbolAddress("Py_Version")
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	rm := ef.GetRemoteMemory()
 	versionHex := rm.Uint32(libpf.Address(addr))
-	major = uint8((versionHex >> 24) & 0xff)
-	minor = uint8((versionHex >> 16) & 0xff)
+	major, minor, patch = decodePyVersionHex(versionHex)
 	if major == 0 {
-		return 0, 0, fmt.Errorf("invalid Py_Version 0x%x", versionHex)
+		return 0, 0, 0, fmt.Errorf("invalid Py_Version 0x%x", versionHex)
 	}
-	return major, minor, nil
+	return major, minor, patch, nil
 }
 
 //nolint:lll
 type pythonData struct {
 	version uint16
+
+	// fullVersion is the "major.minor" or "major.minor.patch" string reported by
+	// RuntimeInfo(); patch may be absent. Not used for offset selection.
+	fullVersion string
 
 	autoTLSKey libpf.SymbolValue
 
@@ -146,6 +160,10 @@ var _ interpreter.Data = &pythonData{}
 
 func (d *pythonData) String() string {
 	return fmt.Sprintf("Python %d.%d", d.version>>8, d.version&0xff)
+}
+
+func (p *pythonInstance) RuntimeInfo() (string, string, bool) {
+	return "cpython", p.d.fullVersion, true
 }
 
 func (d *pythonData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.Address,
@@ -804,13 +822,16 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	if err != nil {
 		return nil, err
 	}
-	if major == 0 {
-		majorFromSym, minorFromSym, versionErr := readPyVersionHex(ef)
-		if versionErr != nil {
-			return nil, nil
-		}
+
+	// The patch level is only available from the symbol, never from the file name,
+	// so the full version is built here, where it is known.
+	var fullVersion string
+	if majorFromSym, minorFromSym, patchFromSym, versionErr := readPyVersionHex(ef); versionErr == nil {
 		major = uint16(majorFromSym)
 		minor = uint16(minorFromSym)
+		fullVersion = fmt.Sprintf("%d.%d.%d", major, minor, patchFromSym)
+	} else if major == 0 {
+		return nil, nil
 	}
 
 	if mainDSO {
@@ -877,8 +898,12 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		}
 	}
 
+	if fullVersion == "" {
+		fullVersion = fmt.Sprintf("%d.%d", major, minor)
+	}
 	pd := &pythonData{
 		version:         version,
+		fullVersion:     fullVersion,
 		autoTLSKey:      autoTLSKey,
 		staticTLSOffset: staticTLSOffset,
 	}

--- a/interpreter/python/python_test.go
+++ b/interpreter/python/python_test.go
@@ -120,3 +120,32 @@ func TestPythonRegexs(t *testing.T) {
 		}
 	}
 }
+
+// TestDecodePyVersionHex verifies the PY_VERSION_HEX bit-decoding against
+// real CPython constants (the value stored in the Py_Version symbol). The
+// layout is (major<<24)|(minor<<16)|(micro<<8)|(releaselevel<<4)|serial, so the
+// low byte (release/serial) must not leak into major/minor/patch.
+func TestDecodePyVersionHex(t *testing.T) {
+	tests := map[string]struct {
+		hex                             uint32
+		wantMajor, wantMinor, wantPatch uint8
+	}{
+		// 0xMMmmppRS — RS = releaselevel(4b)+serial(4b); 0xF0 = final release.
+		"3.8.0 final":  {0x030800F0, 3, 8, 0},
+		"3.11.4 final": {0x030B04F0, 3, 11, 4},
+		"3.12.7 final": {0x030C07F0, 3, 12, 7},
+		"3.11.9 final": {0x030B09F0, 3, 11, 9},
+		// Pre-releases still carry the correct micro; only the low byte differs.
+		"3.14.0a1": {0x030E00A1, 3, 14, 0},
+		// Two-digit micro must survive the mask.
+		"3.9.19 final": {0x030913F0, 3, 9, 19},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			major, minor, patch := decodePyVersionHex(tt.hex)
+			assert.Equal(t, tt.wantMajor, major)
+			assert.Equal(t, tt.wantMinor, minor)
+			assert.Equal(t, tt.wantPatch, patch)
+		})
+	}
+}

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -306,9 +306,18 @@ func rubyVersion(major, minor, release uint32) uint32 {
 	return major*0x10000 + minor*0x100 + release
 }
 
-func (r *rubyData) String() string {
+// versionString renders the version as major.minor.release.
+func (r *rubyData) versionString() string {
 	ver := r.version
-	return fmt.Sprintf("Ruby %d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+	return fmt.Sprintf("%d.%d.%d", (ver>>16)&0xff, (ver>>8)&0xff, ver&0xff)
+}
+
+func (r *rubyData) String() string {
+	return "Ruby " + r.versionString()
+}
+
+func (r *rubyInstance) RuntimeInfo() (string, string, bool) {
+	return "ruby", r.r.versionString(), true
 }
 
 func (r *rubyData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf.Address,

--- a/interpreter/types.go
+++ b/interpreter/types.go
@@ -174,4 +174,8 @@ type Instance interface {
 
 	// Release resources that are used to symbolize a stack.
 	ReleaseResources() error
+
+	// RuntimeInfo returns the runtime family name and full version for source
+	// resolution, e.g. ("cpython", "3.11.4"). Returns ok=false if not applicable.
+	RuntimeInfo() (name string, version string, ok bool)
 }

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // CoredumpProcess implements Process interface to ELF coredumps.
@@ -175,22 +176,44 @@ func OpenCoredumpFile(f *pfelf.File) (*CoredumpProcess, error) {
 	return cd, nil
 }
 
-// MainExecutable gets the file path from the mappings of the main executable.
-func (cd *CoredumpProcess) MainExecutable() string {
+// mainExecutableFile returns the coredump file holding the main executable, or
+// nil if the coredump does not identify one.
+func (cd *CoredumpProcess) mainExecutableFile() *CoredumpFile {
 	if cd.execPhdrPtr == 0 {
-		return ""
+		return nil
 	}
 
 	for _, file := range cd.files {
 		for _, mapping := range file.Mappings {
 			if cd.execPhdrPtr >= libpf.Address(mapping.Prog.Vaddr) &&
 				cd.execPhdrPtr <= libpf.Address(mapping.Prog.Vaddr+mapping.Prog.Memsz) {
-				return file.Name.String()
+				return file
 			}
 		}
 	}
 
+	return nil
+}
+
+// MainExecutable gets the file path from the mappings of the main executable.
+func (cd *CoredumpProcess) MainExecutable() string {
+	if file := cd.mainExecutableFile(); file != nil {
+		return file.Name.String()
+	}
 	return ""
+}
+
+// GetExecutableFileIdentifier implements the Process interface, returning the
+// synthesized identity parseMappings gave the executable's mappings.
+func (cd *CoredumpProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	file := cd.mainExecutableFile()
+	if file == nil {
+		return util.OnDiskFileIdentifier{}, errors.New("coredump has no main executable")
+	}
+	return util.OnDiskFileIdentifier{
+		DeviceID: coredumpFileDevice,
+		InodeNum: file.inode,
+	}, nil
 }
 
 // PID implements the Process interface.
@@ -271,6 +294,10 @@ func (cd *CoredumpProcess) OpenELF(path string) (*pfelf.File, error) {
 	return nil, fmt.Errorf("ELF file `%s` not found", path)
 }
 
+// coredumpFileDevice is the synthetic device ID given to every file-backed
+// mapping in a coredump, so that they are recognized as file-backed at all.
+const coredumpFileDevice = 1
+
 // Global inode counter to generate unique inode for each coredump file
 var curInode atomic.Uint64
 
@@ -349,7 +376,7 @@ func (cd *CoredumpProcess) parseMappings(desc []byte,
 			mapping.Path = cf.Name.String()
 			mapping.FileOffset = entry.FileOffset * hdr.PageSize
 			// Synthesize non-zero device and inode indicating this is a filebacked mapping.
-			mapping.Device = 1
+			mapping.Device = coredumpFileDevice
 			mapping.Inode = cf.inode
 		} else {
 			// This file backed mapping is not in the coredump LOAD tables
@@ -360,7 +387,7 @@ func (cd *CoredumpProcess) parseMappings(desc []byte,
 				Length:     entry.End - entry.Start,
 				Flags:      elf.PF_R + elf.PF_X,
 				FileOffset: entry.FileOffset * hdr.PageSize,
-				Device:     1,
+				Device:     coredumpFileDevice,
 				Inode:      cf.inode,
 				Path:       cf.Name.String(),
 			})

--- a/process/process.go
+++ b/process/process.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/stringutil"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // ErrNoMappings is returned when no mappings can be extracted.
@@ -109,7 +110,20 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 	if err != nil {
 		return libpf.NullString, err
 	}
-	return libpf.Intern(str), nil
+	// Drop the kernel's deleted marker, as trimMappingPath does for mapping paths, so
+	// the executable stays comparable with /proc/<pid>/maps after a binary swap.
+	return libpf.Intern(strings.TrimSuffix(str, deletedSuffix)), nil
+}
+
+// GetExecutableFileIdentifier implements the Process interface. Stating the exe
+// symlink follows it to the executable, whose device and inode are the ones
+// /proc/<pid>/maps reports for the mappings backed by it.
+func (sp *systemProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(sp.procBase+"exe", &st); err != nil {
+		return util.OnDiskFileIdentifier{}, fmt.Errorf("stat %sexe: %w", sp.procBase, err)
+	}
+	return fileIdentifierFromStat(&st), nil
 }
 
 func (sp *systemProcess) GetProcessMeta(enrichers []MetaEnricher) Meta {
@@ -276,10 +290,13 @@ func detectSelfContainerIDViaInode() (libpf.String, uint64, error) {
 	return matched, selfIno, nil
 }
 
+// deletedSuffix is what the kernel appends to the path of a file that has been
+// unlinked while still mapped or open.
+// See path_with_deleted in linux/fs/d_path.c
+const deletedSuffix = " (deleted)"
+
 func trimMappingPath(path string) string {
-	// Trim the deleted indication from the path.
-	// See path_with_deleted in linux/fs/d_path.c
-	path = strings.TrimSuffix(path, " (deleted)")
+	path = strings.TrimSuffix(path, deletedSuffix)
 	if path == "/dev/zero" {
 		// Some JIT engines map JIT area from /dev/zero
 		// make it anonymous.

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -10,6 +10,8 @@ import (
 	"os"
 
 	"golang.org/x/sys/unix"
+
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // openInRoot securely opens a file within a given root directory using openat2
@@ -62,4 +64,10 @@ func checkInodeDeviceMapping(f *os.File, m *RawMapping) error {
 			m.Path, stat.Dev, stat.Ino, m.Device, m.Inode)
 	}
 	return nil
+}
+
+// fileIdentifierFromStat builds an OnDiskFileIdentifier from a stat result, so
+// that it is comparable with the identifier of a mapping backed by the same file.
+func fileIdentifierFromStat(stat *unix.Stat_t) util.OnDiskFileIdentifier {
+	return util.OnDiskFileIdentifier{DeviceID: stat.Dev, InodeNum: stat.Ino}
 }

--- a/process/process_other.go
+++ b/process/process_other.go
@@ -10,6 +10,8 @@ import (
 	"os"
 
 	"golang.org/x/sys/unix"
+
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // openInRoot opens filePath relative to rootPath. On non-Linux platforms
@@ -54,4 +56,10 @@ func checkInodeDeviceMapping(f *os.File, m *RawMapping) error {
 			m.Path, stat.Dev, stat.Ino, m.Device, m.Inode)
 	}
 	return nil
+}
+
+// fileIdentifierFromStat builds an OnDiskFileIdentifier from a stat result, so
+// that it is comparable with the identifier of a mapping backed by the same file.
+func fileIdentifierFromStat(stat *unix.Stat_t) util.OnDiskFileIdentifier {
+	return util.OnDiskFileIdentifier{DeviceID: uint64(stat.Dev), InodeNum: stat.Ino}
 }

--- a/process/types.go
+++ b/process/types.go
@@ -139,8 +139,14 @@ type Process interface {
 	// GetProcessMeta returns process specific metadata.
 	GetProcessMeta([]MetaEnricher) Meta
 
-	// GetExe returns the executable path of the process.
+	// GetExe returns the executable path of the process, with the kernel's
+	// " (deleted)" suffix removed.
 	GetExe() (libpf.String, error)
+
+	// GetExecutableFileIdentifier returns the on-disk identity of the process's own
+	// executable, comparable with any mapping's, so callers can tell it apart from
+	// the libraries it loaded.
+	GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error)
 
 	// IterateMappings parses process memory mappings and calls the
 	// callback for each mapping. The RawMapping's Path field may reference

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -71,6 +72,20 @@ type Config struct {
 	FilterErrorFrames     bool
 	IncludeEnvVars        libpf.Set[string]
 	ProcessMetaEnrichers  []process.MetaEnricher
+	ResourceEnrichers     []procmeta.ResourceEnricher
+}
+
+// newMappingFilters resolves each enricher's mapping requirements once, so the
+// mapping pass need not re-read them, pairing every non-nil filter with the index of
+// the enricher that declared it — the index the selected mappings are delivered by.
+func newMappingFilters(enrichers []procmeta.ResourceEnricher) []mappingFilter {
+	var filters []mappingFilter
+	for i, e := range enrichers {
+		if want := e.ResourceConfig().WantMapping; want != nil {
+			filters = append(filters, mappingFilter{enricher: i, want: want})
+		}
+	}
+	return filters
 }
 
 // New creates a new ProcessManager which is responsible for keeping track of loading
@@ -82,6 +97,9 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 	if cfg.FrameCacheSize == 0 {
 		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
+
+	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
+	mappingFilters := newMappingFilters(resourceEnrichers)
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
 		util.OnDiskFileIdentifier.Hash32)
@@ -141,6 +159,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
 		metaEnrichers:            metaEnrichers,
+		resourceEnrichers:        resourceEnrichers,
+		mappingFilters:           mappingFilters,
 		attachedProbes:           make(map[libpf.PID]map[ProbeAttacher]libpf.Void),
 	}
 
@@ -379,7 +399,7 @@ func hashFrameCacheKey(fk frameCacheKey) uint32 {
 // trace handling to a goroutine pool, the caching strategy needs to be updated
 // accordingly.
 func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *samples.TypeMetadata) {
-	procMeta := pm.metaForPID(bpfTrace.PID)
+	procMeta, resource := pm.metaForPID(bpfTrace.PID)
 	meta := &samples.TraceEventMeta{
 		Timestamp:      libpf.UnixTime64(times.KTime(bpfTrace.KTime).UnixNano()),
 		Comm:           bpfTrace.Comm,
@@ -392,6 +412,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *sa
 		ProfileType:    profileType,
 		Value:          bpfTrace.Value,
 		EnvVars:        procMeta.EnvVariables,
+		Resource:       resource,
 		TraceID:        bpfTrace.APMTraceID,
 		SpanID:         bpfTrace.APMTransactionID,
 		ExtraMeta:      procMeta.ExtraMeta,

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -31,6 +31,7 @@ import (
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
 	"go.opentelemetry.io/ebpf-profiler/procmeta"
+	"go.opentelemetry.io/ebpf-profiler/procmeta/runtimeinfo"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -98,7 +99,11 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
 
-	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
+	// The built-in enricher is always on, and comes first so that a configured
+	// enricher can override what it contributed.
+	resourceEnrichers := append(
+		[]procmeta.ResourceEnricher{runtimeinfo.NewEnricher()},
+		cfg.ResourceEnrichers...)
 	mappingFilters := newMappingFilters(resourceEnrichers)
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"golang.org/x/sys/unix"
 
@@ -33,6 +34,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/processcontext"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -120,15 +122,19 @@ func (pm *ProcessManager) getLibcInfo(pid libpf.PID) *libc.LibcInfo {
 // metadata is gathered (including configured process MetaEnrichers) without
 // the processmanager lock held.
 //
+// created reports whether this call created the processInfo, i.e. the first
+// observation of the process. That is the lifecycle signal to use: a process may be
+// synchronized many times without ever retaining a mapping.
+//
 // Returns nil on failure.
 // Caller must not hold the pm.mu lock.
 func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
-	pr process.Process) *processInfo {
+	pr process.Process) (info *processInfo, created bool) {
 	pm.mu.RLock()
 	info, ok := pm.pidToProcessInfo[pid]
 	pm.mu.RUnlock()
 	if ok {
-		return info
+		return info, false
 	}
 
 	// Gather metadata without holding the processmanager lock:
@@ -140,21 +146,80 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 
 	// Check if another goroutine registered the PID in-between.
 	if info, ok = pm.pidToProcessInfo[pid]; ok {
-		return info
+		return info, false
 	}
 
 	if err := pm.ebpf.UpdatePidPageMappingInfo(pid, dummyPrefix, 0, 0); err != nil {
-		return nil
+		return nil, false
 	}
 
 	pm.pidPageToMappingInfoSize++
 	info = &processInfo{
 		meta:     meta,
 		libcInfo: nil,
+		// Sole allocation site of the slots, so they are always as long as the
+		// registered enrichers, which index them.
+		contributions: make([]*pcommon.Resource, len(pm.resourceEnrichers)),
+		enricherState: make([]any, len(pm.resourceEnrichers)),
 	}
 	pm.pidToProcessInfo[pid] = info
 
-	return info
+	return info, true
+}
+
+// enrichResources runs the resource enrichers for a process and publishes the merge
+// of their contributions. One that reports no change keeps its previous
+// contribution, so data that has become unreadable is not lost.
+//
+// Caller must not hold pm.mu: enrichers run arbitrary code and read /proc and
+// remote process memory.
+func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
+	interpreters map[util.OnDiskFileIdentifier]interpreter.Instance,
+	enricherMappings [][]process.RawMapping, newProcessOrExec bool,
+) {
+	if info == nil || len(pm.resourceEnrichers) == 0 {
+		return
+	}
+
+	// Only meta and resource are read from another goroutine (metaForPID); the slots
+	// belong to the synchronizing one. So the enrichers update the slots in place,
+	// and pm.mu is taken once, to publish resource.
+	if newProcessOrExec {
+		// Nothing derived from the replaced program can carry over: "no change" means
+		// "my contribution still holds", which after an exec it cannot. Otherwise an
+		// enricher resolving nothing for the new executable would keep the old
+		// program's attributes, and a fill-once one would never look again.
+		clear(info.contributions)
+		clear(info.enricherState)
+	}
+
+	req := procmeta.ResourceRequest{
+		Process:      pr,
+		Interpreters: interpreters,
+	}
+
+	// A new or execed process starts from cleared state, so the merge is due even if
+	// no enricher reports a change.
+	changed := newProcessOrExec
+	for i, e := range pm.resourceEnrichers {
+		if enricherMappings != nil {
+			req.Mappings = enricherMappings[i]
+		}
+		req.State = &info.enricherState[i]
+		if res, ok := e.EnrichResource(&req); ok {
+			info.contributions[i] = res
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+
+	merged := procmeta.MergeResources(nil, info.contributions)
+
+	pm.mu.Lock()
+	info.resource = merged
+	pm.mu.Unlock()
 }
 
 // assignInterpreter will update the interpreters maps with given interpreter.Instance.
@@ -601,13 +666,16 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		// the case of main thread exit. Ignore it.
 	}
 
-	info := pm.getOrCreateProcessInfo(pid, pr)
+	info, firstObservation := pm.getOrCreateProcessInfo(pid, pr)
 	if info == nil {
 		return
 	}
 
 	pm.mu.Lock()
-	// Check if process meta needs an update
+	// Check if process meta needs an update. execve preserves the tgid, so a
+	// re-exec of the same path is invisible here and leaves env vars and the
+	// process context unrefreshed. Detecting it needs a sched_process_exec
+	// tracepoint.
 	updateProcessMeta := exe != libpf.NullString && exe != info.meta.Executable
 	oldProcessContextInfo := info.meta.ProcessContextInfo
 
@@ -645,10 +713,21 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	capHint := max(32, min(len(oldMappings), 256))
 	mappings := make([]Mapping, 0, capHint)
 	mpAdd := make([]*Mapping, 0, capHint)
-	var processContextInfo processcontext.Info
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
+
+	// enricherMappings collects, per enricher, the mappings its filter selected, and
+	// is nil when none wants any. The filters are hoisted so the callback below,
+	// which runs once per mapping, captures a slice header instead of reaching
+	// through pm each iteration.
+	mappingFilters := pm.mappingFilters
+	var enricherMappings [][]process.RawMapping
+	if len(mappingFilters) > 0 {
+		enricherMappings = make([][]process.RawMapping, len(pm.resourceEnrichers))
+	}
+
+	var processContextInfo processcontext.Info
 
 	// This callback processes each memory mapping, keeping only executable
 	// file-backed mappings and executable/prctl-named anonymous or DLL mappings
@@ -660,6 +739,15 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			processContextInfo = readProcessContext(m.Vaddr, pr, oldProcessContextInfo)
 			// The eBPF hook on prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME) will trigger a
 			// PID resynchronization when the process names its context mapping "OTEL_CTX".
+		}
+
+		for _, f := range mappingFilters {
+			if f.want(&m) {
+				// Detach Path from the recycled scanner buffer before storing.
+				selected := m
+				selected.Path = libpf.Intern(selected.Path).String()
+				enricherMappings[f.enricher] = append(enricherMappings[f.enricher], selected)
+			}
 		}
 
 		interpreterMapping := isInterpreterMapping(&m)
@@ -793,17 +881,27 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	// Sort and publish the new mappings and meta.
 	slices.SortFunc(mappings, compareMapping)
 
-	info = pm.getOrCreateProcessInfo(pid, pr)
+	// A concurrent ProcessedUntil may have dropped the processInfo since this
+	// synchronization started; recreating it starts from empty enricher state.
+	info, recreated := pm.getOrCreateProcessInfo(pid, pr)
 	pm.mu.Lock()
 	if info != nil {
 		info.mappings = mappings
 		if updateProcessMeta {
 			info.meta = meta
+			// Reset resource to nil to avoid pairing the replaced program's samples with
+			// the old one.
+			info.resource = nil
 		}
 		info.meta.ProcessContextInfo = processContextInfo
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()
+
+	// Contribute resource attributes, now that the mappings and the interpreters
+	// attached this round are known.
+	pm.enrichResources(pr, info, interpreters, enricherMappings,
+		updateProcessMeta || firstObservation || recreated)
 
 	// Synchronize all interpreters with updated mappings
 	for _, instance := range interpreters {
@@ -862,14 +960,15 @@ func (pm *ProcessManager) CleanupPIDs() {
 	}
 }
 
-// metaForPID returns the process metadata for given PID.
-func (pm *ProcessManager) metaForPID(pid libpf.PID) process.Meta {
+// metaForPID returns a consistent snapshot of a PID's metadata and of the resource
+// the enrichers contributed for it.
+func (pm *ProcessManager) metaForPID(pid libpf.PID) (process.Meta, *pcommon.Resource) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		return procInfo.meta
+		return procInfo.meta, procInfo.resource
 	}
-	return process.Meta{}
+	return process.Meta{}, nil
 }
 
 // findMappingForTrace locates the mapping for a given host trace.

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -150,6 +150,9 @@ type testProcess struct {
 	pid      libpf.PID
 	exe      libpf.String
 	mappings []process.RawMapping
+	// exeID is what GetExecutableFileIdentifier reports; the zero value stands
+	// for an executable that could not be identified.
+	exeID util.OnDiskFileIdentifier
 }
 
 func (tp *testProcess) PID() libpf.PID {
@@ -170,6 +173,13 @@ func (tp *testProcess) GetProcessMeta(enrichers []process.MetaEnricher) process.
 
 func (tp *testProcess) GetExe() (libpf.String, error) {
 	return tp.exe, nil
+}
+
+func (tp *testProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	if tp.exeID == (util.OnDiskFileIdentifier{}) {
+		return util.OnDiskFileIdentifier{}, errors.New("no executable")
+	}
+	return tp.exeID, nil
 }
 
 func (tp *testProcess) IterateMappings(callback func(process.RawMapping) bool) (uint32, error) {

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libc"
@@ -19,6 +20,7 @@ import (
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -161,7 +163,7 @@ func (tp *testProcess) GetMachineData() process.MachineData {
 func (tp *testProcess) GetProcessMeta(enrichers []process.MetaEnricher) process.Meta {
 	meta := process.Meta{Executable: tp.exe}
 	for _, e := range enrichers {
-		e.EnrichMeta(fmt.Sprintf("/proc/%d", tp.pid), &meta)
+		e.EnrichMeta(fmt.Sprintf("/proc/%d/", tp.pid), &meta)
 	}
 	return meta
 }
@@ -570,22 +572,17 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	enricherCalls := 0
 	enricher := process.MetaEnricherFunc(func(procBase string, meta *process.Meta) {
 		enricherCalls++
-		require.Equal(fmt.Sprintf("/proc/%d", pid), procBase)
+		require.Equal(fmt.Sprintf("/proc/%d/", pid), procBase)
 		meta.ExtraMeta = map[libpf.String]string{key: meta.Executable.String()}
 	})
 
-	pm := &ProcessManager{
-		ebpf:             &testEbpfHandler{},
-		interpreters:     make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
-		pidToProcessInfo: make(map[libpf.PID]*processInfo),
-		exitEvents:       make(map[libpf.PID]times.KTime),
-		metaEnrichers:    []process.MetaEnricher{enricher},
-	}
+	pm := newTestProcessManager([]process.MetaEnricher{enricher}, nil)
 
 	// Process first seen: gather and enrich metadata.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
 	require.Equal(1, enricherCalls)
-	require.Equal("foobar", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ := pm.metaForPID(pid)
+	require.Equal("foobar", meta.ExtraMeta[key])
 
 	// Unchanged executable: don't refetch metadata, don't enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
@@ -594,5 +591,405 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	// Executable changed: refetch metadata and enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobarbaz")})
 	require.Equal(2, enricherCalls)
-	require.Equal("foobarbaz", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ = pm.metaForPID(pid)
+	require.Equal("foobarbaz", meta.ExtraMeta[key])
+}
+
+// testResourceEnricher is a ResourceEnricher whose behaviour each test controls
+// through enrich.
+type testResourceEnricher struct {
+	cfg    procmeta.ResourceConfig
+	calls  int
+	reqs   []procmeta.ResourceRequest
+	enrich func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool)
+}
+
+func (e *testResourceEnricher) ResourceConfig() procmeta.ResourceConfig {
+	return e.cfg
+}
+
+func (e *testResourceEnricher) EnrichResource(req *procmeta.ResourceRequest) (
+	*pcommon.Resource, bool,
+) {
+	e.calls++
+	e.reqs = append(e.reqs, *req)
+	if e.enrich == nil {
+		return nil, false
+	}
+	return e.enrich(req, e.calls)
+}
+
+// resourceWithAttr builds a single-attribute resource.
+func resourceWithAttr(key, value string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	r.Attributes().PutStr(key, value)
+	return &r
+}
+
+// resourceAttrs flattens a resource's string attributes, or returns nil.
+func resourceAttrs(r *pcommon.Resource) map[string]string {
+	if r == nil {
+		return nil
+	}
+	attrs := make(map[string]string, r.Attributes().Len())
+	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+		attrs[k] = v.Str()
+		return true
+	})
+	return attrs
+}
+
+func newTestProcessManager(metaEnrichers []process.MetaEnricher,
+	resourceEnrichers []procmeta.ResourceEnricher,
+) *ProcessManager {
+	return &ProcessManager{
+		ebpf:              &testEbpfHandler{},
+		interpreters:      make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
+		pidToProcessInfo:  make(map[libpf.PID]*processInfo),
+		exitEvents:        make(map[libpf.PID]times.KTime),
+		metaEnrichers:     metaEnrichers,
+		resourceEnrichers: resourceEnrichers,
+		mappingFilters:    newMappingFilters(resourceEnrichers),
+	}
+}
+
+// TestSynchronizeProcessRunsResourceEnrichers verifies that resource enrichers run
+// on every synchronization, unlike meta enrichers, so attributes resolving after
+// first observation are still picked up.
+func TestSynchronizeProcessRunsResourceEnrichers(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	// Contributes nothing on the first call, then an attribute on the second, as a
+	// late-resolving enricher would.
+	enricher := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				return nil, false
+			}
+			return resourceWithAttr("late.attr", "resolved"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(1, enricher.calls)
+	_, resource := pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Equal(pid, enricher.reqs[0].Process.PID())
+
+	// Same executable: the meta enrichers would not run, but this one does.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(2, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting no change keeps the published contribution.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, false
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(3, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting a change with a nil resource withdraws it.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, true
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptUntilExec verifies that derived
+// state is kept across synchronizations of one program and dropped on the one after
+// an exec — an empty slot being the whole signal an enricher gets, and needs.
+func TestSynchronizeProcessResourceEnricherStateKeptUntilExec(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	// The state each call was handed, which is how the exec handling is observable.
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Seed a known process with a mapping the sync below can match and reuse, which
+	// keeps it out of the ELF-parsing path that needs a fuller ProcessManager.
+	rawMapping := process.RawMapping{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R | elf.PF_X,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}
+	pm.pidToProcessInfo[pid] = &processInfo{
+		meta: process.Meta{Executable: exe},
+		mappings: []Mapping{{
+			Vaddr:  libpf.Address(rawMapping.Vaddr),
+			Length: rawMapping.Length,
+			Device: rawMapping.Device,
+			Inode:  rawMapping.Inode,
+			FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
+				File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+					FileID:   libpf.NewFileID(1, 0),
+					FileName: libpf.Intern("foobar"),
+				}),
+				Start: 0,
+				End:   libpf.Address(rawMapping.Length),
+			}),
+		}},
+		contributions: make([]*pcommon.Resource, 1),
+		enricherState: make([]any, 1),
+	}
+
+	// Known process, unchanged executable: what the previous call stored is still
+	// there, the seeded record included.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{rawMapping}}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]any{nil, 1}, seen)
+
+	// Executable changed: the state derived from the program that is gone goes too.
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid, exe: libpf.Intern("/bin/other"),
+		mappings: []process.RawMapping{rawMapping},
+	})
+	require.Equal([]any{nil, 1, nil}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings verifies that a
+// process retaining no mapping keeps its derived state all the same. Retained
+// mappings say nothing about the lifecycle — a fully JIT-compiled process keeps
+// none — and looking execed every sync would resolve fill-once enrichers forever.
+func TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Non-executable, so no mapping is retained for the process.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}}}
+
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+
+	pm.mu.RLock()
+	mappings := pm.pidToProcessInfo[pid].mappings
+	pm.mu.RUnlock()
+	require.Empty(mappings)
+
+	// New once, on first observation, and never again.
+	require.Equal([]any{nil, 1, 2}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherExecDropsContributions verifies that an exec
+// drops what the enrichers derived from the previous program. Otherwise an enricher
+// resolving nothing for the new executable — runtime info once a Python process
+// execs a native binary — would keep the old attributes indefinitely.
+func TestSynchronizeProcessResourceEnricherExecDropsContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				*req.State = "resolved"
+				return resourceWithAttr("process.runtime.name", "cpython"), true
+			}
+			// Nothing to report for the new executable.
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"process.runtime.name": "cpython"}, resourceAttrs(resource))
+
+	// Exec: the contribution and the state derived from the old program go.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Nil(*enricher.reqs[1].State)
+}
+
+// TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource verifies that a
+// replaced program's resource is never readable beside the new executable's
+// metadata, which is published before the enrichers run and the resource after. An
+// enricher runs in exactly that window, so it can observe what a trace would see.
+func TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	type observation struct {
+		exe      string
+		resource *pcommon.Resource
+	}
+	var observed []observation
+
+	enricher := &testResourceEnricher{}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		meta, resource := pm.metaForPID(pid)
+		observed = append(observed, observation{meta.Executable.String(), resource})
+		// Identify the program, so a contribution carried across the exec shows up.
+		return resourceWithAttr("exe", meta.Executable.String()), true
+	}
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/python3"}, resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/native"}, resourceAttrs(resource))
+
+	require.Len(observed, 2)
+	// First observation: the process has no resource yet.
+	require.Equal("/usr/bin/python3", observed[0].exe)
+	require.Nil(observed[0].resource)
+	// Second: metadata is already the new program's, so the old resource is gone.
+	require.Equal("/usr/bin/native", observed[1].exe)
+	require.Nil(observed[1].resource)
+}
+
+// TestSynchronizeProcessMergesResourceContributions verifies that contributions
+// from several enrichers are merged, with later enrichers winning on key
+// collisions, and that each enricher's contribution is tracked independently.
+func TestSynchronizeProcessMergesResourceContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	first := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			r := pcommon.NewResource()
+			r.Attributes().PutStr("shared", "first")
+			r.Attributes().PutStr("only.first", "1")
+			return &r, true
+		},
+	}
+	second := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			// Contribute only on the first call, to check the stored contribution
+			// still takes part in later merges.
+			if call > 1 {
+				return nil, false
+			}
+			return resourceWithAttr("shared", "second"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{first, second})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+}
+
+// TestSynchronizeProcessResourceEnricherState verifies that per-process enricher
+// state survives across synchronizations and is dropped, and closed, on exit.
+func TestSynchronizeProcessResourceEnricherState(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	var seen []int
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			state, _ := (*req.State).(*testEnricherState)
+			if state == nil {
+				state = &testEnricherState{}
+				*req.State = state
+			}
+			state.counter++
+			seen = append(seen, state.counter)
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	proc := &testProcess{pid: pid, exe: libpf.Intern("foobar")}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3}, seen)
+
+	pm.mu.RLock()
+	state, _ := pm.pidToProcessInfo[pid].enricherState[0].(*testEnricherState)
+	pm.mu.RUnlock()
+	require.NotNil(state)
+
+	// Process exit drops the state along with the processInfo holding it.
+	pm.processPIDExit(pid)
+	pm.ProcessedUntil(times.GetKTime())
+
+	pm.mu.RLock()
+	_, tracked := pm.pidToProcessInfo[pid]
+	pm.mu.RUnlock()
+	require.False(tracked)
+
+	// A process observed again under the same PID starts from empty state.
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3, 1}, seen)
+}
+
+type testEnricherState struct {
+	counter int
+}
+
+// TestSynchronizeProcessResourceEnricherMappings verifies that only the mappings
+// an enricher's WantMapping filter selects are delivered to it, and that each
+// enricher gets its own selection.
+func TestSynchronizeProcessResourceEnricherMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	wantsNamed := &testResourceEnricher{
+		cfg: procmeta.ResourceConfig{
+			WantMapping: func(m *process.RawMapping) bool { return m.Path == "[anon:MY_REGION]" },
+		},
+	}
+	wantsNothing := &testResourceEnricher{}
+	pm := newTestProcessManager(nil,
+		[]procmeta.ResourceEnricher{wantsNamed, wantsNothing})
+
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid,
+		exe: libpf.Intern("foobar"),
+		mappings: []process.RawMapping{
+			{Vaddr: 0x1000, Flags: elf.PF_R, Path: "/bin/foobar"},
+			{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+			{Vaddr: 0x3000, Flags: elf.PF_R | elf.PF_W},
+		},
+	})
+
+	require.Len(wantsNamed.reqs, 1)
+	require.Equal([]process.RawMapping{
+		{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+	}, wantsNamed.reqs[0].Mappings)
+
+	require.Len(wantsNothing.reqs, 1)
+	require.Empty(wantsNothing.reqs[0].Mappings)
 }

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	lru "github.com/elastic/go-freelru"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -132,6 +134,16 @@ type ProcessManager struct {
 
 	metaEnrichers []process.MetaEnricher
 
+	// resourceEnrichers contribute OTel resource attributes on every process
+	// synchronization. Their index is the index into processInfo.contributions
+	// and processInfo.enricherState.
+	resourceEnrichers []procmeta.ResourceEnricher
+
+	// mappingFilters holds the non-nil WantMapping filters of resourceEnrichers,
+	// in the same order, so the mapping pass can dispatch without re-reading each
+	// enricher's config. Empty when no enricher wants mappings.
+	mappingFilters []mappingFilter
+
 	// probeAttachers is the set of per-process probe attachers registered via
 	// RegisterProbeAttacher. Protected by mu.
 	probeAttachers []ProbeAttacher
@@ -168,11 +180,26 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 	}
 }
 
+// mappingFilter pairs a WantMapping predicate with the enricher that declared it.
+type mappingFilter struct {
+	enricher int
+	want     func(m *process.RawMapping) bool
+}
+
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
 	// process metadata, updated on executable changes
 	meta process.Meta
+	// resource is the merge of the contributions, published under ProcessManager.mu
+	// and immutable once it is. Nil until something contributes.
+	resource *pcommon.Resource
+	// contributions holds each enricher's latest contribution, indexed by
+	// ProcessManager.resourceEnrichers. Entries are immutable once stored.
+	contributions []*pcommon.Resource
+	// enricherState holds each enricher's per-process state, indexed the same way.
+	// Dropped, with no teardown call, when the process exits.
+	enricherState []any
 	// executable mappings sorted by FileID and mapping start address
 	mappings []Mapping
 	// C-library Thread Specific Data information

--- a/procmeta/procmeta.go
+++ b/procmeta/procmeta.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package procmeta provides the extension point for contributing OTel resource
+// attributes to a profiled process.
+//
+// It complements process.MetaEnricher, which collects metadata once when a process
+// is first observed. Attributes that resolve later — a memory region published
+// after startup, a runtime whose interpreter attaches once its mapping appears —
+// need a ResourceEnricher, called on every resynchronization, contributing an
+// immutable resource rather than writing to shared metadata.
+package procmeta // import "go.opentelemetry.io/ebpf-profiler/procmeta"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/util"
+)
+
+// ResourceConfig declares what a ResourceEnricher needs. The zero value asks for
+// nothing; new requirements are added as new fields.
+type ResourceConfig struct {
+	// WantMapping selects the mappings delivered in ResourceRequest.Mappings, nil
+	// selecting none. Called for every mapping of every synchronized process, so it
+	// must be cheap: no allocation, no syscalls.
+	WantMapping func(m *process.RawMapping) bool
+}
+
+// ResourceRequest describes a process and what the process manager observed for it
+// this synchronization. Valid only for the duration of the EnrichResource call:
+// enrichers must not retain it, or anything reachable from it.
+type ResourceRequest struct {
+	// Process gives access to remote memory, mappings and the executable.
+	Process process.Process
+
+	// Mappings holds the mappings selected by ResourceConfig.WantMapping, in
+	// /proc/<pid>/maps order.
+	Mappings []process.RawMapping
+
+	// Interpreters holds the instances attached to the process, keyed by the on-disk
+	// identity of the DSO each was detected in, and is nil until one attaches.
+	// Read-only: driving the instances belongs to the process manager.
+	Interpreters map[util.OnDiskFileIdentifier]interpreter.Instance
+
+	// State points at the manager's per-process storage slot for this enricher:
+	// *State is what the previous call stored, nil on the first. Keep per-process
+	// state here rather than in enricher-owned maps, so it is dropped with the
+	// process. Storage, not a lifecycle — the value is dropped with no teardown
+	// call, so it must not own anything needing an explicit release.
+	State *any
+}
+
+// ResourceEnricher contributes OTel resource attributes for a process.
+type ResourceEnricher interface {
+	// ResourceConfig returns the enricher's requirements. It is called once, when
+	// the enricher is registered.
+	ResourceConfig() ResourceConfig
+
+	// EnrichResource returns the enricher's contribution for the process described
+	// by req, freshly built and treated as immutable by the caller, which retains it
+	// across synchronizations.
+	//
+	// changed reports whether it differs from the previous call's: false keeps the
+	// stored contribution and ignores res, (nil, true) withdraws it. Withdrawing a
+	// process's last contribution takes effect at the next reporting period, since
+	// samples already collected keep the attribution they were collected with.
+	//
+	// A first call, and the one after an exec, arrive with State and the stored
+	// contribution already dropped, so an execed process needs no special handling:
+	// it looks exactly like one never seen before.
+	EnrichResource(req *ResourceRequest) (res *pcommon.Resource, changed bool)
+}
+
+// MergeResources combines a base resource with enricher contributions, applied in
+// order, so a contribution wins over the base and a later one over an earlier one
+// on key collisions. Any input may be nil.
+//
+// Returns nil if all are nil, and shares a single non-nil input as-is: inputs are
+// immutable, so copying is unnecessary.
+func MergeResources(base *pcommon.Resource,
+	contributions []*pcommon.Resource,
+) *pcommon.Resource {
+	count, single := 0, base
+	if base != nil {
+		count = 1
+	}
+	for _, c := range contributions {
+		if c != nil {
+			count++
+			single = c
+		}
+	}
+	if count <= 1 {
+		return single
+	}
+
+	merged := pcommon.NewResource()
+	attrs := merged.Attributes()
+	add := func(r *pcommon.Resource) {
+		if r == nil {
+			return
+		}
+		r.Attributes().Range(func(k string, v pcommon.Value) bool {
+			v.CopyTo(attrs.PutEmpty(k))
+			return true
+		})
+	}
+	add(base)
+	for _, c := range contributions {
+		add(c)
+	}
+	return &merged
+}

--- a/procmeta/procmeta_test.go
+++ b/procmeta/procmeta_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// resourceWith builds a resource from string attributes.
+func resourceWith(attrs map[string]string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	for k, v := range attrs {
+		r.Attributes().PutStr(k, v)
+	}
+	return &r
+}
+
+func TestMergeResources(t *testing.T) {
+	tests := map[string]struct {
+		base          *pcommon.Resource
+		contributions []*pcommon.Resource
+		expected      map[string]string
+		expectNil     bool
+	}{
+		"no contributions": {
+			contributions: nil,
+			expectNil:     true,
+		},
+		"all nil": {
+			contributions: []*pcommon.Resource{nil, nil},
+			expectNil:     true,
+		},
+		"base only": {
+			base:     resourceWith(map[string]string{"a": "1"}),
+			expected: map[string]string{"a": "1"},
+		},
+		"contribution wins over base": {
+			base: resourceWith(map[string]string{"a": "from-base", "c": "3"}),
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "contributed"}),
+			},
+			expected: map[string]string{"a": "contributed", "c": "3"},
+		},
+		"single contribution": {
+			contributions: []*pcommon.Resource{nil, resourceWith(map[string]string{"a": "1"})},
+			expected:      map[string]string{"a": "1"},
+		},
+		"disjoint keys": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "1"}),
+				resourceWith(map[string]string{"b": "2"}),
+			},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		"later contribution wins on collision": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "first", "b": "2"}),
+				resourceWith(map[string]string{"a": "second"}),
+			},
+			expected: map[string]string{"a": "second", "b": "2"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			merged := MergeResources(test.base, test.contributions)
+			if test.expectNil {
+				require.Nil(t, merged)
+				return
+			}
+			require.NotNil(t, merged)
+
+			got := make(map[string]string, merged.Attributes().Len())
+			merged.Attributes().Range(func(k string, v pcommon.Value) bool {
+				got[k] = v.Str()
+				return true
+			})
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+// TestMergeResourcesDoesNotModifyContributions verifies that merging leaves the
+// inputs untouched: the process manager retains them across synchronizations and
+// re-merges them, so a merge that mutated them would corrupt later merges.
+func TestMergeResourcesDoesNotModifyContributions(t *testing.T) {
+	first := resourceWith(map[string]string{"a": "first"})
+	second := resourceWith(map[string]string{"a": "second"})
+
+	merged := MergeResources(first, []*pcommon.Resource{second})
+	require.NotNil(t, merged)
+
+	v, ok := merged.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+
+	v, ok = first.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "first", v.Str())
+	v, ok = second.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+}
+
+// TestMergeResourcesSharesSingleContribution documents that a lone contribution
+// is returned as-is rather than copied. Contributions are immutable, so sharing
+// is safe and avoids an allocation on the common single-enricher path.
+func TestMergeResourcesSharesSingleContribution(t *testing.T) {
+	only := resourceWith(map[string]string{"a": "1"})
+	require.Same(t, only, MergeResources(nil, []*pcommon.Resource{nil, only, nil}))
+	// Likewise a base with no contribution to merge onto it.
+	require.Same(t, only, MergeResources(only, nil))
+}

--- a/procmeta/runtimeinfo/runtimeinfo.go
+++ b/procmeta/runtimeinfo/runtimeinfo.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package runtimeinfo contributes the process.runtime.name and
+// process.runtime.version resource attributes. Knowing a sample came from CPython
+// 3.11.4 rather than just "CPython" is what lets that version's standard library
+// sources be resolved.
+package runtimeinfo // import "go.opentelemetry.io/ebpf-profiler/procmeta/runtimeinfo"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/log"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
+)
+
+// enricher reports the runtime of a process. Stateless: whether a process is
+// already resolved is recorded in its state slot.
+type enricher struct{}
+
+// NewEnricher returns a ResourceEnricher contributing the language runtime of a
+// process, resolved from the interpreters the profiler attached to it.
+func NewEnricher() procmeta.ResourceEnricher {
+	return enricher{}
+}
+
+func (enricher) ResourceConfig() procmeta.ResourceConfig {
+	return procmeta.ResourceConfig{}
+}
+
+// resolved marks a process whose runtime has been reported, which is then left
+// alone: a process does not swap runtimes, and re-resolving on every sync would let
+// the reported one flip as further interpreters attach. An exec needs no handling
+// here: the manager drops this marker with the contribution, so the next call
+// resolves again.
+type resolved struct{}
+
+func (enricher) EnrichResource(req *procmeta.ResourceRequest) (*pcommon.Resource, bool) {
+	if _, done := (*req.State).(resolved); done {
+		return nil, false
+	}
+
+	name, version := selectRuntime(req)
+	if name == "" {
+		// No interpreter attached yet, or none can report. They are detected as their
+		// mappings appear, so a later synchronization may still resolve one.
+		return nil, false
+	}
+
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv.ProcessRuntimeNameKey), name)
+	if version != "" {
+		res.Attributes().PutStr(string(semconv.ProcessRuntimeVersionKey), version)
+	}
+
+	*req.State = resolved{}
+	return &res, true
+}
+
+// selectRuntime picks the runtime to report for a process that may host several: a
+// Go binary embedding CPython, or Python calling a JIT-compiled library over FFI.
+func selectRuntime(req *procmeta.ResourceRequest) (name, version string) {
+	// Smallest (name, version), so a process hosting several keeps reporting the same
+	// one instead of flipping with Go's map order and splitting its samples.
+	candidates := 0
+	for _, inst := range req.Interpreters {
+		n, v, ok := inst.RuntimeInfo()
+		if !ok {
+			continue
+		}
+		candidates++
+		if name == "" || n < name || (n == name && v < version) {
+			name, version = n, v
+		}
+	}
+	if candidates < 2 {
+		// Nothing to disambiguate: none can report, or exactly one can and it is the
+		// answer whichever DSO it came from. Identifying the executable costs a stat,
+		// so it waits for an actual choice — a process that never resolves a runtime
+		// would otherwise pay for it on every resynchronization.
+		return name, version
+	}
+
+	// Prefer the top-level runtime: the one whose DSO is the process's own
+	// executable. That is what makes a Go binary embedding CPython report "go".
+	exeID, err := req.Process.GetExecutableFileIdentifier()
+	if err != nil {
+		log.Debugf("Failed to identify the executable of PID %d: %v", req.Process.PID(), err)
+		return name, version
+	}
+	if inst, ok := req.Interpreters[exeID]; ok {
+		if n, v, ok := inst.RuntimeInfo(); ok {
+			return n, v
+		}
+	}
+	return name, version
+}

--- a/procmeta/runtimeinfo/runtimeinfo_test.go
+++ b/procmeta/runtimeinfo/runtimeinfo_test.go
@@ -1,0 +1,255 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeinfo_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
+	"go.opentelemetry.io/ebpf-profiler/procmeta/runtimeinfo"
+	"go.opentelemetry.io/ebpf-profiler/util"
+)
+
+// fakeInstance is an interpreter.Instance reporting a fixed runtime.
+type fakeInstance struct {
+	interpreter.InstanceStubs
+	name, version string
+	// reports is false for an interpreter that cannot tell its runtime, as one whose
+	// version data is unread does.
+	reports bool
+}
+
+func (i *fakeInstance) RuntimeInfo() (string, string, bool) {
+	return i.name, i.version, i.reports
+}
+
+func (i *fakeInstance) Detach(interpreter.EbpfHandler, libpf.PID) error { return nil }
+
+func runtime(name, version string) *fakeInstance {
+	return &fakeInstance{name: name, version: version, reports: true}
+}
+
+func oid(inode uint64) util.OnDiskFileIdentifier {
+	return util.OnDiskFileIdentifier{DeviceID: 1, InodeNum: inode}
+}
+
+// fakeProcess reports nothing but its executable's identity and its PID, all the
+// enricher asks of it. The embedded interface is nil, so any other call panics.
+type fakeProcess struct {
+	process.Process
+	exe util.OnDiskFileIdentifier
+	// err is returned instead of exe, as it is for a process whose executable
+	// cannot be stat'ed any more.
+	err error
+}
+
+func (p *fakeProcess) GetExecutableFileIdentifier() (util.OnDiskFileIdentifier, error) {
+	return p.exe, p.err
+}
+
+func (*fakeProcess) PID() libpf.PID { return 1 }
+
+var errNotImplemented = errors.New("not implemented")
+
+// executable returns a process whose executable has the given identity.
+func executable(exe util.OnDiskFileIdentifier) *fakeProcess {
+	return &fakeProcess{exe: exe}
+}
+
+// enrich runs the enricher once and returns the attributes it contributed.
+func enrich(t *testing.T, req *procmeta.ResourceRequest) (map[string]string, bool) {
+	t.Helper()
+	res, changed := runtimeinfo.NewEnricher().EnrichResource(req)
+	if res == nil {
+		return nil, changed
+	}
+	attrs := make(map[string]string, res.Attributes().Len())
+	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+		attrs[k] = v.Str()
+		return true
+	})
+	return attrs, changed
+}
+
+func TestEnricher_SelectRuntime(t *testing.T) {
+	exeOID := oid(1)
+	libOID := oid(2)
+
+	tests := map[string]struct {
+		interpreters map[util.OnDiskFileIdentifier]interpreter.Instance
+		proc         *fakeProcess
+		expected     map[string]string
+	}{
+		"no interpreter attached": {
+			proc: executable(exeOID),
+		},
+		"single runtime in the executable": {
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: runtime("cpython", "3.11.4"),
+			},
+			proc: executable(exeOID),
+			expected: map[string]string{
+				"process.runtime.name":    "cpython",
+				"process.runtime.version": "3.11.4",
+			},
+		},
+		"single runtime in a library": {
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				libOID: runtime("cpython", "3.11.4"),
+			},
+			proc: executable(exeOID),
+			expected: map[string]string{
+				"process.runtime.name":    "cpython",
+				"process.runtime.version": "3.11.4",
+			},
+		},
+		"executable wins over embedded runtime": {
+			// A Go binary embedding CPython must report Go.
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: runtime("go", "1.24.6"),
+				libOID: runtime("cpython", "3.11.4"),
+			},
+			proc: executable(exeOID),
+			expected: map[string]string{
+				"process.runtime.name":    "go",
+				"process.runtime.version": "1.24.6",
+			},
+		},
+		"executable reports nothing, fall back to a library": {
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &fakeInstance{},
+				libOID: runtime("ruby", "3.3.0"),
+			},
+			proc: executable(exeOID),
+			expected: map[string]string{
+				"process.runtime.name":    "ruby",
+				"process.runtime.version": "3.3.0",
+			},
+		},
+		"executable not observed, several libraries": {
+			// Deterministic despite Go's randomized map iteration: smallest
+			// (name, version) wins, so samples do not split across resources.
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				oid(2): runtime("ruby", "3.3.0"),
+				oid(3): runtime("cpython", "3.12.7"),
+				oid(4): runtime("cpython", "3.11.4"),
+				oid(5): runtime("php", "8.3.1"),
+			},
+			expected: map[string]string{
+				"process.runtime.name":    "cpython",
+				"process.runtime.version": "3.11.4",
+			},
+		},
+		"executable cannot be identified, fall back to a library": {
+			// The exe symlink is gone, as it is for a process that exited under us.
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: runtime("go", "1.24.6"),
+				libOID: runtime("cpython", "3.11.4"),
+			},
+			proc: &fakeProcess{err: errNotImplemented},
+			expected: map[string]string{
+				"process.runtime.name":    "cpython",
+				"process.runtime.version": "3.11.4",
+			},
+		},
+		"no interpreter reports a runtime": {
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: &fakeInstance{},
+				libOID: &fakeInstance{},
+			},
+			proc: executable(exeOID),
+		},
+		"version omitted when unknown": {
+			interpreters: map[util.OnDiskFileIdentifier]interpreter.Instance{
+				exeOID: runtime("erlang", ""),
+			},
+			proc: executable(exeOID),
+			expected: map[string]string{
+				"process.runtime.name": "erlang",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var state any
+			proc := test.proc
+			if proc == nil {
+				proc = executable(util.OnDiskFileIdentifier{})
+			}
+			attrs, changed := enrich(t, &procmeta.ResourceRequest{
+				Process:      proc,
+				Interpreters: test.interpreters,
+				State:        &state,
+			})
+			require.Equal(t, test.expected, attrs)
+			require.Equal(t, test.expected != nil, changed)
+		})
+	}
+}
+
+// TestEnricher_ResolvesOnceUntilExec verifies that the runtime is resolved as soon as
+// an interpreter attaches, then left alone — re-resolving would let it flip as more
+// attach — and resolved afresh after an exec.
+func TestEnricher_ResolvesOnceUntilExec(t *testing.T) {
+	e := runtimeinfo.NewEnricher()
+	exeOID := oid(1)
+	var state any
+
+	// No interpreter attached yet: nothing to report, but keep looking.
+	req := &procmeta.ResourceRequest{Process: executable(exeOID), State: &state}
+	_, changed := e.EnrichResource(req)
+	require.False(t, changed)
+	require.Nil(t, state)
+
+	// An interpreter attaches.
+	req.Interpreters = map[util.OnDiskFileIdentifier]interpreter.Instance{
+		exeOID: runtime("cpython", "3.11.4"),
+	}
+	res, changed := e.EnrichResource(req)
+	require.True(t, changed)
+	v, ok := res.Attributes().Get("process.runtime.version")
+	require.True(t, ok)
+	require.Equal(t, "3.11.4", v.Str())
+
+	// Already resolved: a second interpreter does not change what is reported.
+	req.Interpreters[oid(2)] = runtime("cpython", "3.9.1")
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+
+	// An exec replaces the program, so the runtime resolves again. The manager
+	// performs one by clearing the state slot and the contribution before calling any
+	// enricher, so this one has nothing of its own to do about it.
+	state = nil
+	req.Interpreters = map[util.OnDiskFileIdentifier]interpreter.Instance{
+		exeOID: runtime("ruby", "3.3.0"),
+	}
+	res, changed = e.EnrichResource(req)
+	require.True(t, changed)
+	v, ok = res.Attributes().Get("process.runtime.name")
+	require.True(t, ok)
+	require.Equal(t, "ruby", v.Str())
+
+	// An exec into a program hosting no runtime reports nothing, which cannot mean
+	// "the previous runtime still holds": the manager already dropped it.
+	state = nil
+	req.Interpreters = nil
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+	require.Nil(t, state)
+}
+
+func TestEnricher_ResourceConfig(t *testing.T) {
+	// The runtime is derived from the interpreters the process manager passes in,
+	// so this enricher needs no mappings of its own.
+	cfg := runtimeinfo.NewEnricher().ResourceConfig()
+	require.Nil(t, cfg.WantMapping)
+}

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -75,6 +75,14 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	rtp := (*eventsTree)[key]
+	// Refresh so a resource resolved late applies to the samples already collected
+	// for this PID this period. Only non-nil overwrites, so a process whose
+	// attributes become unreadable keeps what it had; the next period starts from an
+	// empty tree, which is where a withdrawal takes effect.
+	if meta.Resource != nil && meta.Resource != rtp.Resource {
+		rtp.Resource = meta.Resource
+		(*eventsTree)[key] = rtp
+	}
 	if _, exists := rtp.Events[meta.ProfileType]; !exists {
 		rtp.Events[meta.ProfileType] = make(samples.SampleToEvents)
 	}

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -175,6 +176,69 @@ func TestBaseReporterGenerate(t *testing.T) {
 	// Verify profiles exist
 	assert.Greater(t, scopeProfile.Profiles().Len(), 0,
 		"Should have at least one profile")
+}
+
+// TestReportTraceEventLateResourceAppliesRetroactively verifies that a context
+// published after sampling started applies to that PID's earlier samples: one
+// bucket, the late resource applied, and a later nil not stripping it.
+func TestReportTraceEventLateResourceAppliesRetroactively(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+
+	makeResource := func(name string) *pcommon.Resource {
+		r := pcommon.NewResource()
+		r.Attributes().PutStr("service.name", name)
+		return &r
+	}
+
+	trace := &libpf.Trace{
+		Frames: func() libpf.Frames {
+			frames := make(libpf.Frames, 0, 1)
+			frames.Append(&libpf.Frame{
+				Type:            libpf.NativeFrame,
+				AddressOrLineno: 0x100,
+				FunctionName:    libpf.Intern("f"),
+			})
+			return frames
+		}(),
+	}
+
+	now := libpf.UnixTime64(time.Now().UnixNano())
+	baseMeta := func(resource *pcommon.Resource) *samples.TraceEventMeta {
+		return &samples.TraceEventMeta{
+			Timestamp:      now,
+			Comm:           libpf.NewCommFromString("svc"),
+			ExecutablePath: libpf.Intern("/usr/bin/svc"),
+			ContainerID:    libpf.Intern("c1"),
+			PID:            1234,
+			TID:            1235,
+			ProfileType:    profileTypeSampling,
+			Resource:       resource,
+		}
+	}
+
+	// Samples collected before the process context is detected.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	// The context is published and detected: later samples carry the resource.
+	resource := makeResource("svc")
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(resource)))
+
+	// Process tears down and the context mapping disappears.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	tree := *treePtr
+
+	require.Len(t, tree, 1, "all samples for one PID belong to a single bucket")
+	for _, rtp := range tree {
+		require.NotNil(t, rtp.Resource,
+			"late-detected resource should apply to the whole period")
+		serviceName, ok := rtp.Resource.Attributes().Get("service.name")
+		require.True(t, ok)
+		assert.Equal(t, "svc", serviceName.Str())
+	}
 }
 
 // processNameAttrProducer is a test SampleAttrProducer that reads "process.name" from

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -103,7 +103,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 		}
 
 		rp := profiles.ResourceProfiles().AppendEmpty()
-		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars)
+		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars, toEvents.Resource)
 		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
@@ -303,7 +303,10 @@ func (p *Pdata) setProfile(
 	return nil
 }
 
-func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String) {
+func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String, res *pcommon.Resource) {
+	if res != nil {
+		res.Attributes().CopyTo(attrs)
+	}
 	if resource.APMServiceName != "" {
 		attrs.PutStr(string(semconv.ServiceNameKey), resource.APMServiceName)
 	}

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -866,3 +866,84 @@ func TestGenerate_Validate(t *testing.T) {
 		CheckSampleTimestampShape: true}).Check(&data)
 	require.NoError(t, err)
 }
+
+func singleEventTree(rk samples.ResourceKey, res *pcommon.Resource) samples.TraceEventsTree {
+	filePath := libpf.Intern("/bin/svc")
+	mapping := libpf.NewFrameMapping(libpf.FrameMappingData{
+		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+			FileID:   libpf.NewFileID(7, 8),
+			FileName: filePath,
+		}),
+	})
+	return samples.TraceEventsTree{
+		rk: samples.ResourceToProfiles{
+			Resource: res,
+			Events: map[*samples.TypeMetadata]samples.SampleToEvents{
+				profileTypeSampling: {
+					{}: &samples.TraceEvents{
+						Frames:     singleFrameTrace(libpf.NativeFrame, mapping, 0x10, "f", filePath, 1),
+						Timestamps: []uint64{uint64(time.Unix(1010, 0).UnixNano())},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGenerate_Resource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	res := pcommon.NewResource()
+	res.Attributes().PutStr("service.namespace", "team-a")
+	res.Attributes().PutStr("service.instance.id", "instance-42")
+	res.Attributes().PutStr("deployment.environment", "prod")
+	res.Attributes().PutInt("not-a-string", 7)
+	res.Attributes().PutStr(string(semconv.ServiceNameKey), "proto-svc")
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            42,
+	}, &res)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		"service.namespace":                      "team-a",
+		"service.instance.id":                    "instance-42",
+		"deployment.environment":                 "prod",
+		"not-a-string":                           int64(7),
+		string(semconv.ServiceNameKey):           "proto-svc",
+		string(semconv.ProcessPIDKey):            int64(42),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}
+
+func TestGenerate_NilResource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            99,
+		APMServiceName: "apm-svc",
+	}, nil)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		string(semconv.ServiceNameKey):           "apm-svc",
+		string(semconv.ProcessPIDKey):            int64(99),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -4,6 +4,7 @@
 package samples // import "go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
@@ -17,6 +18,7 @@ type TraceEventMeta struct {
 	// SampleAttrProducer.CollectExtraSampleMeta to attach process-level attributes.
 	ExtraMeta      map[libpf.String]string
 	APMServiceName string
+	Resource       *pcommon.Resource
 	Timestamp      libpf.UnixTime64
 	CPU            uint32
 	ProfileType    *TypeMetadata
@@ -44,6 +46,11 @@ type ResourceToProfiles struct {
 	// EnvVars can not be part of ResourceKey as maps are not
 	// comparable.
 	EnvVars map[libpf.String]libpf.String
+
+	// Resource holds the OTel resource attributed to the process, if any.
+	// Deliberately not part of ResourceKey: refreshing it as samples arrive lets
+	// a resource resolved late apply to the whole reporting period.
+	Resource *pcommon.Resource
 
 	// Events holds the actual profiling information.
 	Events map[*TypeMetadata]SampleToEvents

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -211,6 +212,10 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process, called on every process synchronization.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
 	// PIDNamespaceTranslation toggles translation of host-level PIDs/TGIDs into
 	// their container-namespace equivalents. Useful for sidecar deployments where
 	// the profiler and the target application share a PID namespace but not host PIDs.
@@ -298,6 +303,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		FilterErrorFrames:     cfg.FilterErrorFrames,
 		IncludeEnvVars:        cfg.IncludeEnvVars,
 		ProcessMetaEnrichers:  cfg.ProcessMetaEnrichers,
+		ResourceEnrichers:     cfg.ResourceEnrichers,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)


### PR DESCRIPTION
Reports `process.runtime.name` and `process.runtime.version` per process, derived from the
interpreter instances already attached to it: a new `RuntimeInfo()` on `interpreter.Instance`, plus a
`procmeta.ResourceEnricher` that selects among them and emits the attributes.

A process may host several runtimes, so the enricher prefers the one whose DSO is the process's own
executable, falls back to the lexicographically smallest for determinism, and resolves once until the
executable changes. All of that policy lives in the enricher, so no runtime-specific code is added to
the process manager. Relates to #1716.

Draft, since the first two commits add the `procmeta.ResourceEnricher` extension point this builds
on, which is a separate change.