### PR TITLE
procmeta/processcontext: propagate OTel process context as resource attributes

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -216,3 +216,27 @@ jobs:
             *) echo >&2 "bug: bad arch selected"; exit 1;;
           esac
           support/run-tests.sh ${{ matrix.kernel }}
+
+  # Runs on host (not qemu) because the qemu initramfs doesn't allow loading
+  # shared libraries, which the dlopen/lib testdata variants will need once thread
+  # context support lands.
+  host-integration-tests:
+    name: Integration tests (processcontext ${{ matrix.target_arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - { target_arch: amd64, runner: ubuntu-24.04 }
+          - { target_arch: arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - name: Clone code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up environment
+        uses: ./.github/workflows/env
+      - name: Install musl-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -y --no-install-recommends --no-install-suggests install musl-dev
+      - name: Run host integration tests
+        run: make host-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all all-common clean ebpf generate generate-collector test test-deps \
 	test-junit protobuf docker-image agent legal integration-test-binaries \
 	codespell lint ebpf-profiler format format-ebpf format-go pprof-execs \
+	processctx-execs host-integration-tests \
 	pprof_1_23 pprof_1_24 pprof_1_24_cgo otelcol-ebpf-profiler \
 	rust-components rust-targets rust-tests vanity-import-check vanity-import-fix \
 	otel-from-tree otel-from-lib
@@ -52,6 +53,7 @@ all: ebpf-profiler
 clean:
 	@go clean -cache -i
 	@$(MAKE) -s -C support/ebpf clean
+	@$(MAKE) -C procmeta/processcontext/integrationtests/testdata clean
 	@chmod -Rf u+w go/ || true
 	@rm -rf go .cache support/*.test interpreter/go/integrationtests/pprof_1_*
 	@rm -f otelcol-ebpf-profiler cmd/otelcol-ebpf-profiler/{*.go,go.mod,go.sum} || true
@@ -143,6 +145,14 @@ test-deps: $(GOLABELS_TESTDATA_TARGETS)
 	)
 
 TEST_INTEGRATION_BINARY_DIRS := tracer processmanager/ebpf kallsyms support interpreter/go/integrationtests
+
+processctx-execs:
+	$(MAKE) -C procmeta/processcontext/integrationtests/testdata
+
+# Runs on the host (not qemu): the runtime differs from the qemu-based
+# integration suite, so it uses a dedicated build tag.
+host-integration-tests: processctx-execs
+	go test -exec sudo -v -tags host_integration ./procmeta/processcontext/integrationtests/
 
 pprof-execs: pprof_1_23 pprof_1_24 pprof_1_24_cgo pprof_1_24_cgo_pie pprof_stable pprof_stable_buildinfo_cgo pprof_stable_cgo pprof_stable_cgo_pie
 

--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -8,6 +8,7 @@ package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
 import (
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 )
 
@@ -18,6 +19,7 @@ type Option interface {
 type controllerOption struct {
 	executableReporter   reporter.ExecutableReporter
 	processMetaEnrichers []process.MetaEnricher
+	resourceEnrichers    []procmeta.ResourceEnricher
 	reporterFactory      func(cfg *reporter.Config, nextConsumer xconsumer.Profiles) (reporter.Reporter, error)
 	onShutdown           func() error
 }
@@ -59,6 +61,19 @@ func WithReporterFactory(reporterFactory func(cfg *reporter.Config, nextConsumer
 func WithProcessMetaEnricher(enrichers ...process.MetaEnricher) Option {
 	return optFunc(func(option *controllerOption) *controllerOption {
 		option.processMetaEnrichers = append(option.processMetaEnrichers, enrichers...)
+		return option
+	})
+}
+
+// WithResourceEnricher registers a hook contributing OTel resource attributes to a
+// process. Unlike WithProcessMetaEnricher it runs on every mapping
+// resynchronization, so it can supply attributes that resolve after first
+// observation: a memory region published later, a runtime whose interpreter
+// attaches. It declares what it needs through procmeta.ResourceConfig, and its
+// contribution is merged into the resource of that process's profiles.
+func WithResourceEnricher(enrichers ...procmeta.ResourceEnricher) Option {
+	return optFunc(func(option *controllerOption) *controllerOption {
+		option.resourceEnrichers = append(option.resourceEnrichers, enrichers...)
 		return option
 	})
 }

--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -76,6 +76,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 			Config:               *cfg,
 			ExecutableReporter:   controllerOption.executableReporter,
 			ProcessMetaEnrichers: controllerOption.processMetaEnrichers,
+			ResourceEnrichers:    controllerOption.resourceEnrichers,
 			ReporterFactory:      controllerOption.reporterFactory,
 			OnShutdown:           controllerOption.onShutdown,
 		}

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/collector/config"
@@ -24,7 +25,12 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery and executable change time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
-	OnShutdown           func() error
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process. They are called on every process synchronization,
+	// so they can supply attributes that resolve later than process discovery.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
+	OnShutdown        func() error
 
 	// If ReporterFactory is set, it will be used to create a Reporter and set it as the Reporter field.
 	// Either ReporterFactory or Reporter must be set. If both are set, ReporterFactory will be used.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -109,6 +109,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		OBIProcessCtx:           c.config.OBIProcessCtx,
 		PIDNamespaceTranslation: c.config.PIDNamespaceTranslation,
 		ProcessMetaEnrichers:    c.config.ProcessMetaEnrichers,
+		ResourceEnrichers:       c.config.ResourceEnrichers,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load eBPF tracer: %w", err)

--- a/process/types.go
+++ b/process/types.go
@@ -12,7 +12,6 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
-	"go.opentelemetry.io/ebpf-profiler/processcontext"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
@@ -115,8 +114,6 @@ type Meta struct {
 	EnvVariables map[libpf.String]libpf.String
 	// container ID retrieved from /proc/PID/cgroup
 	ContainerID libpf.String
-	// process context
-	ProcessContextInfo processcontext.Info
 
 	// ExtraMeta holds arbitrary key-value pairs populated by a MetaEnricher.
 	// It is nil unless an enricher is configured and explicitly sets values.

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -71,6 +72,20 @@ type Config struct {
 	FilterErrorFrames     bool
 	IncludeEnvVars        libpf.Set[string]
 	ProcessMetaEnrichers  []process.MetaEnricher
+	ResourceEnrichers     []procmeta.ResourceEnricher
+}
+
+// newMappingFilters resolves each enricher's mapping requirements once, so the
+// mapping pass need not re-read them, pairing every non-nil filter with the index of
+// the enricher that declared it — the index the selected mappings are delivered by.
+func newMappingFilters(enrichers []procmeta.ResourceEnricher) []mappingFilter {
+	var filters []mappingFilter
+	for i, e := range enrichers {
+		if want := e.ResourceConfig().WantMapping; want != nil {
+			filters = append(filters, mappingFilter{enricher: i, want: want})
+		}
+	}
+	return filters
 }
 
 // New creates a new ProcessManager which is responsible for keeping track of loading
@@ -82,6 +97,9 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 	if cfg.FrameCacheSize == 0 {
 		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
+
+	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
+	mappingFilters := newMappingFilters(resourceEnrichers)
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
 		util.OnDiskFileIdentifier.Hash32)
@@ -141,6 +159,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
 		metaEnrichers:            metaEnrichers,
+		resourceEnrichers:        resourceEnrichers,
+		mappingFilters:           mappingFilters,
 		attachedProbes:           make(map[libpf.PID]map[ProbeAttacher]libpf.Void),
 	}
 
@@ -379,7 +399,7 @@ func hashFrameCacheKey(fk frameCacheKey) uint32 {
 // trace handling to a goroutine pool, the caching strategy needs to be updated
 // accordingly.
 func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *samples.TypeMetadata) {
-	procMeta := pm.metaForPID(bpfTrace.PID)
+	procMeta, resource := pm.metaForPID(bpfTrace.PID)
 	meta := &samples.TraceEventMeta{
 		Timestamp:      libpf.UnixTime64(times.KTime(bpfTrace.KTime).UnixNano()),
 		Comm:           bpfTrace.Comm,
@@ -392,6 +412,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace, profileType *sa
 		ProfileType:    profileType,
 		Value:          bpfTrace.Value,
 		EnvVars:        procMeta.EnvVariables,
+		Resource:       resource,
 		TraceID:        bpfTrace.APMTraceID,
 		SpanID:         bpfTrace.APMTransactionID,
 		ExtraMeta:      procMeta.ExtraMeta,

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -98,6 +99,21 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		cfg.FrameCacheSize = DefaultFrameCacheSize
 	}
 
+	// Keep the user-requested reporting set separate from the full capture set.
+	reportEnvVars := maps.Clone(cfg.IncludeEnvVars)
+	includeEnvVars := maps.Clone(cfg.IncludeEnvVars)
+	if includeEnvVars == nil {
+		includeEnvVars = make(libpf.Set[string])
+	}
+	// The base resource's env vars are captured for every process; those the user did
+	// not ask for are dropped again once that resource is built.
+	internalOnlyEnvVars := make(libpf.Set[libpf.String])
+	for _, name := range procmeta.EnvVarNames() {
+		includeEnvVars[name] = libpf.Void{}
+		if _, report := reportEnvVars[name]; !report {
+			internalOnlyEnvVars[libpf.Intern(name)] = libpf.Void{}
+		}
+	}
 	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
 	mappingFilters := newMappingFilters(resourceEnrichers)
 
@@ -132,8 +148,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 	}
 
 	metaEnrichers := make([]process.MetaEnricher, 0, len(cfg.ProcessMetaEnrichers)+2)
-	if len(cfg.IncludeEnvVars) > 0 {
-		metaEnrichers = append(metaEnrichers, process.NewEnvVarsEnricher(cfg.IncludeEnvVars))
+	if len(includeEnvVars) > 0 {
+		metaEnrichers = append(metaEnrichers, process.NewEnvVarsEnricher(includeEnvVars))
 	}
 
 	selfContainerEnricher, err := process.NewSelfContainerIDEnricher()
@@ -158,6 +174,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 		kernelSymbols:            ks,
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        cfg.FilterErrorFrames,
+		reportEnvVars:            reportEnvVars,
+		internalOnlyEnvVars:      internalOnlyEnvVars,
 		metaEnrichers:            metaEnrichers,
 		resourceEnrichers:        resourceEnrichers,
 		mappingFilters:           mappingFilters,

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -32,6 +32,7 @@ import (
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
 	"go.opentelemetry.io/ebpf-profiler/procmeta"
+	"go.opentelemetry.io/ebpf-profiler/procmeta/processcontext"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -114,7 +115,11 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 			internalOnlyEnvVars[libpf.Intern(name)] = libpf.Void{}
 		}
 	}
-	resourceEnrichers := slices.Clone(cfg.ResourceEnrichers)
+	// The built-in enricher is always on, and comes first so that a configured
+	// enricher can override what it contributed.
+	resourceEnrichers := append(
+		[]procmeta.ResourceEnricher{processcontext.NewEnricher()},
+		cfg.ResourceEnrichers...)
 	mappingFilters := newMappingFilters(resourceEnrichers)
 
 	elfInfoCache, err := lru.New[util.OnDiskFileIdentifier, elfInfo](elfInfoCacheSize,
@@ -148,9 +153,8 @@ func New(ctx context.Context, cfg Config) (*ProcessManager, error) {
 	}
 
 	metaEnrichers := make([]process.MetaEnricher, 0, len(cfg.ProcessMetaEnrichers)+2)
-	if len(includeEnvVars) > 0 {
-		metaEnrichers = append(metaEnrichers, process.NewEnvVarsEnricher(includeEnvVars))
-	}
+	// includeEnvVars is never empty: it always holds the process context env vars.
+	metaEnrichers = append(metaEnrichers, process.NewEnvVarsEnricher(includeEnvVars))
 
 	selfContainerEnricher, err := process.NewSelfContainerIDEnricher()
 	if err != nil {

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -63,6 +64,36 @@ func TestNewConfiguresFrameCacheSize(t *testing.T) {
 	pm.frameCache.Add(frameCacheKey{data: [3]uint64{1}}, libpf.Frames{})
 	pm.frameCache.Add(frameCacheKey{data: [3]uint64{2}}, libpf.Frames{})
 	require.Equal(t, 1, pm.frameCache.Len())
+}
+
+func TestNewSeparatesCapturedAndReportedEnvVars(t *testing.T) {
+	requestedEnvVars := libpf.Set[string]{"FOO": {}}
+	pm, err := New(t.Context(), Config{
+		InterpretersConfig:    interpreterconfig.NoInterpreters(),
+		MonitorInterval:       time.Hour,
+		ExecutableUnloadDelay: time.Hour,
+		EbpfHandler:           &testEbpfHandler{},
+		IncludeEnvVars:        requestedEnvVars,
+	})
+	require.NoError(t, err)
+
+	// Only the user-requested env vars may be reported.
+	assert.Equal(t, libpf.Set[string]{"FOO": {}}, pm.reportEnvVars)
+
+	// The env vars the base resource is derived from are captured for internal use
+	// only, so each is dropped again once that resource is built.
+	internalNames := make([]string, 0, len(pm.internalOnlyEnvVars))
+	for name := range pm.internalOnlyEnvVars {
+		internalNames = append(internalNames, name.String())
+	}
+	assert.ElementsMatch(t, procmeta.EnvVarNames(), internalNames)
+
+	// New must not add the internal env vars to the caller's set.
+	assert.Equal(t, libpf.Set[string]{"FOO": {}}, requestedEnvVars)
+
+	// Later mutations of the caller's set must not affect the reported set.
+	requestedEnvVars["BAR"] = libpf.Void{}
+	assert.NotContains(t, pm.reportEnvVars, "BAR")
 }
 
 func TestKernelFramesUseSharedFrameCacheHit(t *testing.T) {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -34,7 +34,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/process"
-	"go.opentelemetry.io/ebpf-profiler/processcontext"
 	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/support"
@@ -705,7 +704,6 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	// process context unrefreshed. Detecting it needs a sched_process_exec
 	// tracepoint.
 	updateProcessMeta := exe != libpf.NullString && exe != info.meta.Executable
-	oldProcessContextInfo := info.meta.ProcessContextInfo
 
 	// Get existing info
 	oldMappings := info.mappings
@@ -755,20 +753,12 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		enricherMappings = make([][]process.RawMapping, len(pm.resourceEnrichers))
 	}
 
-	var processContextInfo processcontext.Info
-
 	// This callback processes each memory mapping, keeping only executable
 	// file-backed mappings and executable/prctl-named anonymous or DLL mappings
 	// needed by interpreters. Prctl-named mappings remain relevant when
 	// non-executable because a JIT reservation may be split across r-x/rw/--- VMAs.
 	// All other mappings are skipped.
 	numParseErrors, err := pr.IterateMappings(func(m process.RawMapping) bool {
-		if processcontext.IsContextMapping(m.IsExecutable(), m.Path) {
-			processContextInfo = readProcessContext(m.Vaddr, pr, oldProcessContextInfo)
-			// The eBPF hook on prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME) will trigger a
-			// PID resynchronization when the process names its context mapping "OTEL_CTX".
-		}
-
 		for _, f := range mappingFilters {
 			if f.want(&m) {
 				// Detach Path from the recycled scanner buffer before storing.
@@ -923,7 +913,6 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			// the old one.
 			info.resource = nil
 		}
-		info.meta.ProcessContextInfo = processContextInfo
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()
@@ -1076,25 +1065,4 @@ func (pm *ProcessManager) ProcessedUntil(traceCaptureKTime times.KTime) {
 		delete(pm.exitEvents, pid)
 		log.Debugf("PID %v exit latency %v ms", pid, (nowKTime-pidExitKTime)/1e6)
 	}
-}
-
-func readProcessContext(mappingAddr uint64, pr process.Process, oldProcessContextInfo processcontext.Info) processcontext.Info {
-	// Workaround to fix a CodeQL warning about potential for integer overflow when converting from uint64 to uintptr (libpf.Address)
-	addr := libpf.Address(mappingAddr & uint64(^libpf.Address(0)))
-	ctxInfo, err := processcontext.Read(addr, pr.GetRemoteMemory(), oldProcessContextInfo.PublishedAtNs, 0)
-	if err == nil {
-		return ctxInfo
-	}
-	if errors.Is(err, processcontext.ErrNoUpdate) {
-		return oldProcessContextInfo
-	}
-	if errors.Is(err, processcontext.ErrConcurrentUpdate) {
-		// If the context cannot be read because of a concurrent update, keep the resource and thread context since they are immutable,
-		// but discard the extra attributes as they may be stale.
-		oldProcessContextInfo.ClearAttributes()
-		return oldProcessContextInfo
-	}
-
-	log.Debugf("Failed to read ProcessContext for PID %d: %v", pr.PID(), err)
-	return processcontext.Info{}
 }

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"golang.org/x/sys/unix"
 
@@ -33,6 +34,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/processcontext"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -120,15 +122,19 @@ func (pm *ProcessManager) getLibcInfo(pid libpf.PID) *libc.LibcInfo {
 // metadata is gathered (including configured process MetaEnrichers) without
 // the processmanager lock held.
 //
+// created reports whether this call created the processInfo, i.e. the first
+// observation of the process. That is the lifecycle signal to use: a process may be
+// synchronized many times without ever retaining a mapping.
+//
 // Returns nil on failure.
 // Caller must not hold the pm.mu lock.
 func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
-	pr process.Process) *processInfo {
+	pr process.Process) (info *processInfo, created bool) {
 	pm.mu.RLock()
 	info, ok := pm.pidToProcessInfo[pid]
 	pm.mu.RUnlock()
 	if ok {
-		return info
+		return info, false
 	}
 
 	// Gather metadata without holding the processmanager lock:
@@ -140,21 +146,80 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 
 	// Check if another goroutine registered the PID in-between.
 	if info, ok = pm.pidToProcessInfo[pid]; ok {
-		return info
+		return info, false
 	}
 
 	if err := pm.ebpf.UpdatePidPageMappingInfo(pid, dummyPrefix, 0, 0); err != nil {
-		return nil
+		return nil, false
 	}
 
 	pm.pidPageToMappingInfoSize++
 	info = &processInfo{
 		meta:     meta,
 		libcInfo: nil,
+		// Sole allocation site of the slots, so they are always as long as the
+		// registered enrichers, which index them.
+		contributions: make([]*pcommon.Resource, len(pm.resourceEnrichers)),
+		enricherState: make([]any, len(pm.resourceEnrichers)),
 	}
 	pm.pidToProcessInfo[pid] = info
 
-	return info
+	return info, true
+}
+
+// enrichResources runs the resource enrichers for a process and publishes the merge
+// of their contributions. One that reports no change keeps its previous
+// contribution, so data that has become unreadable is not lost.
+//
+// Caller must not hold pm.mu: enrichers run arbitrary code and read /proc and
+// remote process memory.
+func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
+	interpreters map[util.OnDiskFileIdentifier]interpreter.Instance,
+	enricherMappings [][]process.RawMapping, newProcessOrExec bool,
+) {
+	if info == nil || len(pm.resourceEnrichers) == 0 {
+		return
+	}
+
+	// Only meta and resource are read from another goroutine (metaForPID); the slots
+	// belong to the synchronizing one. So the enrichers update the slots in place,
+	// and pm.mu is taken once, to publish resource.
+	if newProcessOrExec {
+		// Nothing derived from the replaced program can carry over: "no change" means
+		// "my contribution still holds", which after an exec it cannot. Otherwise an
+		// enricher resolving nothing for the new executable would keep the old
+		// program's attributes, and a fill-once one would never look again.
+		clear(info.contributions)
+		clear(info.enricherState)
+	}
+
+	req := procmeta.ResourceRequest{
+		Process:      pr,
+		Interpreters: interpreters,
+	}
+
+	// A new or execed process starts from cleared state, so the merge is due even if
+	// no enricher reports a change.
+	changed := newProcessOrExec
+	for i, e := range pm.resourceEnrichers {
+		if enricherMappings != nil {
+			req.Mappings = enricherMappings[i]
+		}
+		req.State = &info.enricherState[i]
+		if res, ok := e.EnrichResource(&req); ok {
+			info.contributions[i] = res
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+
+	merged := procmeta.MergeResources(nil, info.contributions)
+
+	pm.mu.Lock()
+	info.resource = merged
+	pm.mu.Unlock()
 }
 
 // assignInterpreter will update the interpreters maps with given interpreter.Instance.
@@ -601,13 +666,16 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		// the case of main thread exit. Ignore it.
 	}
 
-	info := pm.getOrCreateProcessInfo(pid, pr)
+	info, firstObservation := pm.getOrCreateProcessInfo(pid, pr)
 	if info == nil {
 		return
 	}
 
 	pm.mu.Lock()
-	// Check if process meta needs an update
+	// Check if process meta needs an update. execve preserves the tgid, so a
+	// re-exec of the same path is invisible here and leaves env vars and the
+	// process context unrefreshed. Detecting it needs a sched_process_exec
+	// tracepoint.
 	updateProcessMeta := exe != libpf.NullString && exe != info.meta.Executable
 	oldProcessContextInfo := info.meta.ProcessContextInfo
 
@@ -645,10 +713,21 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	capHint := max(32, min(len(oldMappings), 256))
 	mappings := make([]Mapping, 0, capHint)
 	mpAdd := make([]*Mapping, 0, capHint)
-	var processContextInfo processcontext.Info
 
 	pm.mappingStats.numProcAttempts.Add(1)
 	start := time.Now()
+
+	// enricherMappings collects, per enricher, the mappings its filter selected, and
+	// is nil when none wants any. The filters are hoisted so the callback below,
+	// which runs once per mapping, captures a slice header instead of reaching
+	// through pm each iteration.
+	mappingFilters := pm.mappingFilters
+	var enricherMappings [][]process.RawMapping
+	if len(mappingFilters) > 0 {
+		enricherMappings = make([][]process.RawMapping, len(pm.resourceEnrichers))
+	}
+
+	var processContextInfo processcontext.Info
 
 	// This callback processes each memory mapping, keeping only executable
 	// file-backed mappings and executable/prctl-named anonymous or DLL mappings
@@ -660,6 +739,15 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 			processContextInfo = readProcessContext(m.Vaddr, pr, oldProcessContextInfo)
 			// The eBPF hook on prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME) will trigger a
 			// PID resynchronization when the process names its context mapping "OTEL_CTX".
+		}
+
+		for _, f := range mappingFilters {
+			if f.want(&m) {
+				// Detach Path from the recycled scanner buffer before storing.
+				selected := m
+				selected.Path = libpf.Intern(selected.Path).String()
+				enricherMappings[f.enricher] = append(enricherMappings[f.enricher], selected)
+			}
 		}
 
 		interpreterMapping := isInterpreterMapping(&m)
@@ -793,17 +881,27 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	// Sort and publish the new mappings and meta.
 	slices.SortFunc(mappings, compareMapping)
 
-	info = pm.getOrCreateProcessInfo(pid, pr)
+	// A concurrent ProcessedUntil may have dropped the processInfo since this
+	// synchronization started; recreating it starts from empty enricher state.
+	info, recreated := pm.getOrCreateProcessInfo(pid, pr)
 	pm.mu.Lock()
 	if info != nil {
 		info.mappings = mappings
 		if updateProcessMeta {
 			info.meta = meta
+			// Reset resource to nil to avoid pairing the replaced program's samples with
+			// the old one.
+			info.resource = nil
 		}
 		info.meta.ProcessContextInfo = processContextInfo
 	}
 	interpreters := pm.interpreters[pid]
 	pm.mu.Unlock()
+
+	// Contribute resource attributes, now that the mappings and the interpreters
+	// attached this round are known.
+	pm.enrichResources(pr, info, interpreters, enricherMappings,
+		updateProcessMeta || firstObservation || recreated)
 
 	// Synchronize all interpreters with updated mappings
 	for _, instance := range interpreters {
@@ -862,14 +960,15 @@ func (pm *ProcessManager) CleanupPIDs() {
 	}
 }
 
-// metaForPID returns the process metadata for given PID.
-func (pm *ProcessManager) metaForPID(pid libpf.PID) process.Meta {
+// metaForPID returns a consistent snapshot of a PID's metadata and of the resource
+// the enrichers contributed for it.
+func (pm *ProcessManager) metaForPID(pid libpf.PID) (process.Meta, *pcommon.Resource) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	if procInfo, ok := pm.pidToProcessInfo[pid]; ok {
-		return procInfo.meta
+		return procInfo.meta, procInfo.resource
 	}
-	return process.Meta{}
+	return process.Meta{}, nil
 }
 
 // findMappingForTrace locates the mapping for a given host trace.

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -14,6 +14,7 @@ package processmanager // import "go.opentelemetry.io/ebpf-profiler/processmanag
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"slices"
@@ -139,7 +140,7 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 
 	// Gather metadata without holding the processmanager lock:
 	// This reads /proc and may invoke arbitrary enricher callbacks.
-	meta := pr.GetProcessMeta(pm.metaEnrichers)
+	meta, envResource := pm.readProcessMeta(pr)
 
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -155,8 +156,9 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 
 	pm.pidPageToMappingInfoSize++
 	info = &processInfo{
-		meta:     meta,
-		libcInfo: nil,
+		meta:        meta,
+		envResource: envResource,
+		libcInfo:    nil,
 		// Sole allocation site of the slots, so they are always as long as the
 		// registered enrichers, which index them.
 		contributions: make([]*pcommon.Resource, len(pm.resourceEnrichers)),
@@ -165,6 +167,32 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 	pm.pidToProcessInfo[pid] = info
 
 	return info, true
+}
+
+// readProcessMeta gathers the process metadata, and the base resource that the
+// environment variables captured for the profiler's own use declare.
+//
+// Caller must not hold pm.mu: this reads /proc and invokes arbitrary callbacks.
+func (pm *ProcessManager) readProcessMeta(pr process.Process) (
+	process.Meta, *pcommon.Resource,
+) {
+	meta := pr.GetProcessMeta(pm.metaEnrichers)
+
+	// Built while the captured values are all still there; it picks the ones it
+	// knows.
+	envResource := procmeta.ResourceFromEnvVars(meta.EnvVariables)
+
+	// Drop what was captured for the profiler's own use, so a variable needed
+	// internally is not reported just because it was needed. Only those: what a
+	// MetaEnricher put in EnvVariables is its own business.
+	maps.DeleteFunc(meta.EnvVariables, func(name, _ libpf.String) bool {
+		_, internalOnly := pm.internalOnlyEnvVars[name]
+		return internalOnly
+	})
+	if len(meta.EnvVariables) == 0 {
+		meta.EnvVariables = nil
+	}
+	return meta, envResource
 }
 
 // enrichResources runs the resource enrichers for a process and publishes the merge
@@ -182,8 +210,8 @@ func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
 	}
 
 	// Only meta and resource are read from another goroutine (metaForPID); the slots
-	// belong to the synchronizing one. So the enrichers update the slots in place,
-	// and pm.mu is taken once, to publish resource.
+	// and envResource belong to the synchronizing one. So the enrichers update the
+	// slots in place, and pm.mu is taken once, to publish resource.
 	if newProcessOrExec {
 		// Nothing derived from the replaced program can carry over: "no change" means
 		// "my contribution still holds", which after an exec it cannot. Otherwise an
@@ -198,8 +226,8 @@ func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
 		Interpreters: interpreters,
 	}
 
-	// A new or execed process starts from cleared state, so the merge is due even if
-	// no enricher reports a change.
+	// A new or execed process has a base resource built this round and never
+	// published, so the merge is due even if no enricher reports a change.
 	changed := newProcessOrExec
 	for i, e := range pm.resourceEnrichers {
 		if enricherMappings != nil {
@@ -215,7 +243,7 @@ func (pm *ProcessManager) enrichResources(pr process.Process, info *processInfo,
 		return
 	}
 
-	merged := procmeta.MergeResources(nil, info.contributions)
+	merged := procmeta.MergeResources(info.envResource, info.contributions)
 
 	pm.mu.Lock()
 	info.resource = merged
@@ -874,8 +902,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 
 	// Update metadata of the process.
 	var meta process.Meta
+	var envResource *pcommon.Resource
 	if updateProcessMeta {
-		meta = pr.GetProcessMeta(pm.metaEnrichers)
+		meta, envResource = pm.readProcessMeta(pr)
 	}
 
 	// Sort and publish the new mappings and meta.
@@ -889,6 +918,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		info.mappings = mappings
 		if updateProcessMeta {
 			info.meta = meta
+			info.envResource = envResource
 			// Reset resource to nil to avoid pairing the replaced program's samples with
 			// the old one.
 			info.resource = nil

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libc"
@@ -19,6 +20,7 @@ import (
 	sdtypes "go.opentelemetry.io/ebpf-profiler/nativeunwind/stackdeltatypes"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
@@ -161,7 +163,7 @@ func (tp *testProcess) GetMachineData() process.MachineData {
 func (tp *testProcess) GetProcessMeta(enrichers []process.MetaEnricher) process.Meta {
 	meta := process.Meta{Executable: tp.exe}
 	for _, e := range enrichers {
-		e.EnrichMeta(fmt.Sprintf("/proc/%d", tp.pid), &meta)
+		e.EnrichMeta(fmt.Sprintf("/proc/%d/", tp.pid), &meta)
 	}
 	return meta
 }
@@ -570,22 +572,17 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	enricherCalls := 0
 	enricher := process.MetaEnricherFunc(func(procBase string, meta *process.Meta) {
 		enricherCalls++
-		require.Equal(fmt.Sprintf("/proc/%d", pid), procBase)
+		require.Equal(fmt.Sprintf("/proc/%d/", pid), procBase)
 		meta.ExtraMeta = map[libpf.String]string{key: meta.Executable.String()}
 	})
 
-	pm := &ProcessManager{
-		ebpf:             &testEbpfHandler{},
-		interpreters:     make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
-		pidToProcessInfo: make(map[libpf.PID]*processInfo),
-		exitEvents:       make(map[libpf.PID]times.KTime),
-		metaEnrichers:    []process.MetaEnricher{enricher},
-	}
+	pm := newTestProcessManager([]process.MetaEnricher{enricher}, nil)
 
 	// Process first seen: gather and enrich metadata.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
 	require.Equal(1, enricherCalls)
-	require.Equal("foobar", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ := pm.metaForPID(pid)
+	require.Equal("foobar", meta.ExtraMeta[key])
 
 	// Unchanged executable: don't refetch metadata, don't enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
@@ -594,5 +591,405 @@ func TestSynchronizeProcessRunEnrichers(t *testing.T) {
 	// Executable changed: refetch metadata and enrich.
 	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobarbaz")})
 	require.Equal(2, enricherCalls)
-	require.Equal("foobarbaz", pm.metaForPID(pid).ExtraMeta[key])
+	meta, _ = pm.metaForPID(pid)
+	require.Equal("foobarbaz", meta.ExtraMeta[key])
+}
+
+// testResourceEnricher is a ResourceEnricher whose behaviour each test controls
+// through enrich.
+type testResourceEnricher struct {
+	cfg    procmeta.ResourceConfig
+	calls  int
+	reqs   []procmeta.ResourceRequest
+	enrich func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool)
+}
+
+func (e *testResourceEnricher) ResourceConfig() procmeta.ResourceConfig {
+	return e.cfg
+}
+
+func (e *testResourceEnricher) EnrichResource(req *procmeta.ResourceRequest) (
+	*pcommon.Resource, bool,
+) {
+	e.calls++
+	e.reqs = append(e.reqs, *req)
+	if e.enrich == nil {
+		return nil, false
+	}
+	return e.enrich(req, e.calls)
+}
+
+// resourceWithAttr builds a single-attribute resource.
+func resourceWithAttr(key, value string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	r.Attributes().PutStr(key, value)
+	return &r
+}
+
+// resourceAttrs flattens a resource's string attributes, or returns nil.
+func resourceAttrs(r *pcommon.Resource) map[string]string {
+	if r == nil {
+		return nil
+	}
+	attrs := make(map[string]string, r.Attributes().Len())
+	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+		attrs[k] = v.Str()
+		return true
+	})
+	return attrs
+}
+
+func newTestProcessManager(metaEnrichers []process.MetaEnricher,
+	resourceEnrichers []procmeta.ResourceEnricher,
+) *ProcessManager {
+	return &ProcessManager{
+		ebpf:              &testEbpfHandler{},
+		interpreters:      make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
+		pidToProcessInfo:  make(map[libpf.PID]*processInfo),
+		exitEvents:        make(map[libpf.PID]times.KTime),
+		metaEnrichers:     metaEnrichers,
+		resourceEnrichers: resourceEnrichers,
+		mappingFilters:    newMappingFilters(resourceEnrichers),
+	}
+}
+
+// TestSynchronizeProcessRunsResourceEnrichers verifies that resource enrichers run
+// on every synchronization, unlike meta enrichers, so attributes resolving after
+// first observation are still picked up.
+func TestSynchronizeProcessRunsResourceEnrichers(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	// Contributes nothing on the first call, then an attribute on the second, as a
+	// late-resolving enricher would.
+	enricher := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				return nil, false
+			}
+			return resourceWithAttr("late.attr", "resolved"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(1, enricher.calls)
+	_, resource := pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Equal(pid, enricher.reqs[0].Process.PID())
+
+	// Same executable: the meta enrichers would not run, but this one does.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(2, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting no change keeps the published contribution.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, false
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	require.Equal(3, enricher.calls)
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"late.attr": "resolved"}, resourceAttrs(resource))
+
+	// Reporting a change with a nil resource withdraws it.
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		return nil, true
+	}
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptUntilExec verifies that derived
+// state is kept across synchronizations of one program and dropped on the one after
+// an exec — an empty slot being the whole signal an enricher gets, and needs.
+func TestSynchronizeProcessResourceEnricherStateKeptUntilExec(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	// The state each call was handed, which is how the exec handling is observable.
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Seed a known process with a mapping the sync below can match and reuse, which
+	// keeps it out of the ELF-parsing path that needs a fuller ProcessManager.
+	rawMapping := process.RawMapping{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R | elf.PF_X,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}
+	pm.pidToProcessInfo[pid] = &processInfo{
+		meta: process.Meta{Executable: exe},
+		mappings: []Mapping{{
+			Vaddr:  libpf.Address(rawMapping.Vaddr),
+			Length: rawMapping.Length,
+			Device: rawMapping.Device,
+			Inode:  rawMapping.Inode,
+			FrameMapping: libpf.NewFrameMapping(libpf.FrameMappingData{
+				File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+					FileID:   libpf.NewFileID(1, 0),
+					FileName: libpf.Intern("foobar"),
+				}),
+				Start: 0,
+				End:   libpf.Address(rawMapping.Length),
+			}),
+		}},
+		contributions: make([]*pcommon.Resource, 1),
+		enricherState: make([]any, 1),
+	}
+
+	// Known process, unchanged executable: what the previous call stored is still
+	// there, the seeded record included.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{rawMapping}}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]any{nil, 1}, seen)
+
+	// Executable changed: the state derived from the program that is gone goes too.
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid, exe: libpf.Intern("/bin/other"),
+		mappings: []process.RawMapping{rawMapping},
+	})
+	require.Equal([]any{nil, 1, nil}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings verifies that a
+// process retaining no mapping keeps its derived state all the same. Retained
+// mappings say nothing about the lifecycle — a fully JIT-compiled process keeps
+// none — and looking execed every sync would resolve fill-once enrichers forever.
+func TestSynchronizeProcessResourceEnricherStateKeptWithoutMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+	exe := libpf.Intern("/bin/foobar")
+
+	var seen []any
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			seen = append(seen, *req.State)
+			*req.State = call
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	// Non-executable, so no mapping is retained for the process.
+	proc := &testProcess{pid: pid, exe: exe, mappings: []process.RawMapping{{
+		Vaddr: 0x1000, Length: 0x1000, Flags: elf.PF_R,
+		Device: 7, Inode: 8, Path: exe.String(),
+	}}}
+
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+
+	pm.mu.RLock()
+	mappings := pm.pidToProcessInfo[pid].mappings
+	pm.mu.RUnlock()
+	require.Empty(mappings)
+
+	// New once, on first observation, and never again.
+	require.Equal([]any{nil, 1, 2}, seen)
+}
+
+// TestSynchronizeProcessResourceEnricherExecDropsContributions verifies that an exec
+// drops what the enrichers derived from the previous program. Otherwise an enricher
+// resolving nothing for the new executable — runtime info once a Python process
+// execs a native binary — would keep the old attributes indefinitely.
+func TestSynchronizeProcessResourceEnricherExecDropsContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			if call == 1 {
+				*req.State = "resolved"
+				return resourceWithAttr("process.runtime.name", "cpython"), true
+			}
+			// Nothing to report for the new executable.
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"process.runtime.name": "cpython"}, resourceAttrs(resource))
+
+	// Exec: the contribution and the state derived from the old program go.
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Nil(resource)
+	require.Nil(*enricher.reqs[1].State)
+}
+
+// TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource verifies that a
+// replaced program's resource is never readable beside the new executable's
+// metadata, which is published before the enrichers run and the resource after. An
+// enricher runs in exactly that window, so it can observe what a trace would see.
+func TestSynchronizeProcessExecDoesNotPairNewMetaWithOldResource(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	type observation struct {
+		exe      string
+		resource *pcommon.Resource
+	}
+	var observed []observation
+
+	enricher := &testResourceEnricher{}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+	enricher.enrich = func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+		meta, resource := pm.metaForPID(pid)
+		observed = append(observed, observation{meta.Executable.String(), resource})
+		// Identify the program, so a contribution carried across the exec shows up.
+		return resourceWithAttr("exe", meta.Executable.String()), true
+	}
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/python3")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/python3"}, resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("/usr/bin/native")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"exe": "/usr/bin/native"}, resourceAttrs(resource))
+
+	require.Len(observed, 2)
+	// First observation: the process has no resource yet.
+	require.Equal("/usr/bin/python3", observed[0].exe)
+	require.Nil(observed[0].resource)
+	// Second: metadata is already the new program's, so the old resource is gone.
+	require.Equal("/usr/bin/native", observed[1].exe)
+	require.Nil(observed[1].resource)
+}
+
+// TestSynchronizeProcessMergesResourceContributions verifies that contributions
+// from several enrichers are merged, with later enrichers winning on key
+// collisions, and that each enricher's contribution is tracked independently.
+func TestSynchronizeProcessMergesResourceContributions(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	first := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			r := pcommon.NewResource()
+			r.Attributes().PutStr("shared", "first")
+			r.Attributes().PutStr("only.first", "1")
+			return &r, true
+		},
+	}
+	second := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, call int) (*pcommon.Resource, bool) {
+			// Contribute only on the first call, to check the stored contribution
+			// still takes part in later merges.
+			if call > 1 {
+				return nil, false
+			}
+			return resourceWithAttr("shared", "second"), true
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{first, second})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
+		resourceAttrs(resource))
+}
+
+// TestSynchronizeProcessResourceEnricherState verifies that per-process enricher
+// state survives across synchronizations and is dropped, and closed, on exit.
+func TestSynchronizeProcessResourceEnricherState(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	var seen []int
+	enricher := &testResourceEnricher{
+		enrich: func(req *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			state, _ := (*req.State).(*testEnricherState)
+			if state == nil {
+				state = &testEnricherState{}
+				*req.State = state
+			}
+			state.counter++
+			seen = append(seen, state.counter)
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager(nil, []procmeta.ResourceEnricher{enricher})
+
+	proc := &testProcess{pid: pid, exe: libpf.Intern("foobar")}
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3}, seen)
+
+	pm.mu.RLock()
+	state, _ := pm.pidToProcessInfo[pid].enricherState[0].(*testEnricherState)
+	pm.mu.RUnlock()
+	require.NotNil(state)
+
+	// Process exit drops the state along with the processInfo holding it.
+	pm.processPIDExit(pid)
+	pm.ProcessedUntil(times.GetKTime())
+
+	pm.mu.RLock()
+	_, tracked := pm.pidToProcessInfo[pid]
+	pm.mu.RUnlock()
+	require.False(tracked)
+
+	// A process observed again under the same PID starts from empty state.
+	pm.SynchronizeProcess(proc)
+	require.Equal([]int{1, 2, 3, 1}, seen)
+}
+
+type testEnricherState struct {
+	counter int
+}
+
+// TestSynchronizeProcessResourceEnricherMappings verifies that only the mappings
+// an enricher's WantMapping filter selects are delivered to it, and that each
+// enricher gets its own selection.
+func TestSynchronizeProcessResourceEnricherMappings(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	wantsNamed := &testResourceEnricher{
+		cfg: procmeta.ResourceConfig{
+			WantMapping: func(m *process.RawMapping) bool { return m.Path == "[anon:MY_REGION]" },
+		},
+	}
+	wantsNothing := &testResourceEnricher{}
+	pm := newTestProcessManager(nil,
+		[]procmeta.ResourceEnricher{wantsNamed, wantsNothing})
+
+	pm.SynchronizeProcess(&testProcess{
+		pid: pid,
+		exe: libpf.Intern("foobar"),
+		mappings: []process.RawMapping{
+			{Vaddr: 0x1000, Flags: elf.PF_R, Path: "/bin/foobar"},
+			{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+			{Vaddr: 0x3000, Flags: elf.PF_R | elf.PF_W},
+		},
+	})
+
+	require.Len(wantsNamed.reqs, 1)
+	require.Equal([]process.RawMapping{
+		{Vaddr: 0x2000, Flags: elf.PF_R | elf.PF_W, Path: "[anon:MY_REGION]"},
+	}, wantsNamed.reqs[0].Mappings)
+
+	require.Len(wantsNothing.reqs, 1)
+	require.Empty(wantsNothing.reqs[0].Mappings)
 }

--- a/processmanager/processinfo_test.go
+++ b/processmanager/processinfo_test.go
@@ -642,14 +642,21 @@ func resourceAttrs(r *pcommon.Resource) map[string]string {
 func newTestProcessManager(metaEnrichers []process.MetaEnricher,
 	resourceEnrichers []procmeta.ResourceEnricher,
 ) *ProcessManager {
+	// As New does with an empty IncludeEnvVars: the base-resource env vars are
+	// captured, and reported to nobody.
+	internalOnlyEnvVars := make(libpf.Set[libpf.String])
+	for _, name := range procmeta.EnvVarNames() {
+		internalOnlyEnvVars[libpf.Intern(name)] = libpf.Void{}
+	}
 	return &ProcessManager{
-		ebpf:              &testEbpfHandler{},
-		interpreters:      make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
-		pidToProcessInfo:  make(map[libpf.PID]*processInfo),
-		exitEvents:        make(map[libpf.PID]times.KTime),
-		metaEnrichers:     metaEnrichers,
-		resourceEnrichers: resourceEnrichers,
-		mappingFilters:    newMappingFilters(resourceEnrichers),
+		ebpf:                &testEbpfHandler{},
+		interpreters:        make(map[libpf.PID]map[util.OnDiskFileIdentifier]interpreter.Instance),
+		pidToProcessInfo:    make(map[libpf.PID]*processInfo),
+		exitEvents:          make(map[libpf.PID]times.KTime),
+		metaEnrichers:       metaEnrichers,
+		resourceEnrichers:   resourceEnrichers,
+		mappingFilters:      newMappingFilters(resourceEnrichers),
+		internalOnlyEnvVars: internalOnlyEnvVars,
 	}
 }
 
@@ -907,6 +914,77 @@ func TestSynchronizeProcessMergesResourceContributions(t *testing.T) {
 	_, resource = pm.metaForPID(pid)
 	require.Equal(map[string]string{"shared": "second", "only.first": "1"},
 		resourceAttrs(resource))
+}
+
+// TestSynchronizeProcessPublishesEnvVarBaseResource verifies that the attributes
+// a process's environment declares are published even when no enricher
+// contributes anything, and that a contribution wins over them on key collisions.
+func TestSynchronizeProcessPublishesEnvVarBaseResource(t *testing.T) {
+	require := require.New(t)
+	pid := libpf.PID(123)
+
+	// Stand in for the env-vars meta enricher, which reads /proc/<pid>/environ.
+	envEnricher := process.MetaEnricherFunc(func(_ string, meta *process.Meta) {
+		meta.EnvVariables = map[libpf.String]libpf.String{
+			libpf.Intern("OTEL_SERVICE_NAME"): libpf.Intern("from-env"),
+			libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern(
+				"deployment.environment=prod"),
+		}
+	})
+
+	// Contributes nothing, so only the base resource can account for the result.
+	silent := &testResourceEnricher{
+		enrich: func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+			return nil, false
+		},
+	}
+	pm := newTestProcessManager([]process.MetaEnricher{envEnricher},
+		[]procmeta.ResourceEnricher{silent})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	meta, resource := pm.metaForPID(pid)
+	require.Equal(map[string]string{
+		"service.name":           "from-env",
+		"deployment.environment": "prod",
+	}, resourceAttrs(resource))
+	// Captured for the base resource, but reported to nobody: the user asked for
+	// neither of them.
+	require.Nil(meta.EnvVariables)
+
+	// A contribution overrides the key it declares, and only that one.
+	pm = newTestProcessManager([]process.MetaEnricher{envEnricher},
+		[]procmeta.ResourceEnricher{&testResourceEnricher{
+			enrich: func(_ *procmeta.ResourceRequest, _ int) (*pcommon.Resource, bool) {
+				return resourceWithAttr("service.name", "from-context"), true
+			},
+		}})
+
+	pm.SynchronizeProcess(&testProcess{pid: pid, exe: libpf.Intern("foobar")})
+	_, resource = pm.metaForPID(pid)
+	require.Equal(map[string]string{
+		"service.name":           "from-context",
+		"deployment.environment": "prod",
+	}, resourceAttrs(resource))
+}
+
+// TestReadProcessMetaKeepsEnricherEnvVars verifies that only the env vars captured
+// for the profiler's own use are dropped from the reported metadata: what a
+// MetaEnricher put in EnvVariables stays, listed in IncludeEnvVars or not.
+func TestReadProcessMetaKeepsEnricherEnvVars(t *testing.T) {
+	own := libpf.Intern("ENRICHER_OWN")
+	enricher := process.MetaEnricherFunc(func(_ string, meta *process.Meta) {
+		meta.EnvVariables = map[libpf.String]libpf.String{
+			libpf.Intern("OTEL_SERVICE_NAME"): libpf.Intern("from-env"),
+			own:                               libpf.Intern("kept"),
+		}
+	})
+	pm := newTestProcessManager([]process.MetaEnricher{enricher}, nil)
+
+	meta, resource := pm.readProcessMeta(&testProcess{
+		pid: libpf.PID(123), exe: libpf.Intern("foobar")})
+
+	assert.Equal(t, map[libpf.String]libpf.String{own: libpf.Intern("kept")}, meta.EnvVariables)
+	assert.Equal(t, map[string]string{"service.name": "from-env"}, resourceAttrs(resource))
 }
 
 // TestSynchronizeProcessResourceEnricherState verifies that per-process enricher

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -132,6 +132,14 @@ type ProcessManager struct {
 	// filterErrorFrames determines whether error frames are dropped by `ConvertTrace`.
 	filterErrorFrames bool
 
+	// reportEnvVars holds only the user-requested env vars that may be reported.
+	reportEnvVars libpf.Set[string]
+
+	// internalOnlyEnvVars holds the interned names of the env vars captured to
+	// build each process's base resource but not requested for reporting, so they
+	// are dropped from the process metadata once the base resource is built.
+	internalOnlyEnvVars libpf.Set[libpf.String]
+
 	metaEnrichers []process.MetaEnricher
 
 	// resourceEnrichers contribute OTel resource attributes on every process
@@ -191,8 +199,8 @@ type mappingFilter struct {
 type processInfo struct {
 	// process metadata, updated on executable changes
 	meta process.Meta
-	// resource is the merge of the contributions, published under ProcessManager.mu
-	// and immutable once it is. Nil until something contributes.
+	// resource is the merge of envResource and contributions, published under
+	// ProcessManager.mu and immutable once it is. Nil until something contributes.
 	resource *pcommon.Resource
 	// contributions holds each enricher's latest contribution, indexed by
 	// ProcessManager.resourceEnrichers. Entries are immutable once stored.
@@ -200,6 +208,9 @@ type processInfo struct {
 	// enricherState holds each enricher's per-process state, indexed the same way.
 	// Dropped, with no teardown call, when the process exits.
 	enricherState []any
+	// envResource holds what the process's environment declared, the base the
+	// contributions merge onto. Built with the metadata, immutable once published.
+	envResource *pcommon.Resource
 	// executable mappings sorted by FileID and mapping start address
 	mappings []Mapping
 	// C-library Thread Specific Data information

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	lru "github.com/elastic/go-freelru"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/process"
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/util"
@@ -132,6 +134,16 @@ type ProcessManager struct {
 
 	metaEnrichers []process.MetaEnricher
 
+	// resourceEnrichers contribute OTel resource attributes on every process
+	// synchronization. Their index is the index into processInfo.contributions
+	// and processInfo.enricherState.
+	resourceEnrichers []procmeta.ResourceEnricher
+
+	// mappingFilters holds the non-nil WantMapping filters of resourceEnrichers,
+	// in the same order, so the mapping pass can dispatch without re-reading each
+	// enricher's config. Empty when no enricher wants mappings.
+	mappingFilters []mappingFilter
+
 	// probeAttachers is the set of per-process probe attachers registered via
 	// RegisterProbeAttacher. Protected by mu.
 	probeAttachers []ProbeAttacher
@@ -168,11 +180,26 @@ func (m *Mapping) GetOnDiskFileIdentifier() util.OnDiskFileIdentifier {
 	}
 }
 
+// mappingFilter pairs a WantMapping predicate with the enricher that declared it.
+type mappingFilter struct {
+	enricher int
+	want     func(m *process.RawMapping) bool
+}
+
 // processInfo contains information about the executable mappings
 // and Thread Specific Data of a process.
 type processInfo struct {
 	// process metadata, updated on executable changes
 	meta process.Meta
+	// resource is the merge of the contributions, published under ProcessManager.mu
+	// and immutable once it is. Nil until something contributes.
+	resource *pcommon.Resource
+	// contributions holds each enricher's latest contribution, indexed by
+	// ProcessManager.resourceEnrichers. Entries are immutable once stored.
+	contributions []*pcommon.Resource
+	// enricherState holds each enricher's per-process state, indexed the same way.
+	// Dropped, with no teardown call, when the process exits.
+	enricherState []any
 	// executable mappings sorted by FileID and mapping start address
 	mappings []Mapping
 	// C-library Thread Specific Data information

--- a/procmeta/envvars.go
+++ b/procmeta/envvars.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// The base resource a process declares through its environment. Enricher
+// contributions merge on top of it, so what a process publishes at runtime wins over
+// what it was started with.
+
+package procmeta // import "go.opentelemetry.io/ebpf-profiler/procmeta"
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/log"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+const (
+	// resourceAttrKey is the environment variable OpenTelemetry resource
+	// attributes are read from.
+	resourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES"
+
+	// svcNameKey is the environment variable the service name is read from.
+	svcNameKey = "OTEL_SERVICE_NAME"
+)
+
+// The keys above, interned once rather than on every lookup.
+var (
+	internedResourceAttrKey = libpf.Intern(resourceAttrKey)
+	internedSvcNameKey      = libpf.Intern(svcNameKey)
+)
+
+// EnvVarNames returns the environment variables the base resource is derived from.
+// The process manager captures these whether or not the user asked to report them.
+func EnvVarNames() []string {
+	return []string{svcNameKey, resourceAttrKey}
+}
+
+// ResourceFromEnvVars builds the base resource a process's environment declares,
+// from the variables EnvVarNames names, or nil if neither yields an attribute.
+// Contributions merge on top, so what a process publishes at runtime wins.
+func ResourceFromEnvVars(envVars map[libpf.String]libpf.String) *pcommon.Resource {
+	if len(envVars) == 0 {
+		return nil
+	}
+	r := pcommon.NewResource()
+	if v, ok := envVars[internedResourceAttrKey]; ok {
+		pairs, err := parseResourceAttributes(v.String())
+		if err != nil {
+			log.Debugf("OTEL_RESOURCE_ATTRIBUTES=%q: discarding invalid value: %v", v.String(), err)
+		} else {
+			for _, p := range pairs {
+				r.Attributes().PutStr(p.key, p.value)
+			}
+		}
+	}
+	if v, ok := envVars[internedSvcNameKey]; ok {
+		r.Attributes().PutStr(string(semconv.ServiceNameKey), v.String())
+	}
+	if r.Attributes().Len() == 0 {
+		return nil
+	}
+	return &r
+}
+
+// resourceAttribute is one parsed entry from OTEL_RESOURCE_ATTRIBUTES.
+type resourceAttribute struct {
+	key, value string
+}
+
+// parseResourceAttributes parses OTEL_RESOURCE_ATTRIBUTES as comma-separated
+// percent-encoded key=value pairs, returned in source order for the caller to dedup
+// last-writer-wins. Per OTel spec any decoding error discards the whole value.
+func parseResourceAttributes(raw string) ([]resourceAttribute, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var pairs []resourceAttribute
+	for pair := range strings.SplitSeq(raw, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			return nil, fmt.Errorf("missing '=' in %q", pair)
+		}
+		key, err := url.PathUnescape(strings.TrimSpace(k))
+		if err != nil {
+			return nil, fmt.Errorf("invalid key %q: %w", k, err)
+		}
+		value, err := url.PathUnescape(strings.TrimSpace(v))
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for key %q: %w", key, err)
+		}
+		pairs = append(pairs, resourceAttribute{key, value})
+	}
+	return pairs, nil
+}

--- a/procmeta/envvars_test.go
+++ b/procmeta/envvars_test.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+// TestResourceFromEnvVars covers the base resource a process's environment
+// declares, and the precedence an enricher contribution has over it.
+func TestResourceFromEnvVars(t *testing.T) {
+	tests := []struct {
+		name        string
+		contributed map[string]string
+		envVars     map[libpf.String]libpf.String
+		expected    map[string]string
+	}{
+		{
+			name: "no env vars, no contribution",
+		},
+		{
+			name: "OTEL_SERVICE_NAME",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_SERVICE_NAME"): libpf.Intern("my-service"),
+			},
+			expected: map[string]string{
+				"service.name": "my-service",
+			},
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES simple",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("key1=value1,key2=value2"),
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES percent-encoded values",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("key1=val%2Cwith%2Ccomma,key2=value2"),
+			},
+			expected: map[string]string{
+				"key1": "val,with,comma",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES percent-encoded keys",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("key%3D2=value2,key%2C3=value3"),
+			},
+			expected: map[string]string{
+				"key=2": "value2",
+				"key,3": "value3",
+			},
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES invalid encoding in value discards all",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("good=value,bad=%ZZ"),
+			},
+			// Per OTel spec, the entire value is discarded on any error.
+			expected: nil,
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES invalid encoding in key discards all",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("good=value,bad%ZZ=value2"),
+			},
+			// Per OTel spec, the entire value is discarded on any error.
+			expected: nil,
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES missing equals discards all",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("good=value,badpair"),
+			},
+			// Per OTel spec, the entire value is discarded on any error.
+			expected: nil,
+		},
+		{
+			name: "OTEL_RESOURCE_ATTRIBUTES empty value",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern(""),
+			},
+			expected: nil,
+		},
+		{
+			name:        "a contribution is not overridden by OTEL_SERVICE_NAME",
+			contributed: map[string]string{"service.name": "test-service"},
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_SERVICE_NAME"): libpf.Intern("env-service"),
+			},
+			expected: map[string]string{
+				"service.name": "test-service",
+			},
+		},
+		{
+			name: "both env vars",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_SERVICE_NAME"):        libpf.Intern("my-svc"),
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("deployment.environment=prod"),
+			},
+			expected: map[string]string{
+				"service.name":           "my-svc",
+				"deployment.environment": "prod",
+			},
+		},
+		{
+			name: "OTEL_SERVICE_NAME wins over service.name in OTEL_RESOURCE_ATTRIBUTES",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_SERVICE_NAME"):        libpf.Intern("from-service-name"),
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("service.name=from-attrs"),
+			},
+			expected: map[string]string{
+				"service.name": "from-service-name",
+			},
+		},
+		{
+			// Per OTel spec, duplicate keys within OTEL_RESOURCE_ATTRIBUTES
+			// resolve last-writer-wins.
+			name: "OTEL_RESOURCE_ATTRIBUTES duplicate keys: last writer wins",
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("k=first,k=second,k=third"),
+			},
+			expected: map[string]string{
+				"k": "third",
+			},
+		},
+		{
+			// A contribution still beats OTEL_RESOURCE_ATTRIBUTES, so the
+			// dedup-then-apply order is observable: even though "from-attrs-second"
+			// wins the intra-attr dedup, "preset" wins overall.
+			name:        "a contribution beats the OTEL_RESOURCE_ATTRIBUTES last writer",
+			contributed: map[string]string{"k": "preset"},
+			envVars: map[libpf.String]libpf.String{
+				libpf.Intern("OTEL_RESOURCE_ATTRIBUTES"): libpf.Intern("k=from-attrs-first,k=from-attrs-second"),
+			},
+			expected: map[string]string{
+				"k": "preset",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := ResourceFromEnvVars(tt.envVars)
+
+			var contribution *pcommon.Resource
+			if tt.contributed != nil {
+				contribution = resourceWith(tt.contributed)
+			}
+
+			merged := MergeResources(base, []*pcommon.Resource{contribution})
+
+			if tt.expected == nil {
+				assert.Nil(t, merged)
+				return
+			}
+
+			require.NotNil(t, merged)
+			got := make(map[string]string)
+			merged.Attributes().Range(func(k string, v pcommon.Value) bool {
+				got[k] = v.Str()
+				return true
+			})
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/procmeta/processcontext/enricher.go
+++ b/procmeta/processcontext/enricher.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package processcontext // import "go.opentelemetry.io/ebpf-profiler/procmeta/processcontext"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
+)
+
+// enricher reads the OTel process context a process shares through its OTEL_CTX
+// memory region. Stateless: the timestamp last published for a process lives in
+// that process's state slot.
+type enricher struct{}
+
+// NewEnricher returns a ResourceEnricher contributing the resource attributes a
+// process publishes in its OTEL_CTX memory region.
+func NewEnricher() procmeta.ResourceEnricher {
+	return enricher{}
+}
+
+func (enricher) ResourceConfig() procmeta.ResourceConfig {
+	return procmeta.ResourceConfig{
+		WantMapping: func(m *process.RawMapping) bool {
+			return IsContextMapping(m.IsExecutable(), m.Path)
+		},
+	}
+}
+
+// state is an enricher's per-process state.
+type state struct {
+	// publishedAtNs is the timestamp last published, used to skip re-reading an
+	// unchanged payload.
+	publishedAtNs uint64
+}
+
+func (enricher) EnrichResource(req *procmeta.ResourceRequest) (*pcommon.Resource, bool) {
+	// The mapping is absent until the process publishes it, possibly well after
+	// startup; the eBPF hook on prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME) then triggers
+	// a resynchronization, bringing us back here.
+	var mappingAddr uint64
+	if len(req.Mappings) > 0 {
+		mappingAddr = req.Mappings[0].Vaddr
+	}
+
+	var oldPublishedAtNs uint64
+	if s, ok := (*req.State).(*state); ok {
+		oldPublishedAtNs = s.publishedAtNs
+	}
+
+	info, publish := Resolve(mappingAddr, req.Process.PID(), req.Process.GetRemoteMemory(),
+		oldPublishedAtNs)
+	if !publish {
+		return nil, false
+	}
+
+	*req.State = &state{publishedAtNs: info.PublishedAtNs}
+	return info.Resource, true
+}

--- a/procmeta/processcontext/enricher_test.go
+++ b/procmeta/processcontext/enricher_test.go
@@ -1,0 +1,170 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && (amd64 || arm64)
+
+package processcontext_test
+
+import (
+	"debug/elf"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"google.golang.org/protobuf/proto"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
+	"go.opentelemetry.io/ebpf-profiler/procmeta/processcontext"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+)
+
+const (
+	headerAddr  = 0x1000
+	payloadAddr = 0x2000
+)
+
+// fakeProcess exposes nothing but a PID and a remote memory reader, all a resource
+// enricher needs. The embedded interface is nil, so any other call panics.
+type fakeProcess struct {
+	process.Process
+	pid libpf.PID
+	rm  remotememory.RemoteMemory
+}
+
+func (p *fakeProcess) PID() libpf.PID                             { return p.pid }
+func (p *fakeProcess) GetRemoteMemory() remotememory.RemoteMemory { return p.rm }
+
+// contextMapping is the mapping the enricher's filter selects.
+var contextMapping = process.RawMapping{Vaddr: headerAddr, Path: "[anon:OTEL_CTX]"}
+
+// attrStr returns a resource's string attribute, requiring it to be present.
+func attrStr(t *testing.T, res *pcommon.Resource, key string) string {
+	t.Helper()
+	require.NotNil(t, res)
+	v, ok := res.Attributes().Get(key)
+	require.True(t, ok, "attribute %q missing", key)
+	return v.Str()
+}
+
+// publishedContext returns a process whose memory holds a valid context published
+// at the given timestamp.
+func publishedContext(t *testing.T, publishedAtNs uint64) *fakeProcess {
+	t.Helper()
+	payload, err := proto.Marshal(&testContext)
+	require.NoError(t, err)
+
+	mock := newMockReader()
+	mock.writeAt(headerAddr, createValidHeader(uint32(len(payload)), payloadAddr, publishedAtNs))
+	mock.writeAt(payloadAddr, payload)
+	return &fakeProcess{pid: 1, rm: remotememory.RemoteMemory{ReaderAt: mock}}
+}
+
+func TestEnricher_ResourceConfig(t *testing.T) {
+	cfg := processcontext.NewEnricher().ResourceConfig()
+
+	require.NotNil(t, cfg.WantMapping)
+	require.True(t, cfg.WantMapping(&process.RawMapping{Path: "[anon:OTEL_CTX]"}))
+	require.True(t, cfg.WantMapping(&process.RawMapping{Path: "/memfd:OTEL_CTX"}))
+	require.False(t, cfg.WantMapping(&process.RawMapping{Path: "/usr/lib/libc.so.6"}))
+	// An executable mapping is never a context mapping.
+	require.False(t, cfg.WantMapping(&process.RawMapping{
+		Path: "[anon:OTEL_CTX]", Flags: elf.PF_R | elf.PF_X,
+	}))
+}
+
+// TestEnricher_NoMapping covers a process that never publishes a context region:
+// this enricher has nothing to say about it, ever. Attribution from the environment
+// is the manager's base resource, not a contribution from here.
+func TestEnricher_NoMapping(t *testing.T) {
+	e := processcontext.NewEnricher()
+	var state any
+	req := &procmeta.ResourceRequest{
+		Process: &fakeProcess{pid: 1},
+		State:   &state,
+	}
+
+	res, changed := e.EnrichResource(req)
+	require.False(t, changed)
+	require.Nil(t, res)
+
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+}
+
+// TestEnricher_PublishedContext covers the lifecycle of a context region that
+// appears after the process was first seen, is then republished, and finally goes
+// away.
+func TestEnricher_PublishedContext(t *testing.T) {
+	e := processcontext.NewEnricher()
+	var state any
+
+	// First synchronization, before the process published anything.
+	req := &procmeta.ResourceRequest{
+		Process: &fakeProcess{pid: 1},
+		State:   &state,
+	}
+	_, changed := e.EnrichResource(req)
+	require.False(t, changed)
+
+	// The region shows up.
+	req = &procmeta.ResourceRequest{
+		Process:  publishedContext(t, 1000),
+		Mappings: []process.RawMapping{contextMapping},
+		State:    &state,
+	}
+	res, changed := e.EnrichResource(req)
+	require.True(t, changed)
+	require.Equal(t, "test-service", attrStr(t, res, "service.name"))
+
+	// Same payload on the next synchronization: keep the published contribution
+	// rather than rebuilding an identical one.
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+
+	// Republished with a newer timestamp: read it again.
+	req.Process = publishedContext(t, 2000)
+	res, changed = e.EnrichResource(req)
+	require.True(t, changed)
+	require.Equal(t, "test-service", attrStr(t, res, "service.name"))
+
+	// The region disappears, as on teardown: withdrawn, leaving the base resource.
+	req.Mappings = nil
+	res, changed = e.EnrichResource(req)
+	require.True(t, changed)
+	require.Nil(t, res)
+
+	// Still gone on the next synchronization: nothing left to withdraw.
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+}
+
+// TestEnricher_ExecRebuildsContext verifies that an exec discards the timestamp
+// remembered for the previous program, so a context republished at a lower
+// timestamp is not mistaken for one already seen.
+func TestEnricher_ExecRebuildsContext(t *testing.T) {
+	e := processcontext.NewEnricher()
+	var state any
+
+	req := &procmeta.ResourceRequest{
+		Process:  publishedContext(t, 2000),
+		Mappings: []process.RawMapping{contextMapping},
+		State:    &state,
+	}
+	_, changed := e.EnrichResource(req)
+	require.True(t, changed)
+
+	// A context published earlier than the one already seen is ignored...
+	req.Process = publishedContext(t, 1000)
+	_, changed = e.EnrichResource(req)
+	require.False(t, changed)
+
+	// ...unless the process execed, which the manager performs by clearing the state
+	// slot. That is what drops the remembered timestamp: this enricher has no notion
+	// of an exec of its own.
+	state = nil
+	res, changed := e.EnrichResource(req)
+	require.True(t, changed)
+	require.Equal(t, "test-service", attrStr(t, res, "service.name"))
+}

--- a/procmeta/processcontext/integrationtests/processcontext_integration_test.go
+++ b/procmeta/processcontext/integrationtests/processcontext_integration_test.go
@@ -1,0 +1,221 @@
+//go:build host_integration && linux
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integrationtests
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/log"
+	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/metrics"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
+	"go.opentelemetry.io/ebpf-profiler/tracer"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// expectedResource lists the resource attributes the testdata C programs
+// publish via init_process_context() in processctx_lib.c.
+var expectedResource = map[string]string{
+	"service.name":                "my-service",
+	"service.version":             "4.5.6",
+	"service.instance.id":         "123d8444-2c7e-46e3-89f6-6217880f7123",
+	"deployment.environment.name": "prod",
+	"telemetry.sdk.language":      "c",
+	"telemetry.sdk.version":       "1.2.3",
+	"telemetry.sdk.name":          "example_ctx.c",
+	"resource.key1":               "resource.value1",
+	"resource.key2":               "resource.value2",
+}
+
+type mockIntervals struct{}
+
+func (mockIntervals) MonitorInterval() time.Duration       { return 1 * time.Second }
+func (mockIntervals) TracePollInterval() time.Duration     { return 250 * time.Millisecond }
+func (mockIntervals) PIDCleanupInterval() time.Duration    { return 1 * time.Second }
+func (mockIntervals) ExecutableUnloadDelay() time.Duration { return 1 * time.Second }
+
+// captureReporter is a minimal TraceReporter that captures TraceEventMeta
+// so the test can inspect the Resource that HandleTrace resolved.
+type captureReporter struct {
+	metaCh chan *samples.TraceEventMeta
+}
+
+func newCaptureReporter() *captureReporter {
+	return &captureReporter{metaCh: make(chan *samples.TraceEventMeta, 64)}
+}
+
+func (r *captureReporter) ReportTraceEvent(_ *libpf.Trace, meta *samples.TraceEventMeta) error {
+	r.metaCh <- meta
+	return nil
+}
+
+var _ reporter.TraceReporter = (*captureReporter)(nil)
+
+func isRoot() bool {
+	return os.Geteuid() == 0
+}
+
+func Test_ProcessContext(t *testing.T) {
+	if !isRoot() {
+		t.Skip("root privileges required")
+	}
+
+	curDir, err := os.Getwd()
+	require.NoError(t, err)
+	exeDir := filepath.Join(curDir, "testdata")
+	allCPUs := []int{}
+
+	tests := map[string]struct {
+		exeName string
+		args    []string
+		env     []string
+	}{
+		"glibc_exe": {exeName: "processctx_exe_glibc"},
+		// Publishes the process context after a delay, so the profiler discovers
+		// the PID before the publication and the prctl monitor must trigger a
+		// resync to pick up the OTEL_CTX mapping.
+		"glibc_exe_delayed_publish": {
+			exeName: "processctx_exe_glibc",
+			env:     []string{"OTEL_PROCESS_CTX_PUBLISH_DELAY_MS=200"},
+		},
+		// "musl_exe":     {exeName: "processctx_exe_musl"},
+		// "glibc_lib":    {exeName: "processctx_lib_glibc"},
+		// "musl_lib":     {exeName: "processctx_lib_musl"},
+		// "glibc_dlopen": {exeName: "processctx_dlopen_glibc", args: []string{filepath.Join(exeDir, "libprocessctx_glibc.so")}},
+		// "musl_dlopen":  {exeName: "processctx_dlopen_musl", args: []string{filepath.Join(exeDir, "libprocessctx_musl.so")}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			metrics.Start(noop.Meter{})
+
+			log.SetLevel(slog.LevelDebug)
+			rep := newCaptureReporter()
+			trc, err := tracer.NewTracer(ctx, &tracer.Config{
+				Intervals:              &mockIntervals{},
+				InterpretersConfig:     interpreterconfig.AllInterpreters(),
+				SamplesPerSecond:       20,
+				ProbabilisticInterval:  100,
+				ProbabilisticThreshold: 100,
+				OffCPUThreshold:        uint32(math.MaxUint32 / 100),
+				VerboseMode:            true,
+				TraceReporter:          rep,
+			})
+			require.NoError(t, err)
+			defer trc.Close()
+
+			trc.StartPIDEventProcessor(ctx)
+			require.NoError(t, trc.AttachTracer(allCPUs))
+
+			t.Log("Attached tracer program")
+			require.NoError(t, trc.EnableProfiling())
+			require.NoError(t, trc.AttachSchedMonitor())
+			require.NoError(t, trc.AttachPrctlMonitor())
+
+			traceCh := make(chan *libpf.EbpfTrace)
+			require.NoError(t, trc.StartMapMonitors(ctx, traceCh))
+
+			// Read raw EbpfTrace from the monitor, feed through HandleTrace
+			// (which resolves process metadata including the Resource), and
+			// inspect the TraceEventMeta captured by the reporter.
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case trace := <-traceCh:
+						if trace != nil {
+							trc.HandleTrace(trace)
+						}
+					}
+				}
+			}()
+
+			cmd := exec.CommandContext(ctx, filepath.Join(exeDir, tc.exeName), tc.args...)
+			cmd.Stderr = os.Stderr
+			if len(tc.env) > 0 {
+				cmd.Env = append(os.Environ(), tc.env...)
+			}
+			require.NoError(t, cmd.Start())
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := cmd.Wait()
+				select {
+				case <-ctx.Done():
+					t.Log("Test program cancelled (run complete)")
+				default:
+					// require.* must run on the test goroutine; mark the test
+					// as failed here and cancel so the main loop unblocks and
+					// reports the early child exit.
+					t.Errorf("test program exited unexpectedly: %v", err)
+					cancel()
+				}
+			}()
+
+			timeout := time.NewTimer(10 * time.Second)
+			defer timeout.Stop()
+
+			ok := false
+		Loop:
+			for {
+				select {
+				case <-timeout.C:
+					break Loop
+				case meta := <-rep.metaCh:
+					if meta.PID != libpf.PID(cmd.Process.Pid) {
+						continue
+					}
+					if meta.Resource == nil {
+						continue
+					}
+					if !resourceMatches(meta.Resource, expectedResource) {
+						continue
+					}
+					t.Logf("Got expected resource for PID %d", meta.PID)
+					ok = true
+					break Loop
+				}
+			}
+			cancel()
+			wg.Wait()
+			require.True(t, ok, "process context not received")
+			t.Log("Exiting test case")
+		})
+	}
+}
+
+// resourceMatches reports whether every key in want is present in r with the
+// expected value (other keys in r are ignored). Returns false on the first
+// missing key or value mismatch.
+func resourceMatches(r *pcommon.Resource, want map[string]string) bool {
+	attrs := r.Attributes()
+	for k, v := range want {
+		got, ok := attrs.Get(k)
+		if !ok || got.Type() != pcommon.ValueTypeStr || got.Str() != v {
+			return false
+		}
+	}
+	return true
+}

--- a/procmeta/processcontext/integrationtests/testdata/.gitignore
+++ b/procmeta/processcontext/integrationtests/testdata/.gitignore
@@ -1,0 +1,4 @@
+processctx_exe_*
+libprocessctx_*.so
+processctx_lib_*
+processctx_dlopen_*

--- a/procmeta/processcontext/integrationtests/testdata/Makefile
+++ b/procmeta/processcontext/integrationtests/testdata/Makefile
@@ -1,0 +1,54 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Makefile to build test binaries for processcontext and threadcontext integration tests.
+#
+# These binaries exercise the different TLS models across libc and architecture combinations.
+
+.PHONY: all clean
+
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),aarch64)
+TLS_DIALECT?=desc
+else
+TLS_DIALECT?=gnu2
+endif
+
+
+# Compilers (override on command line if needed)
+GCC       ?= $(ARCH)-linux-gnu-gcc
+MUSL_GCC  ?= $(ARCH)-linux-musl-gcc
+
+
+# Only the static executable variant is built; shared-lib and dlopen targets remain for future thread-context support.
+BINARIES := processctx_exe_glibc # processctx_exe_musl processctx_lib_glibc processctx_lib_musl processctx_dlopen_glibc processctx_dlopen_musl
+
+all: $(BINARIES)
+
+clean:
+	rm -f $(BINARIES)
+
+processctx_exe_glibc: processctx.c processctx_lib.c processctx_lib.h otel_process_ctx.c otel_process_ctx.h
+	$(GCC) -mtls-dialect=$(TLS_DIALECT) -o $@ $< processctx_lib.c otel_process_ctx.c 
+
+processctx_exe_musl: processctx.c processctx_lib.c processctx_lib.h otel_process_ctx.c otel_process_ctx.h
+	$(MUSL_GCC) -mtls-dialect=$(TLS_DIALECT) -o $@ $< processctx_lib.c otel_process_ctx.c -static
+
+libprocessctx_glibc.so: processctx_lib.c processctx_lib.h otel_process_ctx.c otel_process_ctx.h
+	$(GCC) -shared -fPIC -mtls-dialect=$(TLS_DIALECT) -o $@ $< otel_process_ctx.c
+
+libprocessctx_musl.so: processctx_lib.c processctx_lib.h otel_process_ctx.c otel_process_ctx.h
+	$(MUSL_GCC) -shared -fPIC -mtls-dialect=$(TLS_DIALECT) -o $@ $< otel_process_ctx.c
+
+processctx_lib_glibc: processctx.c processctx_lib.h libprocessctx_glibc.so
+	$(GCC) -o $@ $< -L. -lprocessctx_glibc -Wl,-rpath='$$ORIGIN'
+
+processctx_lib_musl: processctx.c processctx_lib.h libprocessctx_musl.so
+	$(MUSL_GCC) -o $@ $< -L. -lprocessctx_musl -Wl,-rpath=/lib/x86_64-linux-musl/ -Wl,-rpath='$$ORIGIN'
+
+processctx_dlopen_glibc: processctx.c
+	$(GCC) -o $@ $< -DUSE_DLOPEN
+
+processctx_dlopen_musl: processctx.c
+	$(MUSL_GCC) -o $@ $< -DUSE_DLOPEN -Wl,-rpath=/lib/x86_64-linux-musl/ 

--- a/procmeta/processcontext/integrationtests/testdata/otel_process_ctx.c
+++ b/procmeta/processcontext/integrationtests/testdata/otel_process_ctx.c
@@ -1,0 +1,1166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Source: https://github.com/open-telemetry/sig-profiling/blob/main/process-context/c-and-cpp/otel_process_ctx.c
+
+#include "otel_process_ctx.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifdef __cplusplus
+#include <atomic>
+using std::atomic_thread_fence;
+using std::memory_order_seq_cst;
+#else
+#include <stdatomic.h>
+#endif
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#define ADD_QUOTES_HELPER(x) #x
+#define ADD_QUOTES(x) ADD_QUOTES_HELPER(x)
+#define KEY_VALUE_LIMIT 4096
+#define UINT14_MAX 16383
+#define OTEL_CTX_SIGNATURE "OTEL_CTX"
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+
+#ifndef MFD_NOEXEC_SEAL
+#define MFD_NOEXEC_SEAL 8U
+#endif
+
+static const otel_process_ctx_data empty_data = {.deployment_environment_name =
+                                                     NULL,
+                                                 .service_instance_id = NULL,
+                                                 .service_name = NULL,
+                                                 .service_version = NULL,
+                                                 .telemetry_sdk_language = NULL,
+                                                 .telemetry_sdk_version = NULL,
+                                                 .telemetry_sdk_name = NULL,
+                                                 .resource_attributes = NULL,
+                                                 .extra_attributes = NULL,
+                                                 .thread_ctx_config = NULL};
+
+#if (defined(OTEL_PROCESS_CTX_NOOP) && OTEL_PROCESS_CTX_NOOP) ||               \
+    !defined(__linux__)
+// NOOP implementations when OTEL_PROCESS_CTX_NOOP is defined or not on Linux
+
+otel_process_ctx_result
+otel_process_ctx_publish(const otel_process_ctx_data *data) {
+  (void)data; // Suppress unused parameter warning
+  return (otel_process_ctx_result){.success = false,
+                                   .error_message =
+                                       "OTEL_PROCESS_CTX_NOOP mode is enabled "
+                                       "- no-op implementation (" __FILE__
+                                       ":" ADD_QUOTES(__LINE__) ")"};
+}
+
+bool otel_process_ctx_drop_current(void) {
+  return true; // Nothing to do, this always succeeds
+}
+
+#ifndef OTEL_PROCESS_CTX_NO_READ
+otel_process_ctx_read_result otel_process_ctx_read(void) {
+  return (otel_process_ctx_read_result){
+      .success = false,
+      .error_message = "OTEL_PROCESS_CTX_NOOP mode is enabled - no-op "
+                       "implementation (" __FILE__ ":" ADD_QUOTES(__LINE__) ")",
+      .data = empty_data};
+}
+
+bool otel_process_ctx_read_drop(otel_process_ctx_read_result *result) {
+  (void)result; // Suppress unused parameter warning
+  return false;
+}
+#endif // OTEL_PROCESS_CTX_NO_READ
+#else  // OTEL_PROCESS_CTX_NOOP
+
+/**
+ * The process context data that's written into the published anonymous mapping.
+ *
+ * An outside-of-process reader will read this struct + otel_process_payload to
+ * get the data.
+ */
+typedef struct __attribute__((packed, aligned(8))) {
+  char otel_process_ctx_signature[8]; // Always "OTEL_CTX"
+  uint32_t otel_process_ctx_version;  // Always > 0, incremented when the data
+                                      // structure changes, currently v2
+  uint32_t otel_process_payload_size; // Always > 0, size of storage
+  uint64_t
+      otel_process_monotonic_published_at_ns; // Timestamp from when the context
+                                              // was published in nanoseconds
+                                              // from CLOCK_BOOTTIME. 0 during
+                                              // updates.
+  char *otel_process_payload; // Always non-null, points to the storage for the
+                              // data; expected to be a protobuf map of string
+                              // key/value pairs, null-terminated
+} otel_process_ctx_mapping;
+
+/**
+ * The full state of a published process context.
+ *
+ * It is used to store the all data for the process context and that needs to be
+ * kept around while the context is published.
+ */
+typedef struct {
+  // The pid of the process that published the context.
+  pid_t publisher_pid;
+  // The actual mapping of the process context. Note that because we
+  // `madvise(..., MADV_DONTFORK)` this mapping is not propagated to child
+  // processes and thus `mapping` is only valid on the process that published
+  // the context.
+  otel_process_ctx_mapping *mapping;
+  // The process context payload.
+  char *payload;
+} otel_process_ctx_state;
+
+/**
+ * Only one context is active, so we keep its state as a global.
+ */
+static otel_process_ctx_state published_state;
+
+static otel_process_ctx_result
+otel_process_ctx_update(uint64_t monotonic_published_at_ns,
+                        const otel_process_ctx_data *data);
+static otel_process_ctx_result
+otel_process_ctx_encode_protobuf_payload(char **out, uint32_t *out_size,
+                                         otel_process_ctx_data data);
+
+static uint64_t monotonic_time_now_ns(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_BOOTTIME, &ts) == -1)
+    return 0;
+  return ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+static bool ctx_is_published(otel_process_ctx_state state) {
+  return state.mapping != NULL && state.mapping != MAP_FAILED &&
+         getpid() == state.publisher_pid;
+}
+
+// The process context is designed to be read by an outside-of-process reader.
+// Thus, for concurrency purposes the steps on this method are ordered in a way
+// to avoid races, or if not possible to avoid, to allow the reader to detect if
+// there was a race.
+otel_process_ctx_result
+otel_process_ctx_publish(const otel_process_ctx_data *data) {
+  if (!data)
+    return (otel_process_ctx_result){
+        .success = false,
+        .error_message = "otel_process_ctx_data is NULL (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")"};
+
+  uint64_t monotonic_published_at_ns = monotonic_time_now_ns();
+  if (monotonic_published_at_ns == 0) {
+    return (otel_process_ctx_result){.success = false,
+                                     .error_message =
+                                         "Failed to get current time (" __FILE__
+                                         ":" ADD_QUOTES(__LINE__) ")"};
+  }
+
+  // Step: If the context has been published by this process, update it in place
+  if (ctx_is_published(published_state))
+    return otel_process_ctx_update(monotonic_published_at_ns, data);
+
+  // Step: Drop any previous context state if it exists
+  // No state should be around anywhere after this step.
+  if (!otel_process_ctx_drop_current()) {
+    return (otel_process_ctx_result){
+        .success = false,
+        .error_message = "Failed to drop previous context (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")"};
+  }
+
+  // Step: Prepare the payload to be published
+  // The payload SHOULD be ready and valid before trying to actually create the
+  // mapping.
+  uint32_t payload_size = 0;
+  otel_process_ctx_result result = otel_process_ctx_encode_protobuf_payload(
+      &published_state.payload, &payload_size, *data);
+  if (!result.success)
+    return result;
+
+  // Step: Create the mapping
+  const ssize_t mapping_size = sizeof(otel_process_ctx_mapping);
+  published_state.publisher_pid =
+      getpid(); // This allows us to detect in forks that we shouldn't touch the
+                // mapping
+  int fd = memfd_create("OTEL_CTX",
+                        MFD_CLOEXEC | MFD_ALLOW_SEALING | MFD_NOEXEC_SEAL);
+  if (fd < 0) {
+    // MFD_NOEXEC_SEAL is a newer flag; older kernels reject unknown flags, so
+    // let's retry without it
+    fd = memfd_create("OTEL_CTX", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  }
+  bool failed_to_close_fd = false;
+  if (fd >= 0) {
+    // Try to create mapping from memfd
+    if (ftruncate(fd, mapping_size) == -1) {
+      otel_process_ctx_drop_current();
+      return (otel_process_ctx_result){.success = false,
+                                       .error_message =
+                                           "Failed to truncate memfd (" __FILE__
+                                           ":" ADD_QUOTES(__LINE__) ")"};
+    }
+    published_state.mapping = (otel_process_ctx_mapping *)mmap(
+        NULL, mapping_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    failed_to_close_fd = (close(fd) == -1);
+  } else {
+    // Fallback: Use an anonymous mapping instead
+    published_state.mapping = (otel_process_ctx_mapping *)mmap(
+        NULL, mapping_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
+        -1, 0);
+  }
+  if (published_state.mapping == MAP_FAILED || failed_to_close_fd) {
+    otel_process_ctx_drop_current();
+
+    if (failed_to_close_fd) {
+      return (otel_process_ctx_result){.success = false,
+                                       .error_message =
+                                           "Failed to close memfd (" __FILE__
+                                           ":" ADD_QUOTES(__LINE__) ")"};
+    } else {
+      return (otel_process_ctx_result){
+          .success = false,
+          .error_message = "Failed to allocate mapping (" __FILE__
+                           ":" ADD_QUOTES(__LINE__) ")"};
+    }
+  }
+
+  // Step: Setup MADV_DONTFORK
+  // This ensures that the mapping is not propagated to child processes (they
+  // should call update/publish again).
+  if (madvise(published_state.mapping, mapping_size, MADV_DONTFORK) == -1) {
+    if (otel_process_ctx_drop_current()) {
+      return (otel_process_ctx_result){
+          .success = false,
+          .error_message = "Failed to setup MADV_DONTFORK (" __FILE__
+                           ":" ADD_QUOTES(__LINE__) ")"};
+    } else {
+      return (otel_process_ctx_result){.success = false,
+                                       .error_message =
+                                           "Failed to drop context (" __FILE__
+                                           ":" ADD_QUOTES(__LINE__) ")"};
+    }
+  }
+
+  // Step: Populate the mapping
+  // The payload and any extra fields must come first and not be reordered with
+  // the monotonic_published_at_ns by the compiler.
+  *published_state.mapping = (otel_process_ctx_mapping){
+      .otel_process_ctx_signature = {'O', 'T', 'E', 'L', '_', 'C', 'T', 'X'},
+      .otel_process_ctx_version = 2,
+      .otel_process_payload_size = payload_size,
+      .otel_process_monotonic_published_at_ns =
+          0, // Set in "Step: Populate the monotonic_published_at_ns into the
+             // mapping" below
+      .otel_process_payload = published_state.payload};
+
+  // Step: Synchronization - Mapping has been filled and is missing
+  // monotonic_published_at_ns Make sure the initialization of the mapping +
+  // payload above does not get reordered with setting the
+  // monotonic_published_at_ns below. Setting the monotonic_published_at_ns is
+  // what tells an outside reader that the context is fully published.
+  atomic_thread_fence(memory_order_seq_cst);
+
+  // Step: Populate the monotonic_published_at_ns into the mapping
+  // The monotonic_published_at_ns must come last and not be reordered with the
+  // fields above by the compiler. After this step, external readers can read
+  // the monotonic_published_at_ns and know that the payload is ready to be
+  // read.
+  published_state.mapping->otel_process_monotonic_published_at_ns =
+      monotonic_published_at_ns;
+
+  // Step: Attempt to name the mapping so outside readers can:
+  // * Find it by name
+  // * Hook on prctl to detect when new mappings are published
+  if (prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, published_state.mapping,
+            mapping_size, OTEL_CTX_SIGNATURE) == -1) {
+    // Naming an anonymous mapping is an optional Linux 5.17+ feature
+    // (`CONFIG_ANON_VMA_NAME`). Many distros, such as Ubuntu and Arch enable
+    // it. On earlier kernel versions or kernels without the feature, this call
+    // can fail.
+    //
+    // It's OK for this to fail because (per-usecase):
+    // 1. "Find it by name" => As a fallback, it's possible to scan the mappings
+    // and for the memfd name.
+    // 2. "Hook on prctl" => When hooking on prctl via eBPF it's still possible
+    // to see this call, even when it's not supported/enabled.
+    //    This works even on older kernels! For this reason we unconditionally
+    //    make this call even on older kernels -- to still allow detection via
+    //    hooking onto prctl.
+  }
+
+  // All done!
+
+  return (otel_process_ctx_result){.success = true, .error_message = NULL};
+}
+
+bool otel_process_ctx_drop_current(void) {
+  otel_process_ctx_state state = published_state;
+
+  // Zero out the state and make sure no operations below are reordered with
+  // zeroing
+  published_state = (otel_process_ctx_state){
+      .publisher_pid = 0, .mapping = NULL, .payload = NULL};
+  atomic_thread_fence(memory_order_seq_cst);
+
+  bool success = true;
+
+  // The mapping only exists if it was created by the current process; if it was
+  // inherited by a fork it doesn't exist anymore (due to the MADV_DONTFORK) and
+  // we don't need to do anything to it.
+  if (ctx_is_published(state)) {
+    success = munmap(state.mapping, sizeof(otel_process_ctx_mapping)) == 0;
+  }
+
+  // The payload may have been inherited from a parent. This is a regular malloc
+  // so we need to free it so we don't leak.
+  free(state.payload);
+
+  return success;
+}
+
+static otel_process_ctx_result
+otel_process_ctx_update(uint64_t monotonic_published_at_ns,
+                        const otel_process_ctx_data *data) {
+  if (data == NULL || !ctx_is_published(published_state)) {
+    return (otel_process_ctx_result){
+        .success = false,
+        .error_message =
+            "Unexpected: otel_process_ctx_data is NULL or context is not "
+            "published (" __FILE__ ":" ADD_QUOTES(__LINE__) ")"};
+  }
+
+  if (monotonic_published_at_ns ==
+      published_state.mapping->otel_process_monotonic_published_at_ns) {
+    // Advance published_at_ns to allow readers to detect the update
+    monotonic_published_at_ns++;
+  }
+
+  // Step: Prepare the new payload to be published
+  // The payload SHOULD be ready and valid before trying to actually update the
+  // mapping.
+  uint32_t payload_size = 0;
+  char *payload;
+  otel_process_ctx_result result =
+      otel_process_ctx_encode_protobuf_payload(&payload, &payload_size, *data);
+  if (!result.success)
+    return result;
+
+  // Step: Zero out monotonic_published_at_ns in the mapping
+  // This enables readers to detect that an update is in-progress
+  published_state.mapping->otel_process_monotonic_published_at_ns = 0;
+
+  // Step: Synchronization - Make sure readers observe the zeroing above before
+  // anything else below
+  atomic_thread_fence(memory_order_seq_cst);
+
+  // Step: Install updated data
+  published_state.mapping->otel_process_payload_size = payload_size;
+  published_state.mapping->otel_process_payload = payload;
+
+  // Step: Synchronization - Make sure readers observe the updated data before
+  // anything else below
+  atomic_thread_fence(memory_order_seq_cst);
+
+  // Step: Install new monotonic_published_at_ns
+  // The update is now complete -- readers that observe the new timestamp will
+  // observe the updated payload
+  published_state.mapping->otel_process_monotonic_published_at_ns =
+      monotonic_published_at_ns;
+
+  // Step: Attempt to name the mapping so outside readers can detect the update
+  if (prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, published_state.mapping,
+            sizeof(otel_process_ctx_mapping), OTEL_CTX_SIGNATURE) == -1) {
+    // It's OK for this to fail -- see otel_process_ctx_publish for why
+  }
+
+  // Step: Update bookkeeping
+  free(published_state.payload); // This was still pointing to the old payload
+  published_state.payload = payload;
+
+  // All done!
+
+  return (otel_process_ctx_result){.success = true, .error_message = NULL};
+}
+
+// The caller is responsible for enforcing that value fits within UINT14_MAX
+static size_t protobuf_varint_size(uint16_t value) {
+  return value >= 128 ? 2 : 1;
+}
+
+// Field tag for record + varint len + data
+static size_t protobuf_record_size(size_t len) {
+  return 1 + protobuf_varint_size(len) + len;
+}
+
+static size_t protobuf_string_size(const char *str) {
+  return protobuf_record_size(strlen(str));
+}
+
+static size_t protobuf_otel_keyvalue_string_size(const char *key,
+                                                 const char *value) {
+  size_t key_field_size = protobuf_string_size(key); // String
+  size_t value_field_size = protobuf_record_size(protobuf_string_size(
+      value)); // Nested AnyValue message with a string inside
+  return key_field_size +
+         value_field_size; // Does not include the keyvalue record tag + size,
+                           // only its payload
+}
+
+static size_t protobuf_otel_array_value_content_size(const char **strings) {
+  size_t total = 0;
+  for (size_t i = 0; strings[i] != NULL; i++) {
+    total += protobuf_record_size(protobuf_string_size(
+        strings[i])); // ArrayValue.values[i]: AnyValue{string_value}
+  }
+  return total;
+}
+
+// As a simplification, we enforce that keys and values are <= 4096
+// (KEY_VALUE_LIMIT) so that their size + extra bytes always fits within
+// UINT14_MAX
+static otel_process_ctx_result
+validate_and_calculate_protobuf_payload_size(size_t *out_pairs_size,
+                                             const char **pairs) {
+  size_t num_entries = 0;
+  for (size_t i = 0; pairs[i] != NULL; i++)
+    num_entries++;
+  if (num_entries % 2 != 0) {
+    return (otel_process_ctx_result){
+        .success = false,
+        .error_message = "Value in otel_process_ctx_data is NULL (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")"};
+  }
+
+  *out_pairs_size = 0;
+  for (size_t i = 0; pairs[i * 2] != NULL; i++) {
+    const char *key = pairs[i * 2];
+    const char *value = pairs[i * 2 + 1];
+
+    if (strlen(key) > KEY_VALUE_LIMIT) {
+      return (otel_process_ctx_result){
+          .success = false,
+          .error_message =
+              "Length of key in otel_process_ctx_data exceeds 4096 limit "
+              "(" __FILE__ ":" ADD_QUOTES(__LINE__) ")"};
+    }
+    if (strlen(value) > KEY_VALUE_LIMIT) {
+      return (otel_process_ctx_result){
+          .success = false,
+          .error_message =
+              "Length of value in otel_process_ctx_data exceeds 4096 limit "
+              "(" __FILE__ ":" ADD_QUOTES(__LINE__) ")"};
+    }
+
+    *out_pairs_size += protobuf_record_size(
+        protobuf_otel_keyvalue_string_size(key, value)); // KeyValue message
+  }
+  return (otel_process_ctx_result){.success = true, .error_message = NULL};
+}
+
+/**
+ * Writes a protobuf varint encoding for the given value.
+ * As a simplification, only supports values that fit in 1 or 2 bytes (0-16383
+ * UINT14_MAX).
+ */
+static void write_protobuf_varint(char **ptr, uint16_t value) {
+  if (protobuf_varint_size(value) == 1) {
+    *(*ptr)++ = (char)value;
+  } else {
+    // Two bytes: first byte has MSB set, second byte has value
+    *(*ptr)++ = (char)((value & 0x7F) | 0x80); // Low 7 bits + continuation bit
+    *(*ptr)++ = (char)(value >> 7);            // High 7 bits
+  }
+}
+
+static void write_protobuf_string(char **ptr, const char *str) {
+  size_t len = strlen(str);
+  write_protobuf_varint(ptr, len);
+  memcpy(*ptr, str, len);
+  *ptr += len;
+}
+
+static void write_protobuf_tag(char **ptr, uint8_t field_number) {
+  *(*ptr)++ = (char)((field_number << 3) | 2); // Field type is always 2 (LEN)
+}
+
+static void write_attribute(char **ptr, uint8_t field_number, const char *key,
+                            const char *value) {
+  write_protobuf_tag(ptr, field_number);
+  write_protobuf_varint(ptr, protobuf_otel_keyvalue_string_size(key, value));
+
+  // KeyValue
+  write_protobuf_tag(ptr, 1); // KeyValue.key (field 1)
+  write_protobuf_string(ptr, key);
+  write_protobuf_tag(ptr, 2); // KeyValue.value (field 2)
+  write_protobuf_varint(ptr, protobuf_string_size(value));
+
+  // AnyValue
+  write_protobuf_tag(ptr, 1); // AnyValue.string_value (field 1)
+  write_protobuf_string(ptr, value);
+}
+
+static void write_array_attribute(char **ptr, uint8_t field_number,
+                                  const char *key, const char **strings) {
+  size_t array_value_content_size =
+      protobuf_otel_array_value_content_size(strings);
+  size_t any_value_content_size =
+      protobuf_record_size(array_value_content_size);
+  size_t kv_content_size =
+      protobuf_string_size(key) + protobuf_record_size(any_value_content_size);
+
+  write_protobuf_tag(ptr, field_number);
+  write_protobuf_varint(ptr, kv_content_size);
+
+  write_protobuf_tag(ptr, 1); // KeyValue.key (field 1)
+  write_protobuf_string(ptr, key);
+
+  write_protobuf_tag(ptr, 2); // KeyValue.value (field 2) = AnyValue message
+  write_protobuf_varint(ptr, any_value_content_size);
+
+  write_protobuf_tag(ptr,
+                     5); // AnyValue.array_value (field 5) = ArrayValue message
+  write_protobuf_varint(ptr, array_value_content_size);
+
+  for (size_t i = 0; strings[i] != NULL;
+       i++) { // ArrayValue.values (field 1) - repeated AnyValue entries
+    write_protobuf_tag(ptr, 1); // ArrayValue.values[i]
+    write_protobuf_varint(
+        ptr, protobuf_string_size(strings[i])); // Inner AnyValue size
+    write_protobuf_tag(ptr, 1); // AnyValue.string_value (field 1)
+    write_protobuf_string(ptr, strings[i]);
+  }
+}
+
+// Encode the payload as protobuf bytes.
+//
+// This method implements an extremely compact but limited protobuf encoder for
+// the ProcessContext message. It encodes all fields as Resource attributes
+// (KeyValue pairs). For extra compact code, it fixes strings at up to 4096
+// bytes.
+static otel_process_ctx_result
+otel_process_ctx_encode_protobuf_payload(char **out, uint32_t *out_size,
+                                         otel_process_ctx_data data) {
+  const char *pairs[] = {"deployment.environment.name",
+                         data.deployment_environment_name,
+                         "service.instance.id",
+                         data.service_instance_id,
+                         "service.name",
+                         data.service_name,
+                         "service.version",
+                         data.service_version,
+                         "telemetry.sdk.language",
+                         data.telemetry_sdk_language,
+                         "telemetry.sdk.version",
+                         data.telemetry_sdk_version,
+                         "telemetry.sdk.name",
+                         data.telemetry_sdk_name,
+                         NULL};
+
+  size_t pairs_size = 0;
+  otel_process_ctx_result validation_result =
+      validate_and_calculate_protobuf_payload_size(&pairs_size,
+                                                   (const char **)pairs);
+  if (!validation_result.success)
+    return validation_result;
+
+  size_t resource_attributes_pairs_size = 0;
+  if (data.resource_attributes != NULL) {
+    validation_result = validate_and_calculate_protobuf_payload_size(
+        &resource_attributes_pairs_size, data.resource_attributes);
+    if (!validation_result.success)
+      return validation_result;
+  }
+
+  size_t extra_attributes_pairs_size = 0;
+  if (data.extra_attributes != NULL) {
+    validation_result = validate_and_calculate_protobuf_payload_size(
+        &extra_attributes_pairs_size, data.extra_attributes);
+    if (!validation_result.success)
+      return validation_result;
+  }
+
+  size_t thread_ctx_pairs_size = 0;
+  if (data.thread_ctx_config != NULL) {
+    if (data.thread_ctx_config->schema_version != NULL) {
+      const char *thread_ctx_pairs[] = {"threadlocal.schema_version",
+                                        data.thread_ctx_config->schema_version,
+                                        NULL};
+      validation_result = validate_and_calculate_protobuf_payload_size(
+          &thread_ctx_pairs_size, thread_ctx_pairs);
+      if (!validation_result.success)
+        return validation_result;
+    }
+    if (data.thread_ctx_config->attribute_key_map != NULL) {
+      if (data.thread_ctx_config->schema_version == NULL) {
+        return (otel_process_ctx_result){
+            .success = false,
+            .error_message =
+                "attribute_key_map requires schema_version to be set (" __FILE__
+                ":" ADD_QUOTES(__LINE__) ")"};
+      }
+      for (size_t i = 0; data.thread_ctx_config->attribute_key_map[i] != NULL;
+           i++) {
+        if (strlen(data.thread_ctx_config->attribute_key_map[i]) >
+            KEY_VALUE_LIMIT) {
+          return (otel_process_ctx_result){
+              .success = false,
+              .error_message = "Length of attribute_key_map entry exceeds 4096 "
+                               "limit (" __FILE__ ":" ADD_QUOTES(__LINE__) ")"};
+        }
+      }
+      size_t array_value_content_size = protobuf_otel_array_value_content_size(
+          data.thread_ctx_config->attribute_key_map);
+      size_t any_value_content_size =
+          protobuf_record_size(array_value_content_size);
+      size_t kv_content_size =
+          protobuf_string_size("threadlocal.attribute_key_map") +
+          protobuf_record_size(any_value_content_size);
+      thread_ctx_pairs_size += protobuf_record_size(kv_content_size);
+    }
+  }
+
+  size_t resource_size = pairs_size + resource_attributes_pairs_size;
+  size_t total_size = protobuf_record_size(resource_size) +
+                      extra_attributes_pairs_size + thread_ctx_pairs_size;
+
+  char *encoded = (char *)calloc(total_size, 1);
+  if (!encoded) {
+    return (otel_process_ctx_result){
+        .success = false,
+        .error_message = "Failed to allocate memory for payload (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")"};
+  }
+  char *ptr = encoded;
+
+  // ProcessContext.resource (field 1)
+  write_protobuf_tag(&ptr, 1);
+  write_protobuf_varint(&ptr, resource_size);
+
+  for (size_t i = 0; pairs[i * 2] != NULL; i++) {
+    write_attribute(&ptr, 1, pairs[i * 2], pairs[i * 2 + 1]);
+  }
+
+  for (size_t i = 0; data.resource_attributes != NULL &&
+                     data.resource_attributes[i * 2] != NULL;
+       i++) {
+    write_attribute(&ptr, 1, data.resource_attributes[i * 2],
+                    data.resource_attributes[i * 2 + 1]);
+  }
+
+  // ProcessContext.extra_attributes (field 2)
+  for (size_t i = 0;
+       data.extra_attributes != NULL && data.extra_attributes[i * 2] != NULL;
+       i++) {
+    write_attribute(&ptr, 2, data.extra_attributes[i * 2],
+                    data.extra_attributes[i * 2 + 1]);
+  }
+
+  if (data.thread_ctx_config != NULL) {
+    if (data.thread_ctx_config->schema_version != NULL) {
+      write_attribute(&ptr, 2, "threadlocal.schema_version",
+                      data.thread_ctx_config->schema_version);
+    }
+    if (data.thread_ctx_config->attribute_key_map != NULL) {
+      write_array_attribute(&ptr, 2, "threadlocal.attribute_key_map",
+                            data.thread_ctx_config->attribute_key_map);
+    }
+  }
+
+  *out = encoded;
+  *out_size = (uint32_t)total_size;
+
+  return (otel_process_ctx_result){.success = true, .error_message = NULL};
+}
+
+#ifndef OTEL_PROCESS_CTX_NO_READ
+#include <inttypes.h>
+#include <limits.h>
+#include <sys/uio.h>
+#include <sys/utsname.h>
+
+// Note: The below parsing code is only for otel_process_ctx_read and is only
+// provided for debugging and testing purposes.
+
+static void *parse_mapping_start(char *line) {
+  char *endptr = NULL;
+  unsigned long long start = strtoull(line, &endptr, 16);
+  if (start == 0 || start == ULLONG_MAX)
+    return NULL;
+  return (void *)(uintptr_t)start;
+}
+
+static otel_process_ctx_mapping *try_finding_mapping(void) {
+  char line[8192];
+  otel_process_ctx_mapping *result = NULL;
+
+  FILE *fp = fopen("/proc/self/maps", "r");
+  if (!fp)
+    return result;
+
+  while (fgets(line, sizeof(line), fp)) {
+    bool is_process_ctx = strstr(line, "[anon_shmem:OTEL_CTX]") != NULL ||
+                          strstr(line, "[anon:OTEL_CTX]") != NULL ||
+                          strstr(line, "/memfd:OTEL_CTX") != NULL;
+    if (is_process_ctx) {
+      result = (otel_process_ctx_mapping *)parse_mapping_start(line);
+      break;
+    }
+  }
+
+  fclose(fp);
+  return result;
+}
+
+// Helper function to read a protobuf varint (limited to 1-2 bytes, max value
+// UINT14_MAX, matching write_protobuf_varint above)
+static bool read_protobuf_varint(char **ptr, char *end_ptr, uint16_t *value) {
+  if (*ptr >= end_ptr)
+    return false;
+
+  unsigned char first_byte = (unsigned char)**ptr;
+  (*ptr)++;
+
+  if (first_byte < 128) {
+    *value = first_byte;
+    return true;
+  } else {
+    if (*ptr >= end_ptr)
+      return false;
+    unsigned char second_byte = (unsigned char)**ptr;
+    (*ptr)++;
+
+    *value = (first_byte & 0x7F) | (second_byte << 7);
+    return *value <= UINT14_MAX;
+  }
+}
+
+// Helper function to read a protobuf string into a buffer, within the same
+// limits as the encoder imposes
+static bool read_protobuf_string(char **ptr, char *end_ptr, char *buffer) {
+  uint16_t len;
+  if (!read_protobuf_varint(ptr, end_ptr, &len) || len >= KEY_VALUE_LIMIT + 1 ||
+      *ptr + len > end_ptr)
+    return false;
+
+  memcpy(buffer, *ptr, len);
+  buffer[len] = '\0';
+  *ptr += len;
+
+  return true;
+}
+
+// Reads field name and validates the fixed LEN wire type
+static bool read_protobuf_tag(char **ptr, char *end_ptr,
+                              uint8_t *field_number) {
+  if (*ptr >= end_ptr)
+    return false;
+
+  unsigned char tag = (unsigned char)**ptr;
+  (*ptr)++;
+
+  uint8_t wire_type = tag & 0x07;
+  *field_number = tag >> 3;
+
+  return wire_type == 2; // We only need the LEN wire type for now
+}
+
+// Peeks at the key of an OTel KeyValue message without advancing the pointer.
+static bool peek_protobuf_key(char *ptr, char *end_ptr, char *key_buffer) {
+  char *p = ptr;
+  uint8_t kv_field;
+  if (!read_protobuf_tag(&p, end_ptr, &kv_field))
+    return false;
+  if (kv_field != 1)
+    return false; // KeyValue.key is field 1
+  return read_protobuf_string(&p, end_ptr, key_buffer);
+}
+
+// Reads an OTel KeyValue message (key string + AnyValue-wrapped string) into
+// the provided buffers.
+static bool read_protobuf_keyvalue(char **ptr, char *end_ptr, char *key_buffer,
+                                   char *value_buffer) {
+  bool key_found = false;
+  bool value_found = false;
+
+  while (*ptr < end_ptr) {
+    uint8_t kv_field;
+    if (!read_protobuf_tag(ptr, end_ptr, &kv_field))
+      return false;
+
+    if (kv_field == 1) { // KeyValue.key
+      if (!read_protobuf_string(ptr, end_ptr, key_buffer))
+        return false;
+      key_found = true;
+    } else if (kv_field == 2) { // KeyValue.value (AnyValue)
+      uint16_t _any_len; // Unused, but we still need to consume + validate the
+                         // varint
+      if (!read_protobuf_varint(ptr, end_ptr, &_any_len))
+        return false;
+      uint8_t any_field;
+      if (!read_protobuf_tag(ptr, end_ptr, &any_field))
+        return false;
+
+      if (any_field == 1) { // AnyValue.string_value
+        if (!read_protobuf_string(ptr, end_ptr, value_buffer))
+          return false;
+        value_found = true;
+      }
+    }
+  }
+
+  return key_found && value_found;
+}
+
+// Reads an AnyValue.array_value (field 5) from ptr; ptr must be at
+// KeyValue.value (tag 2). Allocates a NULL-terminated array of strings and sets
+// *out_array immediately. On error the caller must free it.
+static bool read_protobuf_array_value_strings(char **ptr, char *end_ptr,
+                                              char *value_buffer,
+                                              const char ***out_array) {
+  uint8_t field;
+  if (!read_protobuf_tag(ptr, end_ptr, &field) || field != 2)
+    return false;
+  uint16_t any_len;
+  if (!read_protobuf_varint(ptr, end_ptr, &any_len))
+    return false;
+  char *any_end = *ptr + any_len;
+  if (any_end > end_ptr)
+    return false;
+
+  if (!read_protobuf_tag(ptr, any_end, &field) || field != 5)
+    return false;
+  uint16_t array_len;
+  if (!read_protobuf_varint(ptr, any_end, &array_len))
+    return false;
+  char *array_end = *ptr + array_len;
+  if (array_end > any_end)
+    return false;
+
+  size_t max = 100;
+  size_t capacity = max + 1;
+  const char **arr = (const char **)calloc(capacity, sizeof(char *));
+  if (!arr)
+    return false;
+  *out_array = arr;
+  size_t count = 0;
+
+  while (*ptr < array_end) {
+    if (count >= max)
+      return false;
+    if (!read_protobuf_tag(ptr, array_end, &field) || field != 1)
+      return false;
+    uint16_t item_len;
+    if (!read_protobuf_varint(ptr, array_end, &item_len))
+      return false;
+    char *item_end = *ptr + item_len;
+    if (item_end > array_end)
+      return false;
+    if (!read_protobuf_tag(ptr, item_end, &field) || field != 1)
+      return false;
+    if (!read_protobuf_string(ptr, item_end, value_buffer))
+      return false;
+    char *dup = strdup(value_buffer);
+    if (!dup)
+      return false;
+    arr[count++] = dup;
+  }
+
+  return true;
+}
+
+// Simplified protobuf decoder to match the exact encoder above. If the protobuf
+// data doesn't match the encoder, this will return false.
+static bool otel_process_ctx_decode_payload(char *payload,
+                                            uint32_t payload_size,
+                                            otel_process_ctx_data *data_out,
+                                            char *key_buffer,
+                                            char *value_buffer) {
+  char *ptr = payload;
+  char *end_ptr = payload + payload_size;
+
+  *data_out = empty_data;
+
+  // Parse ProcessContext wrapper - expect field 1 (resource)
+  uint8_t process_ctx_field;
+  if (!read_protobuf_tag(&ptr, end_ptr, &process_ctx_field) ||
+      process_ctx_field != 1)
+    return false;
+
+  uint16_t resource_len;
+  if (!read_protobuf_varint(&ptr, end_ptr, &resource_len))
+    return false;
+  char *resource_end = ptr + resource_len;
+  if (resource_end > end_ptr)
+    return false;
+
+  size_t resource_index = 0;
+  size_t resource_capacity =
+      201; // Allocate space for 100 pairs + NULL terminator entry
+  data_out->resource_attributes =
+      (const char **)calloc(resource_capacity, sizeof(char *));
+  if (data_out->resource_attributes == NULL)
+    return false;
+
+  size_t extra_attributes_index = 0;
+  size_t extra_attributes_capacity =
+      201; // Allocate space for 100 pairs + NULL terminator entry
+  data_out->extra_attributes =
+      (const char **)calloc(extra_attributes_capacity, sizeof(char *));
+  if (data_out->extra_attributes == NULL)
+    return false;
+
+  // Parse resource attributes (field 1)
+  while (ptr < resource_end) {
+    uint8_t field_number;
+    if (!read_protobuf_tag(&ptr, resource_end, &field_number) ||
+        field_number != 1)
+      return false;
+
+    uint16_t kv_len;
+    if (!read_protobuf_varint(&ptr, resource_end, &kv_len))
+      return false;
+    char *kv_end = ptr + kv_len;
+    if (kv_end > resource_end)
+      return false;
+
+    if (!read_protobuf_keyvalue(&ptr, kv_end, key_buffer, value_buffer))
+      return false;
+
+    char *value = strdup(value_buffer);
+    if (!value)
+      return false;
+
+    // Dispatch based on key
+    const char **field = NULL;
+    if (strcmp(key_buffer, "deployment.environment.name") == 0) {
+      field = &data_out->deployment_environment_name;
+    } else if (strcmp(key_buffer, "service.instance.id") == 0) {
+      field = &data_out->service_instance_id;
+    } else if (strcmp(key_buffer, "service.name") == 0) {
+      field = &data_out->service_name;
+    } else if (strcmp(key_buffer, "service.version") == 0) {
+      field = &data_out->service_version;
+    } else if (strcmp(key_buffer, "telemetry.sdk.language") == 0) {
+      field = &data_out->telemetry_sdk_language;
+    } else if (strcmp(key_buffer, "telemetry.sdk.version") == 0) {
+      field = &data_out->telemetry_sdk_version;
+    } else if (strcmp(key_buffer, "telemetry.sdk.name") == 0) {
+      field = &data_out->telemetry_sdk_name;
+    }
+
+    if (field != NULL) {
+      if (*field != NULL) {
+        free(value);
+        return false;
+      }
+      *field = value;
+    } else {
+      char *key = strdup(key_buffer);
+
+      if (!key || resource_index + 2 >= resource_capacity) {
+        free(key);
+        free(value);
+        return false;
+      }
+      data_out->resource_attributes[resource_index] = key;
+      data_out->resource_attributes[resource_index + 1] = value;
+      resource_index += 2;
+    }
+  }
+
+  // Parse extra attributes (field 2)
+  while (ptr < end_ptr) {
+    uint8_t extra_ctx_field;
+    if (!read_protobuf_tag(&ptr, end_ptr, &extra_ctx_field) ||
+        extra_ctx_field != 2)
+      return false;
+
+    uint16_t kv_len;
+    if (!read_protobuf_varint(&ptr, end_ptr, &kv_len))
+      return false;
+    char *kv_end = ptr + kv_len;
+    if (kv_end > end_ptr)
+      return false;
+
+    if (!peek_protobuf_key(ptr, kv_end, key_buffer))
+      return false;
+
+    if (strcmp(key_buffer, "threadlocal.attribute_key_map") == 0) {
+      // Consume key to advance ptr
+      uint8_t kv_field;
+      if (!read_protobuf_tag(&ptr, kv_end, &kv_field) || kv_field != 1)
+        return false;
+      if (!read_protobuf_string(&ptr, kv_end, key_buffer))
+        return false;
+      if (!data_out->thread_ctx_config) {
+        otel_thread_ctx_config_data *setup =
+            (otel_thread_ctx_config_data *)calloc(
+                1, sizeof(otel_thread_ctx_config_data));
+        if (!setup)
+          return false;
+        data_out->thread_ctx_config = setup;
+      }
+      if (!read_protobuf_array_value_strings(
+              &ptr, kv_end, value_buffer,
+              &((otel_thread_ctx_config_data *)data_out->thread_ctx_config)
+                   ->attribute_key_map))
+        return false;
+    } else {
+      if (!read_protobuf_keyvalue(&ptr, kv_end, key_buffer, value_buffer))
+        return false;
+
+      char *value = strdup(value_buffer);
+      if (!value)
+        return false;
+
+      // Dispatch based on key
+      if (strcmp(key_buffer, "threadlocal.schema_version") == 0) {
+        otel_thread_ctx_config_data *setup =
+            (otel_thread_ctx_config_data *)calloc(
+                1, sizeof(otel_thread_ctx_config_data));
+        if (!setup) {
+          free(value);
+          return false;
+        }
+        setup->schema_version = value;
+        data_out->thread_ctx_config = setup;
+      } else {
+        char *key = strdup(key_buffer);
+        if (!key || extra_attributes_index + 2 >= extra_attributes_capacity) {
+          free(key);
+          free(value);
+          return false;
+        }
+        data_out->extra_attributes[extra_attributes_index] = key;
+        data_out->extra_attributes[extra_attributes_index + 1] = value;
+        extra_attributes_index += 2;
+      }
+    }
+  }
+
+  // Validate all required fields were found
+  return data_out->deployment_environment_name != NULL &&
+         data_out->service_instance_id != NULL &&
+         data_out->service_name != NULL && data_out->service_version != NULL &&
+         data_out->telemetry_sdk_language != NULL &&
+         data_out->telemetry_sdk_version != NULL &&
+         data_out->telemetry_sdk_name != NULL;
+}
+
+void otel_process_ctx_read_data_drop(otel_process_ctx_data data) {
+  if (data.deployment_environment_name)
+    free((void *)data.deployment_environment_name);
+  if (data.service_instance_id)
+    free((void *)data.service_instance_id);
+  if (data.service_name)
+    free((void *)data.service_name);
+  if (data.service_version)
+    free((void *)data.service_version);
+  if (data.telemetry_sdk_language)
+    free((void *)data.telemetry_sdk_language);
+  if (data.telemetry_sdk_version)
+    free((void *)data.telemetry_sdk_version);
+  if (data.telemetry_sdk_name)
+    free((void *)data.telemetry_sdk_name);
+  if (data.resource_attributes) {
+    for (int i = 0; data.resource_attributes[i] != NULL; i++)
+      free((void *)data.resource_attributes[i]);
+    free((void *)data.resource_attributes);
+  }
+  if (data.extra_attributes) {
+    for (int i = 0; data.extra_attributes[i] != NULL; i++)
+      free((void *)data.extra_attributes[i]);
+    free((void *)data.extra_attributes);
+  }
+  if (data.thread_ctx_config) {
+    if (data.thread_ctx_config->schema_version)
+      free((void *)data.thread_ctx_config->schema_version);
+    if (data.thread_ctx_config->attribute_key_map) {
+      for (int i = 0; data.thread_ctx_config->attribute_key_map[i] != NULL;
+           i++) {
+        free((void *)data.thread_ctx_config->attribute_key_map[i]);
+      }
+      free((void *)data.thread_ctx_config->attribute_key_map);
+    }
+    free((void *)data.thread_ctx_config);
+  }
+}
+
+otel_process_ctx_read_result otel_process_ctx_read(void) {
+  otel_process_ctx_mapping *mapping = try_finding_mapping();
+  if (!mapping) {
+    return (otel_process_ctx_read_result){
+        .success = false,
+        .error_message =
+            "No OTEL_CTX mapping found (" __FILE__ ":" ADD_QUOTES(__LINE__) ")",
+        .data = empty_data};
+  }
+
+  if (strncmp(mapping->otel_process_ctx_signature, OTEL_CTX_SIGNATURE,
+              sizeof(mapping->otel_process_ctx_signature)) != 0 ||
+      mapping->otel_process_ctx_version != 2) {
+    return (otel_process_ctx_read_result){
+        .success = false,
+        .error_message = "Invalid OTEL_CTX signature or version (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")",
+        .data = empty_data};
+  }
+
+  otel_process_ctx_data data = empty_data;
+
+  char *key_buffer = (char *)calloc(KEY_VALUE_LIMIT + 1, 1);
+  char *value_buffer = (char *)calloc(KEY_VALUE_LIMIT + 1, 1);
+  if (!key_buffer || !value_buffer) {
+    free(key_buffer);
+    free(value_buffer);
+    return (otel_process_ctx_read_result){
+        .success = false,
+        .error_message = "Failed to allocate decode buffers (" __FILE__
+                         ":" ADD_QUOTES(__LINE__) ")",
+        .data = empty_data};
+  }
+
+  bool success = otel_process_ctx_decode_payload(
+      mapping->otel_process_payload, mapping->otel_process_payload_size, &data,
+      key_buffer, value_buffer);
+  free(key_buffer);
+  free(value_buffer);
+
+  if (!success) {
+    otel_process_ctx_read_data_drop(data);
+    return (otel_process_ctx_read_result){
+        .success = false,
+        .error_message =
+            "Failed to decode payload (" __FILE__ ":" ADD_QUOTES(__LINE__) ")",
+        .data = empty_data};
+  }
+
+  return (otel_process_ctx_read_result){
+      .success = true, .error_message = NULL, .data = data};
+}
+
+bool otel_process_ctx_read_drop(otel_process_ctx_read_result *result) {
+  if (!result || !result->success)
+    return false;
+  otel_process_ctx_read_data_drop(result->data);
+  *result = (otel_process_ctx_read_result){
+      .success = false, .error_message = "Data dropped", .data = empty_data};
+  return true;
+}
+#endif // OTEL_PROCESS_CTX_NO_READ
+
+#endif // OTEL_PROCESS_CTX_NOOP

--- a/procmeta/processcontext/integrationtests/testdata/otel_process_ctx.h
+++ b/procmeta/processcontext/integrationtests/testdata/otel_process_ctx.h
@@ -1,0 +1,178 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Source: https://github.com/open-telemetry/sig-profiling/blob/main/process-context/c-and-cpp/otel_process_ctx.h
+
+#pragma once
+
+#define OTEL_PROCESS_CTX_VERSION_MAJOR 0
+#define OTEL_PROCESS_CTX_VERSION_MINOR 1
+#define OTEL_PROCESS_CTX_VERSION_PATCH 0
+#define OTEL_PROCESS_CTX_VERSION_STRING "0.1.0"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/**
+ * # OpenTelemetry Process Context reference implementation
+ *
+ * `otel_process_ctx.h` and `otel_process_ctx.c` provide a reference
+ * implementation for the OpenTelemetry process-level context sharing
+ * specification.
+ * (https://github.com/open-telemetry/opentelemetry-specification/pull/4719/)
+ *
+ * This reference implementation is Linux-only, as the specification currently
+ * only covers Linux. On non-Linux OS's (or when OTEL_PROCESS_CTX_NOOP is
+ * defined) no-op versions of functions are supplied.
+ */
+
+/**
+ * Config for the experimental thread context sharing mechanism, see
+ * https://docs.google.com/document/d/1eatbHpEXXhWZEPrXZpfR58-5RIx-81mUgF69Zpn3Rz4/edit?tab=t.bmgoq3yor67o
+ * for usage details.
+ */
+typedef struct {
+  const char *schema_version;
+  // NULL-terminated array of attribute key strings to be used in thread
+  // context. Can be NULL if not needed.
+  const char **attribute_key_map;
+} otel_thread_ctx_config_data;
+
+/**
+ * Data that can be published as a process context.
+ *
+ * Every string MUST be valid for the duration of the call to
+ * `otel_process_ctx_publish`. Strings will be copied into the context.
+ *
+ * Strings MUST be:
+ * * Non-NULL
+ * * UTF-8 encoded
+ * * Not longer than INT16_MAX bytes
+ *
+ * Strings MAY be:
+ * * Empty
+ */
+typedef struct {
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-environment-name
+  const char *deployment_environment_name;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id
+  const char *service_instance_id;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name
+  const char *service_name;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-version
+  const char *service_version;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-language
+  const char *telemetry_sdk_language;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-version
+  const char *telemetry_sdk_version;
+  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-name
+  const char *telemetry_sdk_name;
+  // Additional key/value pairs as resource attributes
+  // https://opentelemetry.io/docs/specs/otel/resource/sdk/ Can be NULL if no
+  // resource attributes are needed; if non-NULL, this array MUST be terminated
+  // with a NULL entry. Every even entry is a key, every odd entry is a value
+  // (E.g. "key1", "value1", "key2", "value2", NULL).
+  const char **resource_attributes;
+  // Additional key/value pairs as extra attributes
+  // (ProcessContext.extra_attributes in process_context.proto) Can be NULL if
+  // no extra attributes are needed; if non-NULL, this array MUST be terminated
+  // with a NULL entry. Every even entry is a key, every odd entry is a value
+  // (E.g. "key1", "value1", "key2", "value2", NULL).
+  const char **extra_attributes;
+  // Experimental thread context sharing mechanism configuration. See struct
+  // definition for details. Can be NULL.
+  const otel_thread_ctx_config_data *thread_ctx_config;
+} otel_process_ctx_data;
+
+/** Number of entries in the `otel_process_ctx_data` struct. Can be used to
+ * easily detect when the struct is updated. */
+#define OTEL_PROCESS_CTX_DATA_ENTRIES                                          \
+  sizeof(otel_process_ctx_data) / sizeof(char *)
+
+typedef struct {
+  bool success;
+  const char
+      *error_message; // Static strings only, non-NULL if success is false
+} otel_process_ctx_result;
+
+/**
+ * Publishes a OpenTelemetry process context with the given data.
+ *
+ * The context should remain alive until the application exits (or is just about
+ * to exit). This method is NOT thread-safe.
+ *
+ * Calling `publish` multiple times is supported and will replace a previous
+ * context (only one is published at any given time). Calling `publish` multiple
+ * times usually happens when:
+ * * Some of the `otel_process_ctx_data` changes due to a live system
+ * reconfiguration for the same process
+ * * The process is forked (to provide a new `service_instance_id`)
+ *
+ * This API can be called in a fork of the process that published the previous
+ * context, even though the context is not carried over into forked processes
+ * (although part of its memory allocations are).
+ *
+ * @param data Pointer to the data to publish. This data is copied into the
+ * context and only needs to be valid for the duration of the call. Must not be
+ * `NULL`.
+ * @return The result of the operation.
+ */
+otel_process_ctx_result
+otel_process_ctx_publish(const otel_process_ctx_data *data);
+
+/**
+ * Drops the current OpenTelemetry process context, if any.
+ *
+ * This method is safe to call even there's no current context.
+ * This method is NOT thread-safe.
+ *
+ * This API can be called in a fork of the process that published the current
+ * context to clean memory allocations related to the parent's context (even
+ * though the context itself is not carried over into forked processes).
+ *
+ * @return `true` if the context was successfully dropped or no context existed,
+ * `false` otherwise.
+ */
+bool otel_process_ctx_drop_current(void);
+
+/** This can be disabled if no read support is required. */
+#ifndef OTEL_PROCESS_CTX_NO_READ
+typedef struct {
+  bool success;
+  const char
+      *error_message; // Static strings only, non-NULL if success is false
+  otel_process_ctx_data data; // Strings are allocated using `malloc` and the
+                              // caller is responsible for `free`ing them
+} otel_process_ctx_read_result;
+
+/**
+ * Reads the current OpenTelemetry process context, if any.
+ *
+ * Useful for debugging and testing purposes. Underlying returned strings in
+ * `data` are dynamically allocated using `malloc` and
+ * `otel_process_ctx_read_drop` must be called to free them.
+ *
+ * Thread-safety: This function assumes there is no concurrent mutation of the
+ * process context.
+ *
+ * @return The result of the operation. If successful, `data` contains the
+ * retrieved context data.
+ */
+otel_process_ctx_read_result otel_process_ctx_read(void);
+
+/**
+ * Drops the data resulting from a previous call to `otel_process_ctx_read`.
+ *
+ * @param result The result of a previous call to `otel_process_ctx_read`. Must
+ * not be `NULL`.
+ * @return `true` if the data was successfully dropped, `false` otherwise.
+ */
+bool otel_process_ctx_read_drop(otel_process_ctx_read_result *result);
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/procmeta/processcontext/integrationtests/testdata/processctx.c
+++ b/procmeta/processcontext/integrationtests/testdata/processctx.c
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "processctx_lib.h"
+
+#ifdef USE_DLOPEN
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef int (*init_process_context_t)(void);
+typedef void (*init_thread_context_t)(size_t);
+typedef void (*update_thread_context_t)(uint64_t, uint64_t, uint64_t,
+                                        attribute_t *, size_t);
+typedef void (*burn_t)(int);
+
+init_process_context_t init_process_context;
+init_thread_context_t init_thread_context;
+update_thread_context_t update_thread_context;
+burn_t burn;
+
+static int load_lib(const char *libname) {
+  void *handle = dlopen(libname, RTLD_NOW);
+  if (!handle) {
+    fprintf(stderr, "dlopen failed: %s\n", dlerror());
+    return 1;
+  }
+
+  init_process_context = dlsym(handle, "init_process_context");
+  if (!init_process_context) {
+    fprintf(stderr, "dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+
+  init_thread_context = dlsym(handle, "init_thread_context");
+  if (!init_thread_context) {
+    fprintf(stderr, "dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+
+  update_thread_context = dlsym(handle, "update_thread_context");
+  if (!update_thread_context) {
+    fprintf(stderr, "dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+
+  burn = dlsym(handle, "burn");
+  if (!burn) {
+    fprintf(stderr, "dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+
+  return 0;
+}
+#endif
+
+static atomic_bool running = true;
+
+void handle_sigterm(int sig) {
+  (void)sig;
+  running = false;
+}
+
+int main(int argc, char *argv[]) {
+#ifdef USE_DLOPEN
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <path-to-test_tls_lib.so>\n", argv[0]);
+    return 1;
+  }
+  if (load_lib(argv[1])) {
+    fprintf(stderr, "Failed to load library\n");
+    return 1;
+  }
+#endif
+
+  signal(SIGTERM, handle_sigterm);
+
+  // OTEL_PROCESS_CTX_PUBLISH_DELAY_MS lets the test exercise the prctl monitor
+  // path: the profiler discovers the PID first, then the publish prctl fires
+  // and triggers a resync. We burn CPU rather than sleep so the process stays
+  // on-CPU and is sampled by the profiler's perf event, which drives process
+  // synchronization before the context is published.
+  const char *delay_str = getenv("OTEL_PROCESS_CTX_PUBLISH_DELAY_MS");
+  if (delay_str != NULL) {
+    int delay_ms = atoi(delay_str);
+    if (delay_ms > 0) {
+      burn(delay_ms);
+    }
+  }
+
+  if (init_process_context()) {
+    fprintf(stderr, "Failed to initialize process context\n");
+    return 1;
+  }
+  init_thread_context(128);
+
+  const uint64_t trace_id_lo = 0x1234567890abcdef;
+  const uint64_t trace_id_hi = 0xfedcba9876543210;
+  const uint64_t span_id = 0x1234;
+
+  attribute_t attrs[] = {
+      {2, "some_user_id"},
+      {1, "GET"},
+      {0, "some_endpoint"},
+  };
+
+  // Burn CPU so the profiler can sample us.
+  while (running) {
+    update_thread_context(span_id, trace_id_lo, trace_id_hi, attrs,
+                          sizeof(attrs) / sizeof(attrs[0]));
+    burn(10);
+  }
+
+  return 0;
+}

--- a/procmeta/processcontext/integrationtests/testdata/processctx_lib.c
+++ b/procmeta/processcontext/integrationtests/testdata/processctx_lib.c
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared library that defines a TLS variable. When loaded via dlopen(),
+// this uses dynamic TLS (global-dynamic / TLS descriptor model), testing
+// the dynamic TLS path in the threadcontext interpreter.
+
+#include "processctx_lib.h"
+
+#include "otel_process_ctx.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+// The TLS variable that the threadcontext interpreter looks up.
+// In a shared library, this will use the global-dynamic TLS model.
+__thread otel_thread_ctx_v1_t *otel_thread_ctx_v1;
+
+int init_process_context(void) {
+  const char *attribute_key_map[] = {"http_route", "http_method", "user_id",
+                                     NULL};
+  const otel_thread_ctx_config_data thread_ctx_config = {
+      .schema_version = "tlsdesc_v1_dev",
+      .attribute_key_map = attribute_key_map,
+  };
+  const char *resource_attributes[] = {"resource.key1", "resource.value1",
+                                       "resource.key2", "resource.value2",
+                                       NULL};
+  const char *extra_attributes[] = {"example_extra_attribute_foo",
+                                    "example_extra_attribute_foo_value", NULL};
+
+  otel_process_ctx_data data = {
+      .deployment_environment_name = "prod",
+      .service_instance_id = "123d8444-2c7e-46e3-89f6-6217880f7123",
+      .service_name = "my-service",
+      .service_version = "4.5.6",
+      .telemetry_sdk_language = "c",
+      .telemetry_sdk_version = "1.2.3",
+      .telemetry_sdk_name = "example_ctx.c",
+      .resource_attributes = resource_attributes,
+      .extra_attributes = extra_attributes,
+      .thread_ctx_config = &thread_ctx_config,
+  };
+
+  otel_process_ctx_result res = otel_process_ctx_publish(&data);
+  if (!res.success) {
+    fprintf(stderr, "Failed to publish: %s\n", res.error_message);
+    return 1;
+  }
+  return 0;
+}
+
+void init_thread_context(size_t attrs_data_size) {
+  otel_thread_ctx_v1 =
+      malloc(sizeof(otel_thread_ctx_v1_t) + attrs_data_size);
+  if (otel_thread_ctx_v1 == NULL) {
+    perror("malloc");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void update_thread_context(uint64_t span_id, uint64_t trace_id_lo,
+                           uint64_t trace_id_hi, attribute_t *attrs,
+                           size_t attrs_count) {
+  otel_thread_ctx_v1->valid = 0;
+
+  memcpy(otel_thread_ctx_v1->trace_id, &trace_id_lo,
+         sizeof(trace_id_lo));
+  memcpy(otel_thread_ctx_v1->trace_id + sizeof(trace_id_lo),
+         &trace_id_hi, sizeof(trace_id_hi));
+  memcpy(otel_thread_ctx_v1->span_id, &span_id, sizeof(span_id));
+
+  size_t attr_pos = 0;
+  for (size_t i = 0; i < attrs_count; ++i) {
+    otel_thread_ctx_v1->attrs_data[attr_pos++] = attrs[i].key_index;
+    size_t value_length = strlen(attrs[i].value);
+    otel_thread_ctx_v1->attrs_data[attr_pos++] = value_length;
+    memcpy(otel_thread_ctx_v1->attrs_data + attr_pos, attrs[i].value,
+           value_length);
+    attr_pos += value_length;
+  }
+
+  otel_thread_ctx_v1->attrs_data_size = attr_pos;
+  otel_thread_ctx_v1->valid = 1;
+}
+
+void burn(int ms) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  uint64_t start_time = ts.tv_sec * 1000000000 + ts.tv_nsec;
+  while (1) {
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t current_time = ts.tv_sec * 1000000000 + ts.tv_nsec;
+    if (current_time - start_time > ms * 1000000) {
+      break;
+    }
+  }
+}

--- a/procmeta/processcontext/integrationtests/testdata/processctx_lib.h
+++ b/procmeta/processcontext/integrationtests/testdata/processctx_lib.h
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct __attribute__((packed)) {
+  // W3C trace context fields
+  uint8_t trace_id[16];
+  uint8_t span_id[8];
+
+  // Readers should ignore this record if valid is 0
+  uint8_t valid;
+
+  // Explicit padding for alignment of attrs_data_size
+  uint8_t _padding;
+
+  // Size of attrs_data in bytes (lets reader know when to stop parsing)
+  uint16_t attrs_data_size;
+
+  // Attribute data; each attr is [key_index:1][length:1][value:length]
+  // This is stored without padding to a constant length (like the key table)
+  // so that we squeeze as much data as we can into each context update.
+  uint8_t attrs_data[];
+} otel_thread_ctx_v1_t;
+
+typedef struct {
+  uint8_t key_index;
+  const char *value;
+} attribute_t;
+
+#ifndef USE_DLOPEN
+int init_process_context(void);
+void init_thread_context(size_t attrs_data_size);
+void update_thread_context(uint64_t span_id, uint64_t trace_id_lo,
+                           uint64_t trace_id_hi, attribute_t *attrs,
+                           size_t attrs_count);
+void burn(int ms);
+#endif

--- a/procmeta/processcontext/processcontext.go
+++ b/procmeta/processcontext/processcontext.go
@@ -1,7 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package processcontext // import "go.opentelemetry.io/ebpf-profiler/processcontext"
+// Package processcontext implements the OpenTelemetry Process Context sharing
+// protocol for reading resource attributes from an external process.
+//
+// See [OTEP 4719].
+//
+// [OTEP 4719]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4719-process-ctx.md
+package processcontext // import "go.opentelemetry.io/ebpf-profiler/procmeta/processcontext"
 
 import (
 	"encoding/binary"
@@ -10,12 +16,15 @@ import (
 	"structs"
 	"unsafe"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	processcontextpb "go.opentelemetry.io/proto/otlp/processcontext/v1development"
 	"google.golang.org/protobuf/proto"
 
+	"go.opentelemetry.io/ebpf-profiler/internal/log"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
-	processcontextpb "go.opentelemetry.io/proto/otlp/processcontext/v1development"
 )
 
 const (
@@ -60,9 +69,17 @@ var (
 	ErrNoUpdate = errors.New("ProcessContext has not been updated")
 )
 
+// Info is a snapshot of process context. The pointed-to Resource and
+// ExtraAttributes are shared by pointer across goroutines (process-manager
+// writer, reporter) without locking; once an Info is published they
+// MUST be treated as read-only by all holders.
 type Info struct {
-	Context       *processcontextpb.ProcessContext
-	PublishedAtNs uint64
+	Resource *pcommon.Resource
+	// ExtraAttributes holds the attributes a process publishes outside its resource.
+	// Decoded, but contributed nowhere yet: sample or resource scope is deliberately
+	// still open, so the enricher returns Resource alone.
+	ExtraAttributes *pcommon.Map
+	PublishedAtNs   uint64
 }
 
 // header represents the 32-byte memory region header per OTEP #4719.
@@ -145,6 +162,45 @@ func readOnce(mappingAddr libpf.Address, rm remotememory.RemoteMemory, lastPubli
 	return ctx, nil
 }
 
+// Resolve reads the process context a process publishes in its context region,
+// returning (info, true) when the contribution changed and (_, false) to leave the
+// published one untouched.
+//
+// mappingAddr=0 means the region was not observed this sync; with
+// oldPublishedAtNs > 0 it disappeared, and the contribution is withdrawn.
+//
+// An exec needs no handling here: the caller drops oldPublishedAtNs with the
+// contribution, so a region republished at a lower timestamp is read afresh.
+func Resolve(
+	mappingAddr uint64, pid libpf.PID, rm remotememory.RemoteMemory,
+	oldPublishedAtNs uint64,
+) (Info, bool) {
+	if mappingAddr == 0 {
+		// Withdraw a context whose region is gone; otherwise this process simply does
+		// not publish one.
+		return Info{}, oldPublishedAtNs != 0
+	}
+
+	// Workaround for a CodeQL warning about uint64 -> uintptr (libpf.Address) overflow.
+	addr := libpf.Address(mappingAddr & uint64(^libpf.Address(0)))
+
+	processCtx, err := Read(addr, rm, oldPublishedAtNs, 0)
+	switch {
+	case err == nil:
+		// New process context read successfully, publish it.
+		return processCtx, true
+	case errors.Is(err, ErrNoUpdate), errors.Is(err, ErrConcurrentUpdate):
+		// Payload unchanged, or a writer was mid-update: keep what was published
+		// before, which is nothing at all on the round following an exec.
+		return Info{}, false
+	default:
+		log.Debugf("Failed to read ProcessContext for PID %d: %v", pid, err)
+	}
+
+	// The payload could not be read: withdraw rather than keep a stale context.
+	return Info{}, true
+}
+
 func IsContextMapping(isExecutable bool, mappingPath string) bool {
 	return !isExecutable && (mappingPath == ContextMappingMemfd ||
 		mappingPath == ContextMappingMemfdDeleted ||
@@ -200,11 +256,76 @@ func readPayload(rm remotememory.RemoteMemory, hdr header) (Info, error) {
 		return Info{}, fmt.Errorf("failed to unmarshal ProcessContext: %w", err)
 	}
 
-	return Info{Context: ctx, PublishedAtNs: hdr.MonotonicPublishedAtNs}, nil
+	var resource *pcommon.Resource
+	if ctx.Resource != nil {
+		r := pcommon.NewResource()
+		for _, attr := range ctx.Resource.Attributes {
+			if v, ok := convertAnyValue(attr.Value); ok {
+				v.MoveTo(r.Attributes().PutEmpty(attr.Key))
+			}
+		}
+		resource = &r
+	}
+
+	var extraAttributes *pcommon.Map
+	if ctx.Attributes != nil {
+		m := pcommon.NewMap()
+		for _, attr := range ctx.Attributes {
+			if v, ok := convertAnyValue(attr.Value); ok {
+				v.MoveTo(m.PutEmpty(attr.Key))
+			}
+		}
+		extraAttributes = &m
+	}
+	return Info{Resource: resource, ExtraAttributes: extraAttributes, PublishedAtNs: hdr.MonotonicPublishedAtNs}, nil
 }
 
-func (p *Info) ClearAttributes() {
-	if p.Context != nil {
-		p.Context.Attributes = nil
+// convertAnyValue converts a commonpb.AnyValue to a pcommon.Value, including nested
+// maps and arrays. Returns (_, false) for nil inputs and unknown variants, so
+// callers skip them rather than emit phantom empty entries.
+func convertAnyValue(src *commonpb.AnyValue) (pcommon.Value, bool) {
+	if src == nil {
+		return pcommon.Value{}, false
+	}
+	switch v := src.Value.(type) {
+	case *commonpb.AnyValue_StringValue:
+		return pcommon.NewValueStr(v.StringValue), true
+	case *commonpb.AnyValue_BoolValue:
+		return pcommon.NewValueBool(v.BoolValue), true
+	case *commonpb.AnyValue_IntValue:
+		return pcommon.NewValueInt(v.IntValue), true
+	case *commonpb.AnyValue_DoubleValue:
+		return pcommon.NewValueDouble(v.DoubleValue), true
+	case *commonpb.AnyValue_BytesValue:
+		val := pcommon.NewValueBytes()
+		val.Bytes().FromRaw(v.BytesValue)
+		return val, true
+	case *commonpb.AnyValue_ArrayValue:
+		val := pcommon.NewValueSlice()
+		if v.ArrayValue != nil {
+			sl := val.Slice()
+			sl.EnsureCapacity(len(v.ArrayValue.Values))
+			for _, item := range v.ArrayValue.Values {
+				if itemVal, ok := convertAnyValue(item); ok {
+					itemVal.MoveTo(sl.AppendEmpty())
+				}
+			}
+		}
+		return val, true
+	case *commonpb.AnyValue_KvlistValue:
+		val := pcommon.NewValueMap()
+		if v.KvlistValue != nil {
+			m := val.Map()
+			m.EnsureCapacity(len(v.KvlistValue.Values))
+			for _, kv := range v.KvlistValue.Values {
+				if kvVal, ok := convertAnyValue(kv.Value); ok {
+					kvVal.MoveTo(m.PutEmpty(kv.Key))
+				}
+			}
+		}
+		return val, true
+	default:
+		log.Debugf("convertAnyValue: unknown AnyValue variant %T, skipping", v)
+		return pcommon.Value{}, false
 	}
 }

--- a/procmeta/processcontext/processcontext_test.go
+++ b/procmeta/processcontext/processcontext_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build amd64 || arm64
+//go:build linux && (amd64 || arm64)
 
 package processcontext_test
 
@@ -15,12 +15,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/process"
-	"go.opentelemetry.io/ebpf-profiler/processcontext"
+	"go.opentelemetry.io/ebpf-profiler/procmeta/processcontext"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	processcontextpb "go.opentelemetry.io/proto/otlp/processcontext/v1development"
@@ -41,6 +42,70 @@ var testContext = processcontextpb.ProcessContext{
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{
 						StringValue: "test-service",
+					},
+				},
+			},
+			{
+				Key: "service.version",
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_IntValue{
+						IntValue: 42,
+					},
+				},
+			},
+			{
+				Key: "service.active",
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_BoolValue{
+						BoolValue: true,
+					},
+				},
+			},
+			{
+				Key: "service.weight",
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_DoubleValue{
+						DoubleValue: 3.14,
+					},
+				},
+			},
+			{
+				Key: "service.tags",
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_ArrayValue{
+						ArrayValue: &commonpb.ArrayValue{
+							Values: []*commonpb.AnyValue{
+								{Value: &commonpb.AnyValue_StringValue{StringValue: "tag1"}},
+								{Value: &commonpb.AnyValue_IntValue{IntValue: 2}},
+							},
+						},
+					},
+				},
+			},
+			{
+				Key: "service.metadata",
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_KvlistValue{
+						KvlistValue: &commonpb.KeyValueList{
+							Values: []*commonpb.KeyValue{
+								{
+									Key: "nested.key",
+									Value: &commonpb.AnyValue{
+										Value: &commonpb.AnyValue_StringValue{
+											StringValue: "nested-value",
+										},
+									},
+								},
+								{
+									Key: "nested.count",
+									Value: &commonpb.AnyValue{
+										Value: &commonpb.AnyValue_IntValue{
+											IntValue: 7,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -146,7 +211,11 @@ func TestProcessContext_Read(t *testing.T) {
 				mock.writeAt(headerAddr, header)
 				mock.writeAt(payloadAddr, payload)
 			},
-			expectedResult: processcontext.Info{Context: &testContext, PublishedAtNs: 123456789},
+			expectedResult: processcontext.Info{
+				Resource:        expectedResource(),
+				ExtraAttributes: expectedExtraAttributes(),
+				PublishedAtNs:   123456789,
+			},
 		},
 		{
 			name: "read error",
@@ -254,7 +323,8 @@ func TestProcessContext_Read(t *testing.T) {
 				require.NotNil(t, ctx)
 				require.EqualExportedValues(t, &tt.expectedResult, &ctx)
 			} else {
-				assert.Nil(t, ctx.Context)
+				assert.Nil(t, ctx.Resource)
+				assert.Nil(t, ctx.ExtraAttributes)
 				assert.Zero(t, ctx.PublishedAtNs)
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, tt.expectedErr)
@@ -366,9 +436,37 @@ func TestProcessContext_Read_RealProcessContext(t *testing.T) {
 			result, err := processcontext.Read(libpf.Address(contextMappingAddr), proc.GetRemoteMemory(), 0, 0)
 			require.NoError(t, err)
 			require.EqualExportedValues(t,
-				processcontext.Info{Context: &testContext, PublishedAtNs: 123456789},
+				processcontext.Info{
+					Resource:        expectedResource(),
+					ExtraAttributes: expectedExtraAttributes(),
+					PublishedAtNs:   123456789,
+				},
 				result)
 
 		})
 	}
+}
+
+func expectedResource() *pcommon.Resource {
+	r := pcommon.NewResource()
+	r.Attributes().PutStr("service.name", "test-service")
+	r.Attributes().PutInt("service.version", 42)
+	r.Attributes().PutBool("service.active", true)
+	r.Attributes().PutDouble("service.weight", 3.14)
+
+	tags := r.Attributes().PutEmptySlice("service.tags")
+	tags.AppendEmpty().SetStr("tag1")
+	tags.AppendEmpty().SetInt(2)
+
+	metadata := r.Attributes().PutEmptyMap("service.metadata")
+	metadata.PutStr("nested.key", "nested-value")
+	metadata.PutInt("nested.count", 7)
+
+	return &r
+}
+
+func expectedExtraAttributes() *pcommon.Map {
+	m := pcommon.NewMap()
+	m.PutStr("custom.attribute", "custom-value")
+	return &m
 }

--- a/procmeta/procmeta.go
+++ b/procmeta/procmeta.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package procmeta provides the extension point for contributing OTel resource
+// attributes to a profiled process.
+//
+// It complements process.MetaEnricher, which collects metadata once when a process
+// is first observed. Attributes that resolve later — a memory region published
+// after startup, a runtime whose interpreter attaches once its mapping appears —
+// need a ResourceEnricher, called on every resynchronization, contributing an
+// immutable resource rather than writing to shared metadata.
+package procmeta // import "go.opentelemetry.io/ebpf-profiler/procmeta"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/util"
+)
+
+// ResourceConfig declares what a ResourceEnricher needs. The zero value asks for
+// nothing; new requirements are added as new fields.
+type ResourceConfig struct {
+	// WantMapping selects the mappings delivered in ResourceRequest.Mappings, nil
+	// selecting none. Called for every mapping of every synchronized process, so it
+	// must be cheap: no allocation, no syscalls.
+	WantMapping func(m *process.RawMapping) bool
+}
+
+// ResourceRequest describes a process and what the process manager observed for it
+// this synchronization. Valid only for the duration of the EnrichResource call:
+// enrichers must not retain it, or anything reachable from it.
+type ResourceRequest struct {
+	// Process gives access to remote memory, mappings and the executable.
+	Process process.Process
+
+	// Mappings holds the mappings selected by ResourceConfig.WantMapping, in
+	// /proc/<pid>/maps order.
+	Mappings []process.RawMapping
+
+	// Interpreters holds the instances attached to the process, keyed by the on-disk
+	// identity of the DSO each was detected in, and is nil until one attaches.
+	// Read-only: driving the instances belongs to the process manager.
+	Interpreters map[util.OnDiskFileIdentifier]interpreter.Instance
+
+	// State points at the manager's per-process storage slot for this enricher:
+	// *State is what the previous call stored, nil on the first. Keep per-process
+	// state here rather than in enricher-owned maps, so it is dropped with the
+	// process. Storage, not a lifecycle — the value is dropped with no teardown
+	// call, so it must not own anything needing an explicit release.
+	State *any
+}
+
+// ResourceEnricher contributes OTel resource attributes for a process.
+type ResourceEnricher interface {
+	// ResourceConfig returns the enricher's requirements. It is called once, when
+	// the enricher is registered.
+	ResourceConfig() ResourceConfig
+
+	// EnrichResource returns the enricher's contribution for the process described
+	// by req, freshly built and treated as immutable by the caller, which retains it
+	// across synchronizations.
+	//
+	// changed reports whether it differs from the previous call's: false keeps the
+	// stored contribution and ignores res, (nil, true) withdraws it. Withdrawing a
+	// process's last contribution takes effect at the next reporting period, since
+	// samples already collected keep the attribution they were collected with.
+	//
+	// A first call, and the one after an exec, arrive with State and the stored
+	// contribution already dropped, so an execed process needs no special handling:
+	// it looks exactly like one never seen before.
+	EnrichResource(req *ResourceRequest) (res *pcommon.Resource, changed bool)
+}
+
+// MergeResources combines a base resource with enricher contributions, applied in
+// order, so a contribution wins over the base and a later one over an earlier one
+// on key collisions. Any input may be nil.
+//
+// Returns nil if all are nil, and shares a single non-nil input as-is: inputs are
+// immutable, so copying is unnecessary.
+func MergeResources(base *pcommon.Resource,
+	contributions []*pcommon.Resource,
+) *pcommon.Resource {
+	count, single := 0, base
+	if base != nil {
+		count = 1
+	}
+	for _, c := range contributions {
+		if c != nil {
+			count++
+			single = c
+		}
+	}
+	if count <= 1 {
+		return single
+	}
+
+	merged := pcommon.NewResource()
+	attrs := merged.Attributes()
+	add := func(r *pcommon.Resource) {
+		if r == nil {
+			return
+		}
+		r.Attributes().Range(func(k string, v pcommon.Value) bool {
+			v.CopyTo(attrs.PutEmpty(k))
+			return true
+		})
+	}
+	add(base)
+	for _, c := range contributions {
+		add(c)
+	}
+	return &merged
+}

--- a/procmeta/procmeta_test.go
+++ b/procmeta/procmeta_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// resourceWith builds a resource from string attributes.
+func resourceWith(attrs map[string]string) *pcommon.Resource {
+	r := pcommon.NewResource()
+	for k, v := range attrs {
+		r.Attributes().PutStr(k, v)
+	}
+	return &r
+}
+
+func TestMergeResources(t *testing.T) {
+	tests := map[string]struct {
+		base          *pcommon.Resource
+		contributions []*pcommon.Resource
+		expected      map[string]string
+		expectNil     bool
+	}{
+		"no contributions": {
+			contributions: nil,
+			expectNil:     true,
+		},
+		"all nil": {
+			contributions: []*pcommon.Resource{nil, nil},
+			expectNil:     true,
+		},
+		"base only": {
+			base:     resourceWith(map[string]string{"a": "1"}),
+			expected: map[string]string{"a": "1"},
+		},
+		"contribution wins over base": {
+			base: resourceWith(map[string]string{"a": "from-base", "c": "3"}),
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "contributed"}),
+			},
+			expected: map[string]string{"a": "contributed", "c": "3"},
+		},
+		"single contribution": {
+			contributions: []*pcommon.Resource{nil, resourceWith(map[string]string{"a": "1"})},
+			expected:      map[string]string{"a": "1"},
+		},
+		"disjoint keys": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "1"}),
+				resourceWith(map[string]string{"b": "2"}),
+			},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		"later contribution wins on collision": {
+			contributions: []*pcommon.Resource{
+				resourceWith(map[string]string{"a": "first", "b": "2"}),
+				resourceWith(map[string]string{"a": "second"}),
+			},
+			expected: map[string]string{"a": "second", "b": "2"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			merged := MergeResources(test.base, test.contributions)
+			if test.expectNil {
+				require.Nil(t, merged)
+				return
+			}
+			require.NotNil(t, merged)
+
+			got := make(map[string]string, merged.Attributes().Len())
+			merged.Attributes().Range(func(k string, v pcommon.Value) bool {
+				got[k] = v.Str()
+				return true
+			})
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+// TestMergeResourcesDoesNotModifyContributions verifies that merging leaves the
+// inputs untouched: the process manager retains them across synchronizations and
+// re-merges them, so a merge that mutated them would corrupt later merges.
+func TestMergeResourcesDoesNotModifyContributions(t *testing.T) {
+	first := resourceWith(map[string]string{"a": "first"})
+	second := resourceWith(map[string]string{"a": "second"})
+
+	merged := MergeResources(first, []*pcommon.Resource{second})
+	require.NotNil(t, merged)
+
+	v, ok := merged.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+
+	v, ok = first.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "first", v.Str())
+	v, ok = second.Attributes().Get("a")
+	require.True(t, ok)
+	require.Equal(t, "second", v.Str())
+}
+
+// TestMergeResourcesSharesSingleContribution documents that a lone contribution
+// is returned as-is rather than copied. Contributions are immutable, so sharing
+// is safe and avoids an allocation on the common single-enricher path.
+func TestMergeResourcesSharesSingleContribution(t *testing.T) {
+	only := resourceWith(map[string]string{"a": "1"})
+	require.Same(t, only, MergeResources(nil, []*pcommon.Resource{nil, only, nil}))
+	// Likewise a base with no contribution to merge onto it.
+	require.Same(t, only, MergeResources(only, nil))
+}

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -75,6 +75,14 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	rtp := (*eventsTree)[key]
+	// Refresh so a resource resolved late applies to the samples already collected
+	// for this PID this period. Only non-nil overwrites, so a process whose
+	// attributes become unreadable keeps what it had; the next period starts from an
+	// empty tree, which is where a withdrawal takes effect.
+	if meta.Resource != nil && meta.Resource != rtp.Resource {
+		rtp.Resource = meta.Resource
+		(*eventsTree)[key] = rtp
+	}
 	if _, exists := rtp.Events[meta.ProfileType]; !exists {
 		rtp.Events[meta.ProfileType] = make(samples.SampleToEvents)
 	}

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -175,6 +176,69 @@ func TestBaseReporterGenerate(t *testing.T) {
 	// Verify profiles exist
 	assert.Greater(t, scopeProfile.Profiles().Len(), 0,
 		"Should have at least one profile")
+}
+
+// TestReportTraceEventLateResourceAppliesRetroactively verifies that a context
+// published after sampling started applies to that PID's earlier samples: one
+// bucket, the late resource applied, and a later nil not stripping it.
+func TestReportTraceEventLateResourceAppliesRetroactively(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+
+	makeResource := func(name string) *pcommon.Resource {
+		r := pcommon.NewResource()
+		r.Attributes().PutStr("service.name", name)
+		return &r
+	}
+
+	trace := &libpf.Trace{
+		Frames: func() libpf.Frames {
+			frames := make(libpf.Frames, 0, 1)
+			frames.Append(&libpf.Frame{
+				Type:            libpf.NativeFrame,
+				AddressOrLineno: 0x100,
+				FunctionName:    libpf.Intern("f"),
+			})
+			return frames
+		}(),
+	}
+
+	now := libpf.UnixTime64(time.Now().UnixNano())
+	baseMeta := func(resource *pcommon.Resource) *samples.TraceEventMeta {
+		return &samples.TraceEventMeta{
+			Timestamp:      now,
+			Comm:           libpf.NewCommFromString("svc"),
+			ExecutablePath: libpf.Intern("/usr/bin/svc"),
+			ContainerID:    libpf.Intern("c1"),
+			PID:            1234,
+			TID:            1235,
+			ProfileType:    profileTypeSampling,
+			Resource:       resource,
+		}
+	}
+
+	// Samples collected before the process context is detected.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	// The context is published and detected: later samples carry the resource.
+	resource := makeResource("svc")
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(resource)))
+
+	// Process tears down and the context mapping disappears.
+	require.NoError(t, reporter.ReportTraceEvent(trace, baseMeta(nil)))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	tree := *treePtr
+
+	require.Len(t, tree, 1, "all samples for one PID belong to a single bucket")
+	for _, rtp := range tree {
+		require.NotNil(t, rtp.Resource,
+			"late-detected resource should apply to the whole period")
+		serviceName, ok := rtp.Resource.Attributes().Get("service.name")
+		require.True(t, ok)
+		assert.Equal(t, "svc", serviceName.Str())
+	}
 }
 
 // processNameAttrProducer is a test SampleAttrProducer that reads "process.name" from

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -103,7 +103,7 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 		}
 
 		rp := profiles.ResourceProfiles().AppendEmpty()
-		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars)
+		setResourceAttributes(rp.Resource().Attributes(), resource, toEvents.EnvVars, toEvents.Resource)
 		rp.SetSchemaUrl(semconv.SchemaURL)
 
 		sp := rp.ScopeProfiles().AppendEmpty()
@@ -303,7 +303,10 @@ func (p *Pdata) setProfile(
 	return nil
 }
 
-func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String) {
+func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envVars map[libpf.String]libpf.String, res *pcommon.Resource) {
+	if res != nil {
+		res.Attributes().CopyTo(attrs)
+	}
 	if resource.APMServiceName != "" {
 		attrs.PutStr(string(semconv.ServiceNameKey), resource.APMServiceName)
 	}

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -866,3 +866,84 @@ func TestGenerate_Validate(t *testing.T) {
 		CheckSampleTimestampShape: true}).Check(&data)
 	require.NoError(t, err)
 }
+
+func singleEventTree(rk samples.ResourceKey, res *pcommon.Resource) samples.TraceEventsTree {
+	filePath := libpf.Intern("/bin/svc")
+	mapping := libpf.NewFrameMapping(libpf.FrameMappingData{
+		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+			FileID:   libpf.NewFileID(7, 8),
+			FileName: filePath,
+		}),
+	})
+	return samples.TraceEventsTree{
+		rk: samples.ResourceToProfiles{
+			Resource: res,
+			Events: map[*samples.TypeMetadata]samples.SampleToEvents{
+				profileTypeSampling: {
+					{}: &samples.TraceEvents{
+						Frames:     singleFrameTrace(libpf.NativeFrame, mapping, 0x10, "f", filePath, 1),
+						Timestamps: []uint64{uint64(time.Unix(1010, 0).UnixNano())},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGenerate_Resource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	res := pcommon.NewResource()
+	res.Attributes().PutStr("service.namespace", "team-a")
+	res.Attributes().PutStr("service.instance.id", "instance-42")
+	res.Attributes().PutStr("deployment.environment", "prod")
+	res.Attributes().PutInt("not-a-string", 7)
+	res.Attributes().PutStr(string(semconv.ServiceNameKey), "proto-svc")
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            42,
+	}, &res)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		"service.namespace":                      "team-a",
+		"service.instance.id":                    "instance-42",
+		"deployment.environment":                 "prod",
+		"not-a-string":                           int64(7),
+		string(semconv.ServiceNameKey):           "proto-svc",
+		string(semconv.ProcessPIDKey):            int64(42),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}
+
+func TestGenerate_NilResource(t *testing.T) {
+	d, err := New(100, nil)
+	require.NoError(t, err)
+
+	tree := singleEventTree(samples.ResourceKey{
+		ExecutablePath: libpf.Intern("/bin/svc"),
+		PID:            99,
+		APMServiceName: "apm-svc",
+	}, nil)
+
+	profiles, err := testGenerate(d, tree, "agent", "v1")
+	require.NoError(t, err)
+	require.Equal(t, 1, profiles.ResourceProfiles().Len())
+	attrs := profiles.ResourceProfiles().At(0).Resource().Attributes()
+
+	expected := map[string]any{
+		string(semconv.ServiceNameKey):           "apm-svc",
+		string(semconv.ProcessPIDKey):            int64(99),
+		string(semconv.ProcessExecutablePathKey): "/bin/svc",
+		string(semconv.ProcessExecutableNameKey): "svc",
+	}
+	assert.Equal(t, expected, attrs.AsRaw())
+}

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -4,6 +4,7 @@
 package samples // import "go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
@@ -17,6 +18,7 @@ type TraceEventMeta struct {
 	// SampleAttrProducer.CollectExtraSampleMeta to attach process-level attributes.
 	ExtraMeta      map[libpf.String]string
 	APMServiceName string
+	Resource       *pcommon.Resource
 	Timestamp      libpf.UnixTime64
 	CPU            uint32
 	ProfileType    *TypeMetadata
@@ -44,6 +46,11 @@ type ResourceToProfiles struct {
 	// EnvVars can not be part of ResourceKey as maps are not
 	// comparable.
 	EnvVars map[libpf.String]libpf.String
+
+	// Resource holds the OTel resource attributed to the process, if any.
+	// Deliberately not part of ResourceKey: refreshing it as samples arrive lets
+	// a resource resolved late apply to the whole reporting period.
+	Resource *pcommon.Resource
 
 	// Events holds the actual profiling information.
 	Events map[*TypeMetadata]SampleToEvents

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter/interpreterconfig"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/procmeta"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 
 	"go.opentelemetry.io/ebpf-profiler/kallsyms"
@@ -211,6 +212,10 @@ type Config struct {
 	// ProcessMetaEnrichers are optional hooks for enriching process metadata at
 	// process discovery time. Multiple enrichers are called in order.
 	ProcessMetaEnrichers []process.MetaEnricher
+	// ResourceEnrichers are optional hooks for contributing OTel resource
+	// attributes to a process, called on every process synchronization.
+	// Multiple enrichers are called in order.
+	ResourceEnrichers []procmeta.ResourceEnricher
 	// PIDNamespaceTranslation toggles translation of host-level PIDs/TGIDs into
 	// their container-namespace equivalents. Useful for sidecar deployments where
 	// the profiler and the target application share a PID namespace but not host PIDs.
@@ -298,6 +303,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		FilterErrorFrames:     cfg.FilterErrorFrames,
 		IncludeEnvVars:        cfg.IncludeEnvVars,
 		ProcessMetaEnrichers:  cfg.ProcessMetaEnrichers,
+		ResourceEnrichers:     cfg.ResourceEnrichers,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)


### PR DESCRIPTION
The `OTEL_CTX` region a process publishes is read into `process.Meta.ProcessContextInfo`
(`processmanager/processinfo.go:803`), which nothing consumes, so the resource attributes an
application shares about itself never reach a profile. This propagates them, as a
`procmeta.ResourceEnricher`.

Also derives a base resource from `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, merged under
what the region published, so a process that publishes nothing at runtime is still attributed.
`processcontext` moves under `procmeta`, and the inline read and `Meta.ProcessContextInfo` go away,
which also drops package `process`'s dependency on `processcontext`.

Draft, since the first two commits add the `procmeta.ResourceEnricher` extension point this builds
on, which is a separate change.