### PR TITLE
process: fix mapping device ID computation

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -352,13 +352,13 @@ func iterateMappings(mapsFile io.Reader, callback func(m RawMapping) bool) (uint
 		}
 		major, err := strconv.ParseUint(devs[0], 16, 32)
 		if err != nil {
-			log.Debugf("major device: failed to convert %s to uint64: %v", devs[0], err)
+			log.Debugf("major device: failed to convert %s to uint32: %v", devs[0], err)
 			numParseErrors++
 			continue
 		}
 		minor, err := strconv.ParseUint(devs[1], 16, 32)
 		if err != nil {
-			log.Debugf("minor device: failed to convert %s to uint64: %v", devs[1], err)
+			log.Debugf("minor device: failed to convert %s to uint32: %v", devs[1], err)
 			numParseErrors++
 			continue
 		}

--- a/process/process.go
+++ b/process/process.go
@@ -350,19 +350,21 @@ func iterateMappings(mapsFile io.Reader, callback func(m RawMapping) bool) (uint
 			numParseErrors++
 			continue
 		}
-		major, err := strconv.ParseUint(devs[0], 16, 64)
+		major, err := strconv.ParseUint(devs[0], 16, 32)
 		if err != nil {
 			log.Debugf("major device: failed to convert %s to uint64: %v", devs[0], err)
 			numParseErrors++
 			continue
 		}
-		minor, err := strconv.ParseUint(devs[1], 16, 64)
+		minor, err := strconv.ParseUint(devs[1], 16, 32)
 		if err != nil {
 			log.Debugf("minor device: failed to convert %s to uint64: %v", devs[1], err)
 			numParseErrors++
 			continue
 		}
-		device := major<<8 + minor
+		// Encode like stat(2) st_dev: the legacy major<<8|minor neither matches an
+		// fstat result nor stays unique once the minor exceeds 8 bits.
+		device := unix.Mkdev(uint32(major), uint32(minor))
 
 		var path string
 		if inode == 0 {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
@@ -24,7 +25,7 @@ var testMappings = `55fe82710000-55fe8273c000 r--p 00000000 fd:01 1068432       
 55fe82836000-55fe8283d000 r--p 00125000 fd:01 1068432                    /tmp/usr_bin_seahorse
 55fe8283d000-55fe8283e000 rw-p 0012c000 fd:01 1068432                    /tmp/usr_bin_seahorse
 7f63c8c3e000-7f63c8de0000 r-xp 00085000 08:01 1048922                    /tmp/usr_lib_x86_64-linux-gnu_libcrypto.so.1.1
-7f63c8ebf000-7f63c8fef000 r-xp 0001c000 1fd:01 1075944                   /tmp/usr_lib_x86_64-linux-gnu_libopensc.so.6.0.0
+7f63c8ebf000-7f63c8fef000 r-xp 0001c000 1fd:2ff 1075944                  /tmp/usr_lib_x86_64-linux-gnu_libopensc.so.6.0.0
 7f63c8eef000-7f63c8fdf000 r-xp 0001c000 1fd:01
 7f63c8eef000-7f63c8fdf000 r-xp 0001c000 1fd.01 1075944
 7f63c8eef000-7f63c8fdf000 r- 0001c000 1fd:01 1075944
@@ -35,7 +36,7 @@ var testMappings = `55fe82710000-55fe8273c000 r--p 00000000 fd:01 1068432       
 var allExpectedMappings = []RawMapping{
 	{
 		Vaddr:      0x55fe82710000,
-		Device:     0xfd01,
+		Device:     unix.Mkdev(0xfd, 0x01),
 		Flags:      elf.PF_R,
 		Inode:      1068432,
 		Length:     0x2c000,
@@ -44,7 +45,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x55fe8273c000,
-		Device:     0xfd01,
+		Device:     unix.Mkdev(0xfd, 0x01),
 		Flags:      elf.PF_R + elf.PF_X,
 		Inode:      1068432,
 		Length:     0x82000,
@@ -53,7 +54,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x55fe827be000,
-		Device:     0xfd01,
+		Device:     unix.Mkdev(0xfd, 0x01),
 		Flags:      elf.PF_R,
 		Inode:      1068432,
 		Length:     0x78000,
@@ -62,7 +63,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x55fe82836000,
-		Device:     0xfd01,
+		Device:     unix.Mkdev(0xfd, 0x01),
 		Flags:      elf.PF_R,
 		Inode:      1068432,
 		Length:     0x7000,
@@ -71,7 +72,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x55fe8283d000,
-		Device:     0xfd01,
+		Device:     unix.Mkdev(0xfd, 0x01),
 		Flags:      elf.PF_R + elf.PF_W,
 		Inode:      1068432,
 		Length:     0x1000,
@@ -80,7 +81,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x7f63c8c3e000,
-		Device:     0x0801,
+		Device:     unix.Mkdev(0x08, 0x01),
 		Flags:      elf.PF_R + elf.PF_X,
 		Inode:      1048922,
 		Length:     0x1A2000,
@@ -89,7 +90,7 @@ var allExpectedMappings = []RawMapping{
 	},
 	{
 		Vaddr:      0x7f63c8ebf000,
-		Device:     0x1fd01,
+		Device:     unix.Mkdev(0x1fd, 0x2ff),
 		Flags:      elf.PF_R + elf.PF_X,
 		Inode:      1075944,
 		Length:     0x130000,


### PR DESCRIPTION
`iterateMappings` packed `/proc/PID/maps`' `major:minor` as `major<<8 + minor`, the legacy 16-bit layout.
Consumers of `RawMapping.Device` expect the encoding reported by `stat(2)` (`util/util.go` already documents the field as "dev_t as reported by stat").
The two agree only while the minor fits in 8 bits.

Two consequences: 
- `checkInodeDeviceMapping` rejects matching files.
- `util.OnDiskFileIdentifier` collisions: `major<<8 + minor` is not injective past 8 bits.

Fixed with using `unix.Mkdev`.