### PR TITLE
Go: bump to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/ebpf-profiler
 // For the OpenTelemetry eBPF Profiler distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.6

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-ebpf-profiler/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/nativeunwind/elfunwindinfo/testdata/Makefile
+++ b/nativeunwind/elfunwindinfo/testdata/Makefile
@@ -28,7 +28,7 @@ helloworld.arm64:
 	GOARCH=arm64 $(GO_BINARY) build -o $@ helloworld.go
 
 helloworld.linkexternal:
-	CGO_ENABLED=1 GOTOOLCHAIN=go1.26rc2 $(GO_BINARY) build -ldflags="-linkmode=external" -o $@ helloworld.go
+	CGO_ENABLED=1 GOTOOLCHAIN=go1.26.7 $(GO_BINARY) build -ldflags="-linkmode=external" -o $@ helloworld.go
 
 helloworld.linkexternal.stripped: helloworld.linkexternal
 	objcopy -S $< $@


### PR DESCRIPTION
With the release of Go 1.27 (https://go.dev/blog/go1.27), Go 1.25 is no longer a supported Go version.