### PR TITLE
fix: validate collector ticker intervals

### DIFF
--- a/collector/config/config_linux.go
+++ b/collector/config/config_linux.go
@@ -99,6 +99,14 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("unknown error mode %q", cfg.ErrorMode)
 	}
 
+	if cfg.ReporterInterval <= 0 {
+		return fmt.Errorf("invalid reporter interval: %s", cfg.ReporterInterval)
+	}
+
+	if cfg.MonitorInterval <= 0 {
+		return fmt.Errorf("invalid monitor interval: %s", cfg.MonitorInterval)
+	}
+
 	if cfg.SamplesPerSecond < 1 {
 		return fmt.Errorf("invalid sampling frequency: %d", cfg.SamplesPerSecond)
 	}

--- a/collector/config/config_test.go
+++ b/collector/config/config_test.go
@@ -16,6 +16,8 @@ import (
 // validConfig returns a config with valid defaults for testing.
 func validConfig() *Config {
 	return &Config{
+		ReporterInterval:       5 * time.Second,
+		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,
 		FrameCacheSize:         minFrameCacheSize,
 		ProbabilisticInterval:  1 * time.Minute,
@@ -25,11 +27,53 @@ func validConfig() *Config {
 	}
 }
 
-func TestValidate(t *testing.T) {
-	cfg := &Config{
-		SamplesPerSecond: 0,
-		ErrorMode:        PropagateError,
+func TestValidateIntervals(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		configure func(*Config)
+		wantErr   string
+	}{
+		{
+			name: "zero reporter interval",
+			configure: func(cfg *Config) {
+				cfg.ReporterInterval = 0
+			},
+			wantErr: "invalid reporter interval: 0s",
+		},
+		{
+			name: "negative reporter interval",
+			configure: func(cfg *Config) {
+				cfg.ReporterInterval = -time.Second
+			},
+			wantErr: "invalid reporter interval: -1s",
+		},
+		{
+			name: "zero monitor interval",
+			configure: func(cfg *Config) {
+				cfg.MonitorInterval = 0
+			},
+			wantErr: "invalid monitor interval: 0s",
+		},
+		{
+			name: "negative monitor interval",
+			configure: func(cfg *Config) {
+				cfg.MonitorInterval = -time.Second
+			},
+			wantErr: "invalid monitor interval: -1s",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.configure(cfg)
+
+			require.EqualError(t, confmap.Validate(cfg), tt.wantErr)
+		})
 	}
+}
+
+func TestValidate(t *testing.T) {
+	cfg := validConfig()
+	cfg.SamplesPerSecond = 0
 	err := confmap.Validate(cfg)
 	require.Error(t, err)
 	require.Equal(t, "invalid sampling frequency: 0", err.Error())


### PR DESCRIPTION
`reporter_interval: 0s` currently passes validation. 
Startup then calls `time.NewTicker(0)` and panics, taking down the Collector. 
`monitor_interval` hits the same bug

Repro:

```yaml
receivers:
  profiling:
    reporter_interval: 0s
```

This rejects zero and negative values during config validation. 
Positive intervals and `clock_sync_interval: 0s` still work as before

Tests: `go test -race ./collector/config ./collector ./reporter ./periodiccaller`
