### PR TITLE
processmanager: replace pidPageToMappingInfoSize with atomic.Uint64

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -192,7 +192,7 @@ func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 			}
 		}
 
-		summary[metrics.IDHashmapPidPageToMappingInfo] = metrics.MetricValue(pm.pidPageToMappingInfoSize)
+		summary[metrics.IDHashmapPidPageToMappingInfo] = metrics.MetricValue(pm.pidPageToMappingInfoSize.Load())
 
 		summary[metrics.IDELFInfoCacheHit] = metrics.MetricValue(pm.elfInfoCacheHit.Swap(0))
 		summary[metrics.IDELFInfoCacheMiss] = metrics.MetricValue(pm.elfInfoCacheMiss.Swap(0))

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -147,7 +147,7 @@ func (pm *ProcessManager) getOrCreateProcessInfo(pid libpf.PID,
 		return nil
 	}
 
-	pm.pidPageToMappingInfoSize++
+	pm.pidPageToMappingInfoSize.Add(1)
 	info = &processInfo{
 		meta:     meta,
 		libcInfo: nil,
@@ -514,7 +514,12 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 	for idx := range info.mappings {
 		deleted += pm.processRemovedMapping(pid, &info.mappings[idx])
 	}
-	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, deleted)
+	for {
+		cur := pm.pidPageToMappingInfoSize.Load()
+		if pm.pidPageToMappingInfoSize.CompareAndSwap(cur, cur-min(cur, deleted)) {
+			break
+		}
+	}
 	pm.processRemovedInterpreters(pid, libpf.Set[util.OnDiskFileIdentifier]{})
 
 	for a := range pm.attachedProbes[pid] {
@@ -767,7 +772,12 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	for _, m := range mpRemove {
 		numChanges += pm.processRemovedMapping(pid, m)
 	}
-	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, numChanges)
+	for {
+		cur := pm.pidPageToMappingInfoSize.Load()
+		if pm.pidPageToMappingInfoSize.CompareAndSwap(cur, cur-min(cur, numChanges)) {
+			break
+		}
+	}
 	pm.mu.Lock()
 	collectAnonymousMappings = pm.processRemovedInterpreters(pid, interpretersValid)
 	if collectAnonymousMappings != previousAnonymousMappingsWanted {
@@ -782,7 +792,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	for _, m := range mpAdd {
 		numChanges += pm.processNewMapping(pid, m)
 	}
-	pm.pidPageToMappingInfoSize += numChanges
+	pm.pidPageToMappingInfoSize.Add(numChanges)
 
 	// Update metadata of the process.
 	var meta process.Meta

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -125,7 +125,7 @@ type ProcessManager struct {
 
 	// pidPageToMappingInfoSize reflects the current size of the eBPF hash map
 	// pid_page_to_mapping_info.
-	pidPageToMappingInfoSize uint64
+	pidPageToMappingInfoSize atomic.Uint64
 
 	// filterErrorFrames determines whether error frames are dropped by `ConvertTrace`.
 	filterErrorFrames bool


### PR DESCRIPTION
`pidPageToMappingInfoSize` was mutated in `SynchronizeProcess()` without any lock held, while `collectInterpreterMetrics()` read it under `pm.mu.RLock()` and `processPIDExit()` wrote it under `pm.mu.Lock()`.

Convert the field to `atomic.Uint64` so read/write paths are safe regardless of lock context and without needing to hold the package global lock. Use a CAS loop to keep the underflow guard atomic.