### PR TITLE
metrics: disable metrics collection if telemetry is not configured

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,9 +15,13 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 var (
+	// metricsProviderConfigured indicates if Start() was called with a real (non-noop) metric meter.
+	metricsProviderConfigured bool
+
 	// prevTimestamp holds the timestamp of the buffered metrics
 	prevTimestamp uint32
 
@@ -45,10 +49,16 @@ var (
 	gauges   = map[MetricID]metric.Int64Gauge{}
 )
 
+// Enabled reports whether a real (non-noop) metric meter was provided to Start().
+func Enabled() bool { return metricsProviderConfigured }
+
 // Start initializes the OTel metric instruments for a predefined set of
 // metric definitions. It must be called before any goroutine begins
 // calling AddSlice or Add.
 func Start(meter metric.Meter) {
+	_, enabled := any(meter).(noop.Meter)
+	metricsProviderConfigured = !enabled
+
 	defs := GetDefinitions()
 	metricTypes = make(map[MetricID]MetricType, len(defs))
 	for _, md := range defs {
@@ -56,6 +66,11 @@ func Start(meter metric.Meter) {
 			continue
 		}
 		metricTypes[md.ID] = md.Type
+
+		if !metricsProviderConfigured {
+			continue
+		}
+
 		switch typ := md.Type; typ {
 		case MetricTypeCounter:
 			counter, err := meter.Int64Counter(md.Field,

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -177,6 +177,9 @@ func updateMetricSummary(ii interpreter.Instance, summary metrics.Summary) error
 func collectInterpreterMetrics(ctx context.Context, pm *ProcessManager,
 	monitorInterval time.Duration,
 ) {
+	if !metrics.Enabled() {
+		return
+	}
 	periodiccaller.Start(ctx, monitorInterval, func() {
 		pm.mu.RLock()
 		defer pm.mu.RUnlock()

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1185,12 +1185,14 @@ func (t *Tracer) StartMapMonitors(ctx context.Context, traceOutChan chan<- *libp
 	// calculate and store delta values.
 	previousMetricValue := make([]metrics.MetricValue, len(translateIDs))
 
-	periodiccaller.Start(ctx, t.intervals.MonitorInterval(), func() {
-		metrics.AddSlice(eventMetricCollector())
-		metrics.AddSlice(traceEventMetricCollector())
-		metrics.AddSlice(t.eBPFMetricsCollector(translateIDs, previousMetricValue))
-		metrics.AddSlice(t.customLabels.getAndResetMetrics())
-	})
+	if metrics.Enabled() {
+		periodiccaller.Start(ctx, t.intervals.MonitorInterval(), func() {
+			metrics.AddSlice(eventMetricCollector())
+			metrics.AddSlice(traceEventMetricCollector())
+			metrics.AddSlice(t.eBPFMetricsCollector(translateIDs, previousMetricValue))
+			metrics.AddSlice(t.customLabels.getAndResetMetrics())
+		})
+	}
 
 	return nil
 }


### PR DESCRIPTION
Metrics collection is a constant source of allocations and therefore causing more GC workload. Disable metrics handling, if no telemetry metric provider is configured.

OTel collector with telemetry (to stdout) for metrics configured:
```
receivers:
  profiling:

exporters:
  otlp/firepit:
    endpoint: 127.0.0.1:4317
    tls:
      insecure: true
      insecure_skip_verify: true

service:
  telemetry:
    logs:
      level: info
    metrics:
      readers:
        - periodic:
            exporter:
              console: {}
  pipelines:
    profiles:
      receivers: [profiling]
      exporters: [otlp/firepit]
```

OTel collector without telemetry for metrics configured:
```
receivers:
  profiling:

exporters:
  otlp/firepit:
    endpoint: 127.0.0.1:4317
    tls:
      insecure: true
      insecure_skip_verify: true

service:
  telemetry:
    logs:
      level: info
    metrics:
      level: none
  pipelines:
    profiles:
      receivers: [profiling]
      exporters: [otlp/firepit]
```