### PR TITLE
fix: preserve custom labels during sample aggregation

### DIFF
--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -4,8 +4,12 @@
 package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"slices"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -40,6 +44,41 @@ type baseReporter struct {
 }
 
 var errUnknownProfileType = errors.New("unknown trace profile type")
+
+type customLabel struct {
+	key   string
+	value string
+}
+
+func hashCustomLabels(labels map[libpf.String]libpf.String) libpf.TraceHash {
+	if len(labels) == 0 {
+		return libpf.TraceHash{}
+	}
+
+	ordered := make([]customLabel, 0, len(labels))
+	for key, value := range labels {
+		ordered = append(ordered, customLabel{key: key.String(), value: value.String()})
+	}
+	slices.SortFunc(ordered, func(a, b customLabel) int {
+		if cmp := strings.Compare(a.key, b.key); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.value, b.value)
+	})
+
+	h := fnv.New128a()
+	var size [4]byte
+	for _, label := range ordered {
+		binary.LittleEndian.PutUint32(size[:], uint32(len(label.key)))
+		_, _ = h.Write(size[:])
+		_, _ = h.Write([]byte(label.key))
+		binary.LittleEndian.PutUint32(size[:], uint32(len(label.value)))
+		_, _ = h.Write(size[:])
+		_, _ = h.Write([]byte(label.value))
+	}
+	labelHash, _ := libpf.TraceHashFromBytes(h.Sum(make([]byte, 0, 16)))
+	return labelHash
+}
 
 func (b *baseReporter) Stop() {
 	b.runLoop.Stop()
@@ -79,13 +118,14 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	}
 
 	sampleKey := samples.SampleKey{
-		Hash:      traceHash,
-		Comm:      meta.Comm,
-		TID:       int64(meta.TID),
-		CPU:       int64(meta.CPU),
-		SpanID:    meta.SpanID,
-		TraceID:   meta.TraceID,
-		ExtraMeta: extraMeta,
+		Hash:             traceHash,
+		CustomLabelsHash: hashCustomLabels(trace.CustomLabels),
+		Comm:             meta.Comm,
+		TID:              int64(meta.TID),
+		CPU:              int64(meta.CPU),
+		SpanID:           meta.SpanID,
+		TraceID:          meta.TraceID,
+		ExtraMeta:        extraMeta,
 	}
 	if events, exists := rtp.Events[meta.ProfileType][sampleKey]; exists {
 		events.Timestamps = append(events.Timestamps, uint64(meta.Timestamp))

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -278,3 +278,81 @@ func TestProcessMetaEnricherPipeline(t *testing.T) {
 	}
 	assert.True(t, found, "expected process.name=myapp in the attribute table")
 }
+
+func TestCustomLabelsArePartOfSampleIdentity(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+	frames := make(libpf.Frames, 0, 1)
+	frames.Append(&libpf.Frame{
+		Type:            libpf.GoFrame,
+		AddressOrLineno: 42,
+		FunctionName:    libpf.Intern("work"),
+	})
+
+	meta := &samples.TraceEventMeta{
+		Timestamp:      libpf.UnixTime64(time.Now().UnixNano()),
+		Comm:           libpf.NewCommFromString("app"),
+		ExecutablePath: libpf.Intern("/usr/bin/app"),
+		PID:            1000,
+		TID:            1001,
+		CPU:            0,
+		ProfileType:    profileTypeSampling,
+	}
+
+	for _, value := range []string{"tenant-a", "tenant-b", "tenant-a"} {
+		trace := &libpf.Trace{
+			Frames: frames,
+			CustomLabels: map[libpf.String]libpf.String{
+				libpf.Intern("tenant"): libpf.Intern(value),
+			},
+		}
+		require.NoError(t, reporter.ReportTraceEvent(trace, meta))
+		meta.Timestamp++
+	}
+
+	eventsTreePtr := reporter.traceEvents.RLock()
+	eventsTree := *eventsTreePtr
+	reporter.traceEvents.RUnlock(&eventsTreePtr)
+	profiles, err := reporter.pdata.Generate(eventsTree, reporter.name, reporter.version,
+		reporter.collectionStartTime, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 2, profiles.SampleCount())
+
+	dictionary := profiles.Dictionary()
+	profileSamples := profiles.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).Samples()
+	labelValues := make(map[string]struct{}, profileSamples.Len())
+	timestampsByLabel := make(map[string]int, profileSamples.Len())
+	for i := 0; i < profileSamples.Len(); i++ {
+		profileSample := profileSamples.At(i)
+		attributeIndices := profileSample.AttributeIndices()
+		for j := 0; j < attributeIndices.Len(); j++ {
+			attr := dictionary.AttributeTable().At(int(attributeIndices.At(j)))
+			if dictionary.StringTable().At(int(attr.KeyStrindex())) == "process.context.label.tenant" {
+				value := attr.Value().Str()
+				labelValues[value] = struct{}{}
+				timestampsByLabel[value] = profileSample.TimestampsUnixNano().Len()
+			}
+		}
+	}
+	require.Equal(t, map[string]struct{}{
+		"tenant-a": {},
+		"tenant-b": {},
+	}, labelValues)
+	require.Equal(t, map[string]int{
+		"tenant-a": 2,
+		"tenant-b": 1,
+	}, timestampsByLabel)
+}
+
+func TestCustomLabelHashIsOrderIndependent(t *testing.T) {
+	labelsA := map[libpf.String]libpf.String{}
+	labelsA[libpf.Intern("first")] = libpf.Intern("one")
+	labelsA[libpf.Intern("second")] = libpf.Intern("two")
+
+	labelsB := map[libpf.String]libpf.String{}
+	labelsB[libpf.Intern("second")] = libpf.Intern("two")
+	labelsB[libpf.Intern("first")] = libpf.Intern("one")
+
+	require.Equal(t, hashCustomLabels(labelsA), hashCustomLabels(labelsB))
+	labelsB[libpf.Intern("first")] = libpf.Intern("different")
+	require.NotEqual(t, hashCustomLabels(labelsA), hashCustomLabels(labelsB))
+}

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -80,6 +80,8 @@ type SampleKey struct {
 	Comm libpf.Comm
 
 	Hash libpf.TraceHash
+	// CustomLabelsHash keeps samples with different custom labels distinct.
+	CustomLabelsHash libpf.TraceHash
 
 	TID int64
 	CPU int64


### PR DESCRIPTION
Samples with the same stack, thread and CPU were merged even when Go pprof labels differed. 
The first label set won, so later CPU samples could land on the wrong tenant. 
This was a small but legit attribution bug, pretty easy to hit in a busy Go server

This adds a stable custom label hash to the aggregation key. 
Same labels still batch, different labels stay separate. 
The stack hash stays untouched

Repro

Report two traces with identical frames and metadata, using `tenant=a` and `tenant=b`. 
Before: one OTLP sample with `tenant=a`. 
after: two samples with the right labels

Tests

`go test -race ./reporter ./reporter/internal/pdata ./reporter/samples -count=1`

`go test ./reporter -run 'TestCustomLabelsArePartOfSampleIdentity|TestCustomLabelHashIsOrderIndependent' -count=100`

Follow-up to #716.
