### PR TITLE
fix(process): strip ' (deleted)' suffix from GetExe path

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -109,6 +109,10 @@ func (sp *systemProcess) GetExe() (libpf.String, error) {
 	if err != nil {
 		return libpf.NullString, err
 	}
+	// The kernel appends " (deleted)" to the symlink target when the
+	// executable has been removed from disk. Strip it so callers get
+	// the original path.
+	str = strings.TrimSuffix(str, " (deleted)")
 	return libpf.Intern(str), nil
 }
 


### PR DESCRIPTION
On Linux, when a process's executable is deleted from disk, the kernel appends  " (deleted)" to the /proc/<pid>/exe symlink target.  `GetExe()` returned this raw path to callers.