### PR TITLE
test: fix OffCPUThreshold no longer a config option

### DIFF
--- a/process/processcontext/integrationtests/processcontext_integration_test.go
+++ b/process/processcontext/integrationtests/processcontext_integration_test.go
@@ -8,7 +8,6 @@ package integrationtests
 import (
 	"context"
 	"log/slog"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -116,7 +115,6 @@ func Test_ProcessContext(t *testing.T) {
 				SamplesPerSecond:       20,
 				ProbabilisticInterval:  100,
 				ProbabilisticThreshold: 100,
-				OffCPUThreshold:        uint32(math.MaxUint32 / 100),
 				VerboseMode:            true,
 				TraceReporter:          rep,
 			})


### PR DESCRIPTION
Fixes CI, follow-up of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1734