### PR TITLE
CI: pin Linux kernel version for 7.1.x on arm64

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -205,7 +205,7 @@ jobs:
           - { target_arch: arm64, kernel: 6.12.16 }
           - { target_arch: arm64, kernel: 6.16 }
           - { target_arch: arm64, kernel: 6.18 }
-          - { target_arch: arm64, kernel: 7.1 }
+          - { target_arch: arm64, kernel: 7.1.1 }
     steps:
       - name: Disable man-db
         run: |


### PR DESCRIPTION
Upstream updated the Linux kernel images with
https://github.com/cilium/ci-kernels/commit/a8de7196aa443258d25b74886b38fc75de85ddff and it seems it produces a faulty 7.1.12 arm64 image.

Pin the 7.1 arm64 image to 7.1.1 to avoid this issue until it is resolved upstream.