### PR TITLE
pfelf: add RelTPOFF64 and pass matched RelocType to relocation visitor

### DIFF
--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -1605,7 +1605,7 @@ func loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	// Look for DTPMOD64 relocation to find the TLS module ID offset.
 	// This is used for DTV-based TLS access when TLSDESC is unavailable.
 	var tlsModuleIdOffset libpf.Address
-	if err = ef.VisitRelocations(func(r pfelf.ElfReloc, _ string) bool {
+	if err = ef.VisitRelocations(func(r pfelf.ElfReloc, _ string, _ pfelf.RelocType) bool {
 		log.Debugf("Found DTPMOD64 relocation at offset %x", r.Off)
 		tlsModuleIdOffset = libpf.Address(r.Off)
 		return false

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -731,6 +731,8 @@ const (
 	RelTLSDESC RelocType = 1 << iota
 	// RelDTPMOD64 matches DTPMOD64 relocations (R_AARCH64_TLS_DTPMOD64, R_X86_64_DTPMOD64).
 	RelDTPMOD64
+	// RelTPOFF64 matches TP-relative relocations (R_AARCH64_TLS_TPREL64, R_X86_64_TPOFF64).
+	RelTPOFF64
 )
 
 // classifyRelocAarch64 returns the RelocType for an AARCH64 relocation.
@@ -740,6 +742,8 @@ func classifyRelocAarch64(rela ElfReloc) RelocType {
 		return RelTLSDESC
 	case elf.R_AARCH64_TLS_DTPMOD64:
 		return RelDTPMOD64
+	case elf.R_AARCH64_TLS_TPREL64:
+		return RelTPOFF64
 	default:
 		return 0
 	}
@@ -752,6 +756,8 @@ func classifyRelocX86_64(rela ElfReloc) RelocType {
 		return RelTLSDESC
 	case elf.R_X86_64_DTPMOD64:
 		return RelDTPMOD64
+	case elf.R_X86_64_TPOFF64:
+		return RelTPOFF64
 	default:
 		return 0
 	}
@@ -761,13 +767,15 @@ func classifyRelocX86_64(rela ElfReloc) RelocType {
 // for the TLS symbol, as well as a best-effort string for the symbol's name.
 // It continues until the visitor returns false.
 func (f *File) VisitTLSRelocations(visitor func(ElfReloc, string) bool) error {
-	return f.VisitRelocations(visitor, RelTLSDESC)
+	return f.VisitRelocations(func(r ElfReloc, name string, _ RelocType) bool {
+		return visitor(r, name)
+	}, RelTLSDESC)
 }
 
 // VisitRelocations visits all relocations whose type matches the relTypes
-// bitmask and provides the relocation and symbol name to the visitor. The
-// visitor can return false to stop iteration.
-func (f *File) VisitRelocations(visitor func(ElfReloc, string) bool,
+// bitmask and provides the relocation, symbol name and matched RelocType to the
+// visitor. The visitor can return false to stop iteration.
+func (f *File) VisitRelocations(visitor func(ElfReloc, string, RelocType) bool,
 	relTypes RelocType) error {
 	var classify func(ElfReloc) RelocType
 	switch f.Machine {
@@ -778,9 +786,6 @@ func (f *File) VisitRelocations(visitor func(ElfReloc, string) bool,
 	default:
 		return nil
 	}
-	filterFunc := func(rela ElfReloc) bool {
-		return classify(rela)&relTypes != 0
-	}
 	var err error
 	if err = f.LoadSections(); err != nil {
 		return err
@@ -790,7 +795,7 @@ func (f *File) VisitRelocations(visitor func(ElfReloc, string) bool,
 		section := &f.Sections[i]
 		// NOTE: SHT_REL is not relevant for the archs that we care about
 		if section.Type == elf.SHT_RELA {
-			cont, err := f.visitRelocationsForSection(visitor, filterFunc, section)
+			cont, err := f.visitRelocationsForSection(visitor, classify, relTypes, section)
 			if err != nil {
 				return err
 			}
@@ -803,8 +808,8 @@ func (f *File) VisitRelocations(visitor func(ElfReloc, string) bool,
 	return nil
 }
 
-func (f *File) visitRelocationsForSection(visitor func(ElfReloc, string) bool,
-	checkRelocation func(ElfReloc) bool,
+func (f *File) visitRelocationsForSection(visitor func(ElfReloc, string, RelocType) bool,
+	classify func(ElfReloc) RelocType, relTypes RelocType,
 	relaSection *Section,
 ) (bool, error) {
 	if relaSection.Link >= uint32(len(f.Sections)) {
@@ -847,7 +852,8 @@ func (f *File) visitRelocationsForSection(visitor func(ElfReloc, string) bool,
 			}
 			break
 		}
-		if !checkRelocation(*rela) {
+		relType := classify(*rela)
+		if relType&relTypes == 0 {
 			continue
 		}
 		symNo := int64(rela.Info >> 32)
@@ -861,7 +867,7 @@ func (f *File) visitRelocationsForSection(visitor func(ElfReloc, string) bool,
 			return false, errors.New("failed to get relocation name string")
 		}
 
-		if !visitor(*rela, symStr) {
+		if !visitor(*rela, symStr, relType) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
First of n pieces split out of #1229 per the [request](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1229#pullrequestreview-4617540589).

#### Changes

Two changes to `VisitRelocations`:
- new `RelTPOFF64`, matching `R_AARCH64_TLS_TPREL64` and `R_X86_64_TPOFF64`
- the visitor now receives the `RelocType` that matched, so a caller filtering on a mask of several types can tell which one fired

#### Why 

Needed by the upcoming `tls` package to classify TLS accesses.
Without the matched type the visitor would have to re-decode `rela.Info` per architecture, duplicating `classifyReloc{Aarch64,X86_64}`.