### PR TITLE
thread context 2/n [schema]: parse the per-thread label schema

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -219,3 +219,11 @@ func (f EbpfFrame) Data() uint64 {
 func (f EbpfFrame) Variable(ndx int) uint64 {
 	return f[ndx+1]
 }
+
+// LabelDecoder decodes a per-thread custom-label payload into labels plus a
+// count of entries it could not decode. Implementations must be
+// concurrency-safe, and DecodeLabels must not retain or alias data, which
+// points into a reused ring buffer.
+type LabelDecoder interface {
+	DecodeLabels(data []byte) (labels map[String]String, dropped int)
+}

--- a/process/processcontext/processcontext.go
+++ b/process/processcontext/processcontext.go
@@ -69,12 +69,12 @@ var (
 	errNoUpdate = errors.New("ProcessContext has not been updated")
 )
 
-// Info is a snapshot of process context. attribute.Set is immutable, so the
-// sets are safe to copy and share across goroutines without locking.
+// Info is a snapshot of process context. Copies are safe to share across
+// goroutines: attribute.Set is immutable and threadCtx is never mutated after
+// construction.
 type Info struct {
 	ResourceAttrs attribute.Set
-	// Populated but unused until thread context lands.
-	attributes    attribute.Set
+	threadCtx     *threadContextInfo
 	publishedAtNs uint64
 	// resolved is false only on a zero Info, meaning never resolved or
 	// invalidated by an exec. Resolve never returns an unresolved Info.
@@ -94,64 +94,68 @@ type header struct {
 // read reads ProcessContext from remote process memory at addr.
 // Returns errInvalidContext if the process has no ProcessContext memory region.
 // Retries concurrent updates up to maxAttempts times, or defaultMaxAttempts if 0.
-func read(addr libpf.Address, rm remotememory.RemoteMemory, lastPublishedAtNs uint64, maxAttempts int) (Info, error) {
+func read(addr libpf.Address, rm remotememory.RemoteMemory,
+	lastPublishedAtNs uint64, maxAttempts int,
+) (payloadResult, error) {
 	if maxAttempts == 0 {
 		maxAttempts = defaultMaxAttempts
 	}
 	var lastErr error
 
 	for range maxAttempts {
-		processCtx, err := readOnce(addr, rm, lastPublishedAtNs)
+		result, err := readOnce(addr, rm, lastPublishedAtNs)
 		if err == nil {
-			return processCtx, nil
+			return result, nil
 		}
 		if !errors.Is(err, errConcurrentUpdate) {
-			return Info{}, err
+			return payloadResult{}, err
 		}
 		lastErr = err
 	}
-	return Info{}, lastErr
+	return payloadResult{}, lastErr
 }
 
-func readOnce(mappingAddr libpf.Address, rm remotememory.RemoteMemory, lastPublishedAtNs uint64) (Info, error) {
+func readOnce(mappingAddr libpf.Address, rm remotememory.RemoteMemory,
+	lastPublishedAtNs uint64,
+) (payloadResult, error) {
 	monotonicPublishedAtNs, err := readTimestamp(rm, mappingAddr)
 	if err != nil {
-		return Info{}, fmt.Errorf("%w: %w",
+		return payloadResult{}, fmt.Errorf("%w: %w",
 			errInvalidContext, err)
 	}
 	if monotonicPublishedAtNs == 0 {
-		return Info{}, errConcurrentUpdate
+		return payloadResult{}, errConcurrentUpdate
 	}
 
 	if monotonicPublishedAtNs <= lastPublishedAtNs {
-		return Info{}, errNoUpdate
+		return payloadResult{}, errNoUpdate
 	}
 
 	hdr, err := readHeader(rm, mappingAddr)
 	if err != nil {
-		return Info{}, fmt.Errorf("%w: %w",
+		return payloadResult{}, fmt.Errorf("%w: %w",
 			errInvalidContext, err)
 	}
 
-	ctx, ctxErr := readPayload(rm, hdr)
+	result, ctxErr := readPayload(rm, hdr)
 	// Deferred: the read may have failed only because of a concurrent update
 	// between the header and the payload, which the timestamp recheck detects.
 
 	monotonicPublishedAtNs2, err := readTimestamp(rm, mappingAddr)
 	if err != nil {
-		return Info{}, fmt.Errorf("%w: %w",
+		return payloadResult{}, fmt.Errorf("%w: %w",
 			errInvalidContext, err)
 	}
 
 	if monotonicPublishedAtNs != monotonicPublishedAtNs2 {
-		return Info{}, errConcurrentUpdate
+		return payloadResult{}, errConcurrentUpdate
 	}
 
 	if ctxErr != nil {
-		return Info{}, fmt.Errorf("%w: %w", errInvalidContext, ctxErr)
+		return payloadResult{}, fmt.Errorf("%w: %w", errInvalidContext, ctxErr)
 	}
 
-	return ctx, nil
+	return result, nil
 }
 
 // Resolve reads the process context from a context mapping (if any). Per
@@ -177,9 +181,15 @@ func Resolve(
 		// Workaround for a CodeQL warning about uint64 -> uintptr (libpf.Address) overflow.
 		addr := libpf.Address(mappingAddr & uint64(^libpf.Address(0)))
 
-		ctx, err := read(addr, rm, old.publishedAtNs, 0)
+		result, err := read(addr, rm, old.publishedAtNs, 0)
 		switch {
 		case err == nil:
+			if result.threadCtxErr != nil {
+				// Coherent now, so a real fault, not a torn read: every label
+				// from this process is dropped until it is fixed.
+				log.Warnf("PID %d: failed to read thread context: %v", pid, result.threadCtxErr)
+			}
+			ctx := result.info
 			ctx.resolved = true
 			return ctx
 		case errors.Is(err, errNoUpdate):
@@ -241,22 +251,34 @@ func readHeader(rm remotememory.RemoteMemory, headerAddr libpf.Address) (header,
 	return hdr, nil
 }
 
-func readPayload(rm remotememory.RemoteMemory, hdr header) (Info, error) {
+type payloadResult struct {
+	info Info
+	// A non-fatal thread-context schema fault: info is valid without it.
+	// Returned rather than logged here because only the caller's timestamp
+	// recheck can tell a genuine fault from a torn read.
+	threadCtxErr error
+}
+
+func readPayload(rm remotememory.RemoteMemory, hdr header) (payloadResult, error) {
 	payloadBytes := make([]byte, hdr.PayloadSize)
-	err := rm.Read(libpf.Address(hdr.PayloadPtr), payloadBytes)
-	if err != nil {
-		return Info{}, fmt.Errorf("failed to read payload: %w", err)
+	if err := rm.Read(libpf.Address(hdr.PayloadPtr), payloadBytes); err != nil {
+		return payloadResult{}, fmt.Errorf("failed to read payload: %w", err)
 	}
 
 	ctx := &processcontextpb.ProcessContext{}
 	if err := proto.Unmarshal(payloadBytes, ctx); err != nil {
-		return Info{}, fmt.Errorf("failed to unmarshal ProcessContext: %w", err)
+		return payloadResult{}, fmt.Errorf("failed to unmarshal ProcessContext: %w", err)
 	}
 
-	return Info{
-		ResourceAttrs: newAttributeSet(convertKeyValues(ctx.GetResource().GetAttributes())),
-		attributes:    newAttributeSet(convertKeyValues(ctx.GetAttributes())),
-		publishedAtNs: hdr.MonotonicPublishedAtNs,
+	threadCtx, threadCtxErr := readThreadContextInfo(ctx.GetAttributes())
+
+	return payloadResult{
+		info: Info{
+			ResourceAttrs: newAttributeSet(convertKeyValues(ctx.GetResource().GetAttributes())),
+			threadCtx:     threadCtx,
+			publishedAtNs: hdr.MonotonicPublishedAtNs,
+		},
+		threadCtxErr: threadCtxErr,
 	}, nil
 }
 

--- a/process/processcontext/processcontext.go
+++ b/process/processcontext/processcontext.go
@@ -251,9 +251,11 @@ func readHeader(rm remotememory.RemoteMemory, headerAddr libpf.Address) (header,
 	return hdr, nil
 }
 
+// payloadResult exists only to carry a non-fatal failure to read the
+// thread-context schema alongside Info.
 type payloadResult struct {
 	info Info
-	// A non-fatal thread-context schema fault: info is valid without it.
+	// A non-fatal error: info stays usable, only its threadCtx is nil.
 	// Returned rather than logged here because only the caller's timestamp
 	// recheck can tell a genuine fault from a torn read.
 	threadCtxErr error

--- a/process/processcontext/processcontext_test.go
+++ b/process/processcontext/processcontext_test.go
@@ -7,6 +7,7 @@ package processcontext
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 	"os"
@@ -209,7 +210,6 @@ func TestProcessContext_Read(t *testing.T) {
 			},
 			expectedResult: Info{
 				ResourceAttrs: expectedResourceAttrs(),
-				attributes:    expectedAttributes(),
 				publishedAtNs: 123456789,
 			},
 		},
@@ -311,15 +311,15 @@ func TestProcessContext_Read(t *testing.T) {
 
 			rm := remotememory.RemoteMemory{ReaderAt: mock}
 
-			ctx, err := read(mappingAddr, rm, tt.lastPublishedAtNs, 0)
+			result, err := read(mappingAddr, rm, tt.lastPublishedAtNs, 0)
 
 			if tt.expectedErr == nil {
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedResult, ctx)
+				require.Equal(t, tt.expectedResult, result.info)
 			} else {
-				assert.Zero(t, ctx.ResourceAttrs.Len())
-				assert.Zero(t, ctx.attributes.Len())
-				assert.Zero(t, ctx.publishedAtNs)
+				assert.Zero(t, result.info.ResourceAttrs.Len())
+				assert.Nil(t, result.info.LabelDecoder())
+				assert.Zero(t, result.info.publishedAtNs)
 				require.Error(t, err)
 				assert.ErrorIs(t, err, tt.expectedErr)
 				if tt.errorSubstring != "" {
@@ -424,10 +424,9 @@ func TestProcessContext_Read_RealProcessContext(t *testing.T) {
 			require.Equal(t,
 				Info{
 					ResourceAttrs: expectedResourceAttrs(),
-					attributes:    expectedAttributes(),
 					publishedAtNs: 123456789,
 				},
-				result)
+				result.info)
 
 		})
 	}
@@ -448,8 +447,11 @@ func expectedResourceAttrs() attribute.Set {
 	)
 }
 
-func expectedAttributes() attribute.Set {
-	return attribute.NewSet(attribute.String("custom.attribute", "custom-value"))
+func serviceName(t *testing.T, info Info) string {
+	t.Helper()
+	v, ok := info.ResourceAttrs.Value("service.name")
+	require.True(t, ok)
+	return v.AsString()
 }
 
 // An AnyValue with no variant set is a valid empty value per OTLP
@@ -471,7 +473,7 @@ func TestProcessContext_Read_KeepsEmptyValues(t *testing.T) {
 	mock.writeAt(0x1000, createValidHeader(uint32(len(payload)), payloadAddr, 1))
 	mock.writeAt(payloadAddr, payload)
 
-	info, err := read(libpf.Address(0x1000),
+	result, err := read(libpf.Address(0x1000),
 		remotememory.RemoteMemory{ReaderAt: mock}, 0, 0)
 	require.NoError(t, err)
 
@@ -479,7 +481,104 @@ func TestProcessContext_Read_KeepsEmptyValues(t *testing.T) {
 		attribute.String("set", "v"),
 		attribute.KeyValue{Key: "unset.oneof"},
 		attribute.KeyValue{Key: "absent.value"},
-	), info.ResourceAttrs)
+	), result.info.ResourceAttrs)
+}
+
+// tornTimestampReader simulates a concurrent publish observed between
+// readOnce's two coherence checks.
+type tornTimestampReader struct {
+	inner         io.ReaderAt
+	tsAddr        int64
+	first, second uint64
+	reads         int
+}
+
+func (r *tornTimestampReader) ReadAt(p []byte, off int64) (int, error) {
+	if off == r.tsAddr && len(p) == 8 {
+		r.reads++
+		ts := r.first
+		if r.reads > 1 {
+			ts = r.second
+		}
+		binary.LittleEndian.PutUint64(p, ts)
+		return len(p), nil
+	}
+	return r.inner.ReadAt(p, off)
+}
+
+func TestProcessContext_Read_ThreadContext(t *testing.T) {
+	buildPayload := func(t *testing.T, threadAttrs ...*commonpb.KeyValue) []byte {
+		t.Helper()
+		payload, err := proto.Marshal(&processcontextpb.ProcessContext{
+			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+				{Key: "service.name", Value: strVal("test-service")},
+			}},
+			Attributes: threadAttrs,
+		})
+		require.NoError(t, err)
+		return payload
+	}
+
+	validSchema := []*commonpb.KeyValue{
+		attr(threadCtxSchemaVersionKey, strVal(supportedThreadCtxSchemaVersion)),
+		attr(threadCtxKeyMapKey, arrVal(strVal("route"), strVal("method"))),
+	}
+	malformedSchema := []*commonpb.KeyValue{
+		attr(threadCtxSchemaVersionKey, strVal("v99")),
+	}
+
+	t.Run("valid schema reaches Info.threadCtx", func(t *testing.T) {
+		payload := buildPayload(t, validSchema...)
+		mock := newMockReader()
+		mock.writeAt(0x1000, createValidHeader(uint32(len(payload)), 0x2000, 1))
+		mock.writeAt(0x2000, payload)
+
+		result, err := read(libpf.Address(0x1000), remotememory.RemoteMemory{ReaderAt: mock}, 0, 0)
+		require.NoError(t, err)
+
+		decoder := result.info.LabelDecoder()
+		require.NotNil(t, decoder)
+		labels, dropped := decoder.DecodeLabels(append([]byte{0, 3}, "/rt"...))
+		assert.Zero(t, dropped)
+		assert.Equal(t,
+			map[libpf.String]libpf.String{libpf.Intern("route"): libpf.Intern("/rt")},
+			labels)
+	})
+
+	t.Run("malformed schema is non-fatal", func(t *testing.T) {
+		payload := buildPayload(t, malformedSchema...)
+		mock := newMockReader()
+		mock.writeAt(0x1000, createValidHeader(uint32(len(payload)), 0x2000, 1))
+		mock.writeAt(0x2000, payload)
+
+		result, err := read(libpf.Address(0x1000), remotememory.RemoteMemory{ReaderAt: mock}, 0, 0)
+		require.NoError(t, err)
+		require.Error(t, result.threadCtxErr)
+		assert.Equal(t, "test-service", serviceName(t, result.info))
+		assert.Nil(t, result.info.LabelDecoder())
+	})
+
+	// A schema fault seen during a torn read is not a fault: the bytes it was
+	// decoded from were never coherent. The recheck must win, and threadCtxErr
+	// must not reach the caller for it to log.
+	t.Run("torn read wins over a payload fault", func(t *testing.T) {
+		payload := buildPayload(t, malformedSchema...)
+		mock := newMockReader()
+		mock.writeAt(0x1000, createValidHeader(uint32(len(payload)), 0x2000, 1))
+		mock.writeAt(0x2000, payload)
+
+		reader := &tornTimestampReader{
+			inner:  mock,
+			tsAddr: 0x1000 + int64(monotonicPublishedAtNsOffset),
+			first:  1,
+			second: 2,
+		}
+
+		result, err := readOnce(libpf.Address(0x1000),
+			remotememory.RemoteMemory{ReaderAt: reader}, 0)
+		require.ErrorIs(t, err, errConcurrentUpdate)
+		assert.Zero(t, result)
+	})
 }
 
 func TestAttributesFromEnvVars(t *testing.T) {
@@ -643,12 +742,6 @@ func TestAttributesFromEnvVars(t *testing.T) {
 func TestResolve(t *testing.T) {
 	envVars := map[libpf.String]libpf.String{
 		libpf.Intern("OTEL_SERVICE_NAME"): libpf.Intern("svc"),
-	}
-	serviceName := func(t *testing.T, info Info) string {
-		t.Helper()
-		v, ok := info.ResourceAttrs.Value("service.name")
-		require.True(t, ok)
-		return v.AsString()
 	}
 	// Callers store the result unconditionally, so an unresolved Info would
 	// publish empty attributes.

--- a/process/processcontext/threadlabels.go
+++ b/process/processcontext/threadlabels.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package processcontext // import "go.opentelemetry.io/ebpf-profiler/process/processcontext"
+
+import (
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/log"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
+)
+
+// Per-thread label schema, published as attributes per [OTEP 4947].
+//
+// [OTEP 4947]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4947-thread-ctx.md
+const (
+	threadCtxSchemaVersionKey       = "threadlocal.schema_version"
+	supportedThreadCtxSchemaVersion = "tlsdesc_v1_dev"
+	threadCtxKeyMapKey              = "threadlocal.attribute_key_map"
+	// maxThreadCtxAttributeKeys is the largest key map DecodeLabels can address,
+	// since it reads the key index as a single byte.
+	maxThreadCtxAttributeKeys = 256
+)
+
+// threadContextInfo is one process's published per-thread label schema.
+type threadContextInfo struct {
+	// Indexed by the key index the payload encodes.
+	attributeKeyMap []libpf.String
+}
+
+// readThreadContextInfo parses the threadlocal.* schema attributes. Returns
+// (nil, nil) when no schema is published.
+func readThreadContextInfo(attrs []*commonpb.KeyValue) (*threadContextInfo, error) {
+	var version, keyMap *commonpb.KeyValue
+	for _, attr := range attrs {
+		switch attr.GetKey() {
+		case threadCtxSchemaVersionKey:
+			// A repeated attribute is rejected rather than merged, which would
+			// shift every later key index.
+			if version != nil {
+				return nil, fmt.Errorf("duplicate %s attribute", threadCtxSchemaVersionKey)
+			}
+			version = attr
+		case threadCtxKeyMapKey:
+			if keyMap != nil {
+				return nil, fmt.Errorf("duplicate %s attribute", threadCtxKeyMapKey)
+			}
+			keyMap = attr
+		}
+	}
+
+	if version == nil {
+		if keyMap != nil {
+			return nil, errors.New("thread context attribute key map requires schema version")
+		}
+		// No schema published: the common case, not a fault.
+		return nil, nil
+	}
+	if v := version.GetValue().GetStringValue(); v != supportedThreadCtxSchemaVersion {
+		return nil, fmt.Errorf("unsupported thread context schema version: %s", v)
+	}
+	if keyMap == nil {
+		return &threadContextInfo{}, nil
+	}
+
+	arrayValue := keyMap.GetValue().GetArrayValue()
+	if arrayValue == nil {
+		return nil, errors.New("thread context attribute key map is not an array")
+	}
+	values := arrayValue.GetValues()
+	// Truncate rather than reject: the excess entries are already unusable.
+	if len(values) > maxThreadCtxAttributeKeys {
+		log.Debugf("thread context: attribute key map has %d entries, truncating to %d",
+			len(values), maxThreadCtxAttributeKeys)
+		values = values[:maxThreadCtxAttributeKeys]
+	}
+	attributeKeyMap := make([]libpf.String, 0, len(values))
+	for i, item := range values {
+		stringValue := item.GetStringValue()
+		if stringValue == "" {
+			return nil, fmt.Errorf("invalid thread context attribute at index %d: %.200s",
+				i, item.String())
+		}
+		attributeKeyMap = append(attributeKeyMap, libpf.Intern(stringValue))
+	}
+	return &threadContextInfo{attributeKeyMap: attributeKeyMap}, nil
+}
+
+// DecodeLabels resolves each entry's key index against the published schema.
+// Payload is repeated (key index byte, value length byte, value bytes).
+func (t *threadContextInfo) DecodeLabels(data []byte) (labels map[libpf.String]libpf.String, dropped int) {
+	for len(data) > 0 {
+		if len(data) < 2 {
+			dropped++
+			break
+		}
+		keyIndex := int(data[0])
+		valueLen := int(data[1])
+		if len(data) < 2+valueLen {
+			dropped++
+			break
+		}
+		val := data[2 : 2+valueLen]
+		data = data[2+valueLen:]
+		if keyIndex >= len(t.attributeKeyMap) {
+			dropped++
+			continue
+		}
+		// valueLen already bounds val to what the publisher declared, so an
+		// invalid value is a publisher bug, not a truncated read: drop it
+		// rather than present a possibly nonsensical partial string.
+		if !utf8.Valid(val) {
+			dropped++
+			log.Debugf("thread context: dropping invalid UTF-8 value for %q: %q",
+				t.attributeKeyMap[keyIndex], val)
+			continue
+		}
+		if labels == nil {
+			labels = make(map[libpf.String]libpf.String)
+		}
+		key := t.attributeKeyMap[keyIndex]
+		// A repeated key index means the payload is malformed: still decode it
+		// (last write wins) but count it, rather than silently discard a value.
+		if _, exists := labels[key]; exists {
+			dropped++
+		}
+		// Interning copies val, satisfying LabelDecoder's no-alias contract.
+		labels[key] = libpf.Intern(pfunsafe.ToString(val))
+	}
+	return labels, dropped
+}
+
+// LabelDecoder returns a decoder for the process's per-thread labels, or nil if
+// it publishes no schema.
+func (i Info) LabelDecoder() libpf.LabelDecoder {
+	if i.threadCtx == nil {
+		// Returning i.threadCtx directly would hand back a non-nil interface
+		// holding a typed nil, which a caller's nil test would not catch.
+		return nil
+	}
+	return i.threadCtx
+}

--- a/process/processcontext/threadlabels.go
+++ b/process/processcontext/threadlabels.go
@@ -126,8 +126,10 @@ func (t *threadContextInfo) DecodeLabels(data []byte) (labels map[libpf.String]l
 		key := t.attributeKeyMap[keyIndex]
 		// A repeated key index means the payload is malformed: still decode it
 		// (last write wins) but count it, rather than silently discard a value.
-		if _, exists := labels[key]; exists {
+		if prev, exists := labels[key]; exists {
 			dropped++
+			log.Debugf("thread context: duplicate entry for %q, replacing %q with %q",
+				key, prev, val)
 		}
 		// Interning copies val, satisfying LabelDecoder's no-alias contract.
 		labels[key] = libpf.Intern(pfunsafe.ToString(val))

--- a/process/processcontext/threadlabels_test.go
+++ b/process/processcontext/threadlabels_test.go
@@ -1,0 +1,256 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package processcontext
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+func strVal(s string) *commonpb.AnyValue {
+	return &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: s}}
+}
+
+func attr(k string, v *commonpb.AnyValue) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: k, Value: v}
+}
+
+func arrVal(vals ...*commonpb.AnyValue) *commonpb.AnyValue {
+	return &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+		ArrayValue: &commonpb.ArrayValue{Values: vals},
+	}}
+}
+
+func manyStrVals(n int) []*commonpb.AnyValue {
+	vals := make([]*commonpb.AnyValue, n)
+	for i := range vals {
+		vals[i] = strVal(fmt.Sprintf("k%d", i))
+	}
+	return vals
+}
+
+func manyLibpfStrings(n int) []libpf.String {
+	strs := make([]libpf.String, n)
+	for i := range strs {
+		strs[i] = libpf.Intern(fmt.Sprintf("k%d", i))
+	}
+	return strs
+}
+
+func TestReadThreadContextInfo(t *testing.T) {
+	version := attr(threadCtxSchemaVersionKey, strVal(supportedThreadCtxSchemaVersion))
+
+	tests := map[string]struct {
+		attrs        []*commonpb.KeyValue
+		wantKeyMap   []libpf.String
+		wantNoSchema bool
+		wantErrSub   string
+	}{
+		"no threadlocal attributes": {
+			attrs:        []*commonpb.KeyValue{attr("custom.attribute", strVal("v"))},
+			wantNoSchema: true,
+		},
+		// A key map alone is invalid: without a version the encoding is unknown.
+		"key map without a version": {
+			attrs:      []*commonpb.KeyValue{attr(threadCtxKeyMapKey, arrVal(strVal("a")))},
+			wantErrSub: "requires schema version",
+		},
+		"version without a key map": {
+			attrs:      []*commonpb.KeyValue{version},
+			wantKeyMap: nil,
+		},
+		"version and key map": {
+			attrs: []*commonpb.KeyValue{
+				version,
+				attr(threadCtxKeyMapKey, arrVal(strVal("a"), strVal("b"))),
+			},
+			wantKeyMap: []libpf.String{libpf.Intern("a"), libpf.Intern("b")},
+		},
+		"key map before version": {
+			attrs: []*commonpb.KeyValue{
+				attr(threadCtxKeyMapKey, arrVal(strVal("a"))),
+				version,
+			},
+			wantKeyMap: []libpf.String{libpf.Intern("a")},
+		},
+		"unsupported version": {
+			attrs:      []*commonpb.KeyValue{attr(threadCtxSchemaVersionKey, strVal("v99"))},
+			wantErrSub: "unsupported thread context schema version",
+		},
+		"key map is not an array": {
+			attrs:      []*commonpb.KeyValue{version, attr(threadCtxKeyMapKey, strVal("a"))},
+			wantErrSub: "not an array",
+		},
+		// GetStringValue on a non-string AnyValue also returns "", so this
+		// covers a non-string entry too: same branch, no separate case needed.
+		"key map holds an empty key": {
+			attrs: []*commonpb.KeyValue{
+				version,
+				attr(threadCtxKeyMapKey, arrVal(strVal("a"), strVal(""))),
+			},
+			wantErrSub: "invalid thread context attribute",
+		},
+		"duplicate version attribute": {
+			attrs:      []*commonpb.KeyValue{version, version},
+			wantErrSub: "duplicate",
+		},
+		"duplicate key map attribute": {
+			attrs: []*commonpb.KeyValue{
+				version,
+				attr(threadCtxKeyMapKey, arrVal(strVal("a"))),
+				attr(threadCtxKeyMapKey, arrVal(strVal("b"))),
+			},
+			wantErrSub: "duplicate",
+		},
+		"key map exceeds byte-addressable range": {
+			attrs: []*commonpb.KeyValue{
+				version,
+				attr(threadCtxKeyMapKey, arrVal(manyStrVals(maxThreadCtxAttributeKeys+1)...)),
+			},
+			wantKeyMap: manyLibpfStrings(maxThreadCtxAttributeKeys),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := readThreadContextInfo(tt.attrs)
+
+			switch {
+			case tt.wantNoSchema:
+				require.NoError(t, err)
+				assert.Nil(t, got)
+			case tt.wantErrSub == "":
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, tt.wantKeyMap, got.attributeKeyMap)
+			default:
+				require.Error(t, err)
+				assert.Nil(t, got)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}
+
+// Callers test the result against nil, so a nil schema must not surface as a
+// non-nil interface holding a typed nil.
+func TestInfoLabelDecoder_NilSchema(t *testing.T) {
+	assert.Nil(t, Info{}.LabelDecoder())
+}
+
+func TestDecodeLabels(t *testing.T) {
+	keyMap := []libpf.String{
+		libpf.Intern("http_route"),
+		libpf.Intern("http_method"),
+		libpf.Intern("user_id"),
+	}
+
+	// entryRaw encodes one (key index, value length, value) tuple.
+	entryRaw := func(keyIndex byte, value []byte) []byte {
+		return append([]byte{keyIndex, byte(len(value))}, value...)
+	}
+	entry := func(keyIndex byte, value string) []byte {
+		return entryRaw(keyIndex, []byte(value))
+	}
+
+	tests := map[string]struct {
+		data        []byte
+		want        map[string]string
+		wantDropped int
+	}{
+		"empty payload": {
+			data: nil,
+			want: nil,
+		},
+		// The length prefix counts bytes, not runes.
+		"multi-byte value": {
+			data: entry(0, "/健康"),
+			want: map[string]string{"http_route": "/健康"},
+		},
+		"entries resolve by index, not order": {
+			data: append(append(entry(2, "u-1"), entry(1, "GET")...), entry(0, "/x")...),
+			want: map[string]string{"user_id": "u-1", "http_method": "GET", "http_route": "/x"},
+		},
+		"empty value is kept": {
+			data: entry(1, ""),
+			want: map[string]string{"http_method": ""},
+		},
+		// A key index the published map does not cover cannot be named, but it
+		// carries a length so the entries after it stay decodable.
+		"unknown key index is skipped and counted as dropped": {
+			data:        append(append(entry(9, "dropped"), entry(1, "GET")...), entry(0, "/y")...),
+			want:        map[string]string{"http_method": "GET", "http_route": "/y"},
+			wantDropped: 1,
+		},
+		// Truncation must stop decoding rather than read past the payload, and
+		// must count as dropped so it's not indistinguishable from a clean end.
+		"value length past end of payload": {
+			data:        append(entry(0, "/x"), 1, 40, 'G', 'E', 'T'),
+			want:        map[string]string{"http_route": "/x"},
+			wantDropped: 1,
+		},
+		"trailing byte without a length": {
+			data:        append(entry(0, "/x"), 1),
+			want:        map[string]string{"http_route": "/x"},
+			wantDropped: 1,
+		},
+		// valueLen already bounds the value, so this is a publisher bug, not a
+		// truncated read: the whole entry is dropped rather than salvaged.
+		"invalid UTF-8 value is dropped, siblings kept": {
+			data:        append(entryRaw(0, []byte{0xff}), entry(1, "GET")...),
+			want:        map[string]string{"http_method": "GET"},
+			wantDropped: 1,
+		},
+		// A repeated key index is malformed, so the earlier value is counted as
+		// dropped even though the entry itself decodes (last write wins).
+		"duplicate key index counts the overwritten value as dropped": {
+			data:        append(entry(0, "/x"), entry(0, "/y")...),
+			want:        map[string]string{"http_route": "/y"},
+			wantDropped: 1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc := &threadContextInfo{attributeKeyMap: keyMap}
+
+			got, dropped := tc.DecodeLabels(tt.data)
+
+			// A nil map isn't allocated until the first label is kept.
+			var want map[libpf.String]libpf.String
+			if len(tt.want) > 0 {
+				want = make(map[libpf.String]libpf.String, len(tt.want))
+				for k, v := range tt.want {
+					want[libpf.Intern(k)] = libpf.Intern(v)
+				}
+			}
+			assert.Equal(t, want, got)
+			assert.Equal(t, tt.wantDropped, dropped)
+		})
+	}
+}
+
+// The decoder must not retain the eBPF payload, which is reused per trace.
+// Interning is what breaks ToString's alias, so this guards a decode path that
+// stopped interning.
+func TestDecodeLabelsDoesNotAliasPayload(t *testing.T) {
+	tc := &threadContextInfo{
+		attributeKeyMap: []libpf.String{libpf.Intern("k")},
+	}
+
+	data := append([]byte{0, 3}, "abc"...)
+	got, _ := tc.DecodeLabels(data)
+	require.Equal(t, libpf.Intern("abc"), got[libpf.Intern("k")])
+
+	copy(data[2:], "xyz")
+	assert.Equal(t, libpf.Intern("abc"), got[libpf.Intern("k")],
+		"decoded value must not alias the caller's buffer")
+}


### PR DESCRIPTION
Stack: part of the thread-context split. Graph and status in #1229.
No dependencies, reviewable now. Blocks `labels` (#1849).

Parses the per-thread label schema a process publishes as `threadlocal.*` attributes ([OTEP 4947](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4947-thread-ctx.md)) and exposes it as a`libpf.LabelDecoder`.

### What's here

- `libpf.LabelDecoder`: interface resolving a raw thread-local payload into `map[String]String` plus a count of undecodable entries.
- `readThreadContextInfo`: validates `threadlocal.schema_version` against  `tlsdesc_v1_dev` and interns `threadlocal.attribute_key_map`. No schema published is the common case, not an error, and returns `(nil, nil)`. A malformed schema is non-fatal and `Info` still carries the resource attributes.
- `threadContextInfo.DecodeLabels`: decodes `(key index, value length, value)` entries,  dropping out-of-range indices, invalid UTF-8, and a truncated tail.

`Info.LabelDecoder` has no non-test caller yet: #1849 adds one through `ProcessManager.LabelDecoderForPID`.
