### PR TITLE
remotememory: add error-returning accessors

### DIFF
--- a/process/processcontext/processcontext.go
+++ b/process/processcontext/processcontext.go
@@ -10,7 +10,6 @@
 package processcontext // import "go.opentelemetry.io/ebpf-profiler/process/processcontext"
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/url"
@@ -210,11 +209,11 @@ func IsContextMapping(isExecutable bool, mappingPath string) bool {
 }
 
 func readTimestamp(rm remotememory.RemoteMemory, headerAddr libpf.Address) (uint64, error) {
-	var buf [8]byte
-	if err := rm.Read(headerAddr+monotonicPublishedAtNsOffset, buf[:]); err != nil {
+	ts, err := rm.ReadUint64(headerAddr + monotonicPublishedAtNsOffset)
+	if err != nil {
 		return 0, fmt.Errorf("failed to read timestamp: %w", err)
 	}
-	return binary.LittleEndian.Uint64(buf[:]), nil
+	return ts, nil
 }
 
 // readHeader reads and validates the 32-byte ProcessContext header.

--- a/remotememory/remotememory.go
+++ b/remotememory/remotememory.go
@@ -3,15 +3,16 @@
 
 // remotememory provides access to memory space of a process. The ReaderAt
 // interface is used for the basic access, and various convenience functions are
-// provided to help reading specific data types.
+// provided to help reading specific data types. Accessors without a Read prefix
+// fold a failed read into the zero value.
 package remotememory // import "go.opentelemetry.io/ebpf-profiler/remotememory"
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 )
 
 // RemoteMemory implements a set of convenience functions to access the remote memory
@@ -32,49 +33,74 @@ func (rm RemoteMemory) Read(addr libpf.Address, p []byte) error {
 	return err
 }
 
+// readInt decodes in host byte order.
+func readInt[T ~uint8 | ~uint16 | ~uint32 | ~uint64](
+	rm RemoteMemory, addr libpf.Address,
+) (T, error) {
+	var v T
+	if err := rm.Read(addr, pfunsafe.FromPointer(&v)); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// ReadPtr reads a native pointer from remote memory
+func (rm RemoteMemory) ReadPtr(addr libpf.Address) (libpf.Address, error) {
+	v, err := readInt[uint64](rm, addr)
+	if err != nil {
+		return 0, err
+	}
+	return libpf.Address(v) - rm.Bias, nil
+}
+
+// ReadUint8 reads an 8-bit unsigned integer from remote memory
+func (rm RemoteMemory) ReadUint8(addr libpf.Address) (uint8, error) {
+	return readInt[uint8](rm, addr)
+}
+
+// ReadUint16 reads a 16-bit unsigned integer from remote memory
+func (rm RemoteMemory) ReadUint16(addr libpf.Address) (uint16, error) {
+	return readInt[uint16](rm, addr)
+}
+
+// ReadUint32 reads a 32-bit unsigned integer from remote memory
+func (rm RemoteMemory) ReadUint32(addr libpf.Address) (uint32, error) {
+	return readInt[uint32](rm, addr)
+}
+
+// ReadUint64 reads a 64-bit unsigned integer from remote memory
+func (rm RemoteMemory) ReadUint64(addr libpf.Address) (uint64, error) {
+	return readInt[uint64](rm, addr)
+}
+
 // Ptr reads a native pointer from remote memory
 func (rm RemoteMemory) Ptr(addr libpf.Address) libpf.Address {
-	var buf [8]byte
-	if rm.Read(addr, buf[:]) != nil {
-		return 0
-	}
-	return libpf.Address(binary.LittleEndian.Uint64(buf[:])) - rm.Bias
+	v, _ := rm.ReadPtr(addr)
+	return v
 }
 
 // Uint8 reads an 8-bit unsigned integer from remote memory
 func (rm RemoteMemory) Uint8(addr libpf.Address) uint8 {
-	var buf [1]byte
-	if rm.Read(addr, buf[:]) != nil {
-		return 0
-	}
-	return buf[0]
+	v, _ := readInt[uint8](rm, addr)
+	return v
 }
 
 // Uint16 reads a 16-bit unsigned integer from remote memory
 func (rm RemoteMemory) Uint16(addr libpf.Address) uint16 {
-	var buf [2]byte
-	if rm.Read(addr, buf[:]) != nil {
-		return 0
-	}
-	return binary.LittleEndian.Uint16(buf[:])
+	v, _ := readInt[uint16](rm, addr)
+	return v
 }
 
 // Uint32 reads a 32-bit unsigned integer from remote memory
 func (rm RemoteMemory) Uint32(addr libpf.Address) uint32 {
-	var buf [4]byte
-	if rm.Read(addr, buf[:]) != nil {
-		return 0
-	}
-	return binary.LittleEndian.Uint32(buf[:])
+	v, _ := readInt[uint32](rm, addr)
+	return v
 }
 
 // Uint64 reads a 64-bit unsigned integer from remote memory
 func (rm RemoteMemory) Uint64(addr libpf.Address) uint64 {
-	var buf [8]byte
-	if rm.Read(addr, buf[:]) != nil {
-		return 0
-	}
-	return binary.LittleEndian.Uint64(buf[:])
+	v, _ := readInt[uint64](rm, addr)
+	return v
 }
 
 // String reads a zero terminated string from remote memory

--- a/remotememory/remotememory_test.go
+++ b/remotememory/remotememory_test.go
@@ -33,6 +33,8 @@ func RemoteMemTests(t *testing.T, rm RemoteMemory) {
 		t.Skipf("skipping due to error: %v", err)
 	}
 	require.NoError(t, err)
+	assert.Equal(t, uint8(0x01), rm.Uint8(dataPtr))
+	assert.Equal(t, uint16(0x0201), rm.Uint16(dataPtr))
 	assert.Equal(t, uint32(0x04030201), rm.Uint32(dataPtr))
 	assert.Equal(t, libpf.Address(0x0807060504030201), rm.Ptr(dataPtr))
 	assert.Equal(t, string(str[:len(str)-1]), rm.String(strPtr))
@@ -44,4 +46,27 @@ func TestProcessVirtualMemory(t *testing.T) {
 		t.Skipf("unsupported os %s", runtime.GOOS)
 	}
 	RemoteMemTests(t, NewProcessVirtualMemory(libpf.PID(os.Getpid())))
+}
+
+type errReader struct{ err error }
+
+func (r errReader) ReadAt([]byte, int64) (int, error) { return 0, r.err }
+
+func TestReadPtrBias(t *testing.T) {
+	rm := RemoteMemory{
+		ReaderAt: bytes.NewReader([]byte{0x10, 0, 0, 0, 0, 0, 0, 0}),
+		Bias:     0x4,
+	}
+
+	v, err := rm.ReadPtr(0)
+	require.NoError(t, err)
+	assert.Equal(t, libpf.Address(0xc), v)
+}
+
+func TestReadUint64Error(t *testing.T) {
+	rm := RemoteMemory{ReaderAt: errReader{err: syscall.ESRCH}}
+
+	_, err := rm.ReadUint64(0x1000)
+	require.ErrorIs(t, err, syscall.ESRCH)
+	assert.Zero(t, rm.Uint64(0x1000))
 }


### PR DESCRIPTION
Every `RemoteMemory` accessor folds a failed read into the zero value, so a caller that must tell a read 0 from an unread field has to reimplement one privately. `process/processcontext` did exactly that.

Adds `ReadPtr` and `ReadUint8/16/32/64`.
For now left `String` and `StringPtr` without matching error-returning accessors.