### PR TITLE
php: remove dead buffer reads

### DIFF
--- a/interpreter/php/opcache.go
+++ b/interpreter/php/opcache.go
@@ -116,7 +116,6 @@ package php // import "go.opentelemetry.io/ebpf-profiler/interpreter/php"
 
 import (
 	"debug/elf"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"regexp"
@@ -200,25 +199,8 @@ func (i *opcacheInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 		return nil
 	}
 
-	dasmBufVal := make([]byte, 8)
-	dasmSizeVal := make([]byte, 8)
-	if err := i.rm.Read(i.d.dasmBufPtr+i.bias, dasmBufVal); err != nil {
-		return nil
-	}
-	if err := i.rm.Read(i.d.dasmSizePtr+i.bias, dasmSizeVal); err != nil {
-		return nil
-	}
-
-	buf := make([]byte, 8)
-	if err := i.rm.Read(i.d.dasmBufPtr+i.bias, buf); err != nil {
-		return nil
-	}
-	dasmBuf := binary.LittleEndian.Uint64(buf)
-
-	if err := i.rm.Read(i.d.dasmSizePtr+i.bias, buf); err != nil {
-		return nil
-	}
-	dasmSize := binary.LittleEndian.Uint64(buf)
+	dasmBuf := i.rm.Uint64(i.d.dasmBufPtr + i.bias)
+	dasmSize := i.rm.Uint64(i.d.dasmSizePtr + i.bias)
 	if dasmBuf == 0 || dasmSize == 0 {
 		// This is the normal path if JIT is not enabled, or we try to
 		// attach before JIT engine is initialized.


### PR DESCRIPTION
#1531 fixed bug in php `SynchronizeMappings` (`dasmSize` was being decoded from `dasmBufVal`) by re-reading both pointers into a fresh `buf`. The original `dasmBufVal` and `dasmSizeVal` reads were left in place and have been dead ever since.
